### PR TITLE
chore(lifetimes): simplify store lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3044,7 +3044,7 @@ dependencies = [
 [[package]]
 name = "rpc"
 version = "0.1.0"
-source = "git+https://github.com/openebs/mayastor?rev=5b4d4726190e176ba006c78582aa3fea5ac3ceb6#5b4d4726190e176ba006c78582aa3fea5ac3ceb6"
+source = "git+https://github.com/openebs/mayastor?rev=2868e83704177e439d7bfb4cbd94cff5a371db91#2868e83704177e439d7bfb4cbd94cff5a371db91"
 dependencies = [
  "bytes 0.5.6",
  "prost",

--- a/control-plane/agents/core/src/watcher/watch.rs
+++ b/control-plane/agents/core/src/watcher/watch.rs
@@ -51,7 +51,7 @@ struct WatchCfg {
     pub watch_id: WatchCfgId,
     pub watchers: Vec<WatchParamsCfg>,
 }
-impl<'a> StorableObject<'a> for WatchCfg {
+impl StorableObject for WatchCfg {
     type Key = WatchCfgId;
     fn key(&self) -> Self::Key {
         self.watch_id.clone()

--- a/control-plane/store/src/etcd.rs
+++ b/control-plane/store/src/etcd.rs
@@ -110,7 +110,7 @@ impl Store for Etcd {
         Ok(receiver)
     }
 
-    async fn put_obj<'a, O: StorableObject<'a>>(
+    async fn put_obj<O: StorableObject>(
         &mut self,
         object: &O,
     ) -> Result<(), StoreError> {
@@ -123,7 +123,7 @@ impl Store for Etcd {
         Ok(())
     }
 
-    async fn get_obj<'a, O: StorableObject<'a>>(
+    async fn get_obj<O: StorableObject>(
         &mut self,
         key: &O::Key,
     ) -> Result<O, StoreError> {

--- a/control-plane/store/src/store.rs
+++ b/control-plane/store/src/store.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use etcd_client::Error;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use serde_json::{Error as SerdeError, Value};
 use snafu::Snafu;
 use strum_macros::Display;
@@ -109,12 +109,12 @@ pub trait Store: Sync + Send + Clone {
         key: &K,
     ) -> Result<Receiver<Result<WatchEvent, StoreError>>, StoreError>;
 
-    async fn put_obj<'a, O: StorableObject<'a>>(
+    async fn put_obj<O: StorableObject>(
         &mut self,
         object: &O,
     ) -> Result<(), StoreError>;
 
-    async fn get_obj<'a, O: StorableObject<'a>>(
+    async fn get_obj<O: StorableObject>(
         &mut self,
         _key: &O::Key,
     ) -> Result<O, StoreError>;
@@ -140,9 +140,7 @@ pub trait ObjectKey: Sync + Send {
 
 /// Implemented by objects which get stored in the store, eg: Volume
 #[async_trait]
-pub trait StorableObject<'a>:
-    Serialize + Sync + Send + for<'de> Deserialize<'de>
-{
+pub trait StorableObject: Serialize + Sync + Send + DeserializeOwned {
     type Key: ObjectKey;
 
     fn key(&self) -> Self::Key;


### PR DESCRIPTION
Remove the unneeded lifetime bounds on the StorableObject.

The 'Deserialize' trait with the 'Higher Rank Trait Bounds' has been
replaced with the 'DeserializeOwned' trait which is equivalent (see the
"Trait bounds" section of https://serde.rs/lifetimes.html).