### PR TITLE
chore: remove "allow fail" for test case

### DIFF
--- a/tests-mayastor/tests/nexus.rs
+++ b/tests-mayastor/tests/nexus.rs
@@ -18,9 +18,7 @@ async fn create_nexus_malloc() {
         .unwrap();
 }
 
-// FIXME: CAS-737
 #[actix_rt::test]
-#[allow_fail]
 async fn create_nexus_sizes() {
     let cluster = ClusterBuilder::builder()
         .with_rest_timeout(std::time::Duration::from_secs(1))


### PR DESCRIPTION
The Jira item referenced for this test case has been marked as resolved
so the expectation is that this test case should now pass.