### PR TITLE
chore: update mayastor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [patch.crates-io]
 # Update nix/overlay.nix with the sha256:
 # nix-prefetch-url https://github.com/openebs/Mayastor/tarball/$rev --print-path --unpack
-rpc = { git = "https://github.com/openebs/mayastor", rev = "5b4d4726190e176ba006c78582aa3fea5ac3ceb6" }
+rpc = { git = "https://github.com/openebs/mayastor", rev = "2868e83704177e439d7bfb4cbd94cff5a371db91" }
 paperclip = { git = "https://github.com/MayastorControlPlane/paperclip", branch = "develop" }
 
 [profile.dev]

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -6,7 +6,7 @@ self: super: {
     repo = "Mayastor";
     # Use rev from the RPC patch in the workspace's Cargo.toml
     rev = (builtins.fromTOML (builtins.readFile ../Cargo.toml)).patch.crates-io.rpc.rev;
-    sha256 = "0sh8rnmbkxfg36pgsp060kyk83nwqlhs4fxzasq3zk5bn4mqhs47";
+    sha256 = "1qdr9aj3z5jpbdrzqdxkh3ga98wq9ivsr5qrc1g6n0j9w5pjk2ry";
   };
   control-plane = super.callPackage ./pkgs/control-plane { };
 }


### PR DESCRIPTION
Update mayastor to 2868e83704177e439d7bfb4cbd94cff5a371db91 (current
 tip of develop branch)

This should get rid of the nix-build issues with the sha256.