### PR TITLE
chore: include pools when getting specs

### DIFF
--- a/control-plane/agents/core/src/node/service.rs
+++ b/control-plane/agents/core/src/node/service.rs
@@ -164,11 +164,12 @@ impl Service {
         let nexuses = registry.get_nexuses().await;
         let replicas = registry.get_replicas().await;
         let volumes = registry.get_volumes().await;
+        let pools = registry.get_pools().await;
         Ok(Specs {
             volumes,
             nexuses,
             replicas,
-            ..Default::default()
+            pools,
         })
     }
 }

--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -169,6 +169,15 @@ impl ResourceSpecs {
         }
         vector
     }
+
+    /// Get all PoolSpecs
+    pub(crate) async fn get_pools(&self) -> Vec<PoolSpec> {
+        let mut specs = vec![];
+        for pool_spec in self.pools.values() {
+            specs.push(pool_spec.lock().await.clone());
+        }
+        specs
+    }
 }
 
 impl ResourceSpecsLocked {


### PR DESCRIPTION
Include the list of pools when getting the specs from the REST API.