### PR TITLE
feat: expose resource states through REST API

### DIFF
--- a/common/src/mbus_api/message_bus/v0.rs
+++ b/common/src/mbus_api/message_bus/v0.rs
@@ -7,9 +7,9 @@ use crate::{
     types::v0::message_bus::{
         AddNexusChild, AddVolumeNexus, Child, CreateNexus, CreatePool, CreateReplica, CreateVolume,
         DestroyNexus, DestroyPool, DestroyReplica, DestroyVolume, Filter, GetBlockDevices,
-        GetNexuses, GetNodes, GetPools, GetReplicas, GetSpecs, GetVolumes, JsonGrpcRequest, Nexus,
-        Node, NodeId, Pool, RemoveNexusChild, RemoveVolumeNexus, Replica, ShareNexus, ShareReplica,
-        Specs, UnshareNexus, UnshareReplica, Volume,
+        GetNexuses, GetNodes, GetPools, GetReplicas, GetSpecs, GetStates, GetVolumes,
+        JsonGrpcRequest, Nexus, Node, NodeId, Pool, RemoveNexusChild, RemoveVolumeNexus, Replica,
+        ShareNexus, ShareReplica, Specs, States, UnshareNexus, UnshareReplica, Volume,
     },
 };
 use async_trait::async_trait;
@@ -243,6 +243,12 @@ pub trait MessageBusTrait: Sized {
     /// Get all the specs from the registry
     #[tracing::instrument(level = "debug", err)]
     async fn get_specs(request: GetSpecs) -> BusResult<Specs> {
+        Ok(request.request().await?)
+    }
+
+    /// Get all the states from the registry
+    #[tracing::instrument(level = "debug", err)]
+    async fn get_states(request: GetStates) -> BusResult<States> {
         Ok(request.request().await?)
     }
 }

--- a/common/src/mbus_api/v0.rs
+++ b/common/src/mbus_api/v0.rs
@@ -97,3 +97,5 @@ bus_impl_message_all!(GetWatchers, GetWatches, Watches, Watcher);
 bus_impl_message_all!(DeleteWatch, DeleteWatch, (), Watcher);
 
 bus_impl_message_all!(GetSpecs, GetSpecs, Specs, Registry);
+
+bus_impl_message_all!(GetStates, GetStates, States, Registry);

--- a/common/src/types/v0/message_bus/mod.rs
+++ b/common/src/types/v0/message_bus/mod.rs
@@ -9,6 +9,7 @@ pub mod node;
 pub mod pool;
 pub mod replica;
 pub mod spec;
+pub mod state;
 pub mod volume;
 pub mod watch;
 
@@ -21,6 +22,7 @@ pub use node::*;
 pub use pool::*;
 pub use replica::*;
 pub use spec::*;
+pub use state::*;
 pub use volume::*;
 pub use watch::*;
 
@@ -156,4 +158,10 @@ pub enum MessageIdVs {
     DeleteWatch,
     /// Get Specs
     GetSpecs,
+    /// Get States
+    GetStates,
+}
+
+pub trait UuidString {
+    fn uuid_as_string(&self) -> String;
 }

--- a/common/src/types/v0/message_bus/nexus.rs
+++ b/common/src/types/v0/message_bus/nexus.rs
@@ -37,6 +37,12 @@ pub struct Nexus {
     pub share: Protocol,
 }
 
+impl UuidString for Nexus {
+    fn uuid_as_string(&self) -> String {
+        self.uuid.clone().into()
+    }
+}
+
 bus_impl_string_uuid!(NexusId, "UUID of a mayastor nexus");
 
 /// Nexus State information

--- a/common/src/types/v0/message_bus/pool.rs
+++ b/common/src/types/v0/message_bus/pool.rs
@@ -61,6 +61,12 @@ pub struct Pool {
     pub used: u64,
 }
 
+impl UuidString for Pool {
+    fn uuid_as_string(&self) -> String {
+        self.id.clone().into()
+    }
+}
+
 bus_impl_string_id!(PoolId, "ID of a mayastor pool");
 
 // online > degraded > unknown/faulted

--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -35,6 +35,12 @@ pub struct Replica {
     pub state: ReplicaState,
 }
 
+impl UuidString for Replica {
+    fn uuid_as_string(&self) -> String {
+        self.uuid.clone().into()
+    }
+}
+
 bus_impl_string_uuid!(ReplicaId, "UUID of a mayastor pool replica");
 
 impl From<Replica> for DestroyReplica {

--- a/common/src/types/v0/message_bus/state.rs
+++ b/common/src/types/v0/message_bus/state.rs
@@ -1,0 +1,19 @@
+use crate::types::v0::store::{nexus, pool, replica};
+use serde::{Deserialize, Serialize};
+
+/// Retrieve all states from core agent
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct GetStates {}
+
+/// Runtime state of the resources.
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct States {
+    /// nexus states
+    pub nexuses: Vec<nexus::NexusState>,
+    /// pool states
+    pub pools: Vec<pool::PoolState>,
+    /// replica states
+    pub replicas: Vec<replica::ReplicaState>,
+}

--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -2,8 +2,8 @@
 
 use crate::types::v0::{
     message_bus::{
-        self, ChildState, ChildUri, CreateNexus, DestroyNexus, NexusId, NexusShareProtocol, NodeId,
-        Protocol, VolumeId,
+        self, ChildState, ChildUri, CreateNexus, DestroyNexus, Nexus as MbusNexus, NexusId,
+        NexusShareProtocol, NodeId, Protocol, VolumeId,
     },
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
@@ -27,6 +27,12 @@ pub struct Nexus {
 pub struct NexusState {
     /// Nexus information.
     pub nexus: message_bus::Nexus,
+}
+
+impl From<MbusNexus> for NexusState {
+    fn from(nexus: MbusNexus) -> Self {
+        Self { nexus }
+    }
 }
 
 /// Key used by the store to uniquely identify a NexusState structure.

--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -17,6 +17,11 @@ pub struct Node {
     labels: NodeLabels,
 }
 
+pub struct NodeState {
+    /// Node information
+    pub node: message_bus::Node,
+}
+
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct NodeSpec {
     /// Node identification.

--- a/common/src/types/v0/store/pool.rs
+++ b/common/src/types/v0/store/pool.rs
@@ -1,7 +1,7 @@
 //! Definition of pool types that can be saved to the persistent store.
 
 use crate::types::v0::{
-    message_bus::{self, CreatePool, NodeId, PoolDeviceUri, PoolId},
+    message_bus::{self, CreatePool, NodeId, Pool as MbusPool, PoolDeviceUri, PoolId},
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
         SpecState, SpecTransaction,
@@ -23,12 +23,21 @@ pub struct Pool {
 
 /// Runtime state of the pool.
 /// This should eventually satisfy the PoolSpec.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct PoolState {
     /// Pool information returned by Mayastor.
     pub pool: message_bus::Pool,
     /// Pool labels.
     pub labels: Vec<PoolLabel>,
+}
+
+impl From<MbusPool> for PoolState {
+    fn from(pool: MbusPool) -> Self {
+        Self {
+            pool,
+            labels: vec![],
+        }
+    }
 }
 
 /// State of the Pool Spec

--- a/common/src/types/v0/store/replica.rs
+++ b/common/src/types/v0/store/replica.rs
@@ -2,8 +2,8 @@
 
 use crate::types::v0::{
     message_bus::{
-        self, CreateReplica, NodeId, PoolId, Protocol, ReplicaId, ReplicaOwners,
-        ReplicaShareProtocol,
+        self, CreateReplica, NodeId, PoolId, Protocol, Replica as MbusReplica, ReplicaId,
+        ReplicaOwners, ReplicaShareProtocol,
     },
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
@@ -22,12 +22,16 @@ pub struct Replica {
 }
 
 /// Runtime state of a replica.
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct ReplicaState {
     /// Replica information.
     pub replica: message_bus::Replica,
-    /// State of the replica.
-    pub state: message_bus::ReplicaState,
+}
+
+impl From<MbusReplica> for ReplicaState {
+    fn from(replica: MbusReplica) -> Self {
+        Self { replica }
+    }
 }
 
 /// Key used by the store to uniquely identify a ReplicaState structure.

--- a/control-plane/agents/core/src/core/mod.rs
+++ b/control-plane/agents/core/src/core/mod.rs
@@ -6,6 +6,8 @@ pub mod grpc;
 pub mod registry;
 /// registry with all the resource specs
 pub mod specs;
+/// registry with all the resource states
+pub mod states;
 /// helper wrappers over the resources
 pub mod wrapper;
 

--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -13,7 +13,7 @@
 //!
 //! Each instance also contains the known nexus, pools and replicas that live in
 //! said instance.
-use super::{specs::*, wrapper::NodeWrapper};
+use super::{specs::*, states::ResourceStatesLocked, wrapper::NodeWrapper};
 use crate::core::wrapper::InternalOps;
 use common::errors::SvcError;
 use common_lib::{
@@ -34,8 +34,10 @@ pub type Registry = RegistryInner<Etcd>;
 pub struct RegistryInner<S: Store> {
     /// the actual state of the node
     pub(crate) nodes: Arc<RwLock<HashMap<NodeId, Arc<Mutex<NodeWrapper>>>>>,
-    /// spec (aka desired state) for the various resources
+    /// spec (aka desired state) of the various resources
     pub(crate) specs: ResourceSpecsLocked,
+    /// state (aka actual state) of the various resources
+    pub(crate) states: ResourceStatesLocked,
     /// period to refresh the cache
     cache_period: std::time::Duration,
     pub(crate) store: Arc<Mutex<S>>,
@@ -64,6 +66,7 @@ impl Registry {
         let registry = Self {
             nodes: Default::default(),
             specs: ResourceSpecsLocked::new(),
+            states: ResourceStatesLocked::new(),
             cache_period,
             store: Arc::new(Mutex::new(store)),
             store_timeout,
@@ -147,7 +150,7 @@ impl Registry {
                 let _guard = lock.lock().await;
 
                 let mut node_clone = node.lock().await.clone();
-                if node_clone.reload().await.is_ok() {
+                if node_clone.reload(&self).await.is_ok() {
                     // update node in the registry
                     *node.lock().await = node_clone;
                 }

--- a/control-plane/agents/core/src/core/states.rs
+++ b/control-plane/agents/core/src/core/states.rs
@@ -1,0 +1,102 @@
+use common_lib::types::v0::{
+    message_bus::{Nexus, NexusId, Pool, PoolId, Replica, ReplicaId, UuidString},
+    store::{nexus::NexusState, pool::PoolState, replica::ReplicaState},
+};
+use std::{collections::HashMap, hash::Hash, ops::Deref, sync::Arc};
+use tokio::sync::{Mutex, RwLock};
+use tracing::debug;
+
+/// Locked Resource States
+#[derive(Default, Clone, Debug)]
+pub(crate) struct ResourceStatesLocked(Arc<RwLock<ResourceStates>>);
+
+impl ResourceStatesLocked {
+    pub(crate) fn new() -> Self {
+        ResourceStatesLocked::default()
+    }
+}
+
+impl Deref for ResourceStatesLocked {
+    type Target = Arc<RwLock<ResourceStates>>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Resource States
+#[derive(Default, Debug)]
+pub(crate) struct ResourceStates {
+    /// Todo: Add runtime state information for nodes.
+    nexuses: HashMap<NexusId, Arc<Mutex<NexusState>>>,
+    pools: HashMap<PoolId, Arc<Mutex<PoolState>>>,
+    replicas: HashMap<ReplicaId, Arc<Mutex<ReplicaState>>>,
+}
+
+impl ResourceStates {
+    /// Update the states of the resources.
+    pub(crate) async fn update(
+        &mut self,
+        pools: Vec<Pool>,
+        replicas: Vec<Replica>,
+        nexuses: Vec<Nexus>,
+    ) {
+        Self::update_resource(&mut self.pools, pools).await;
+        Self::update_resource(&mut self.replicas, replicas).await;
+        Self::update_resource(&mut self.nexuses, nexuses).await;
+    }
+
+    /// Returns a vector of nexus states.
+    pub(crate) async fn get_nexus_states(&self) -> Vec<NexusState> {
+        Self::states_vector(&self.nexuses).await
+    }
+
+    /// Returns a vector of pool states.
+    pub(crate) async fn get_pool_states(&self) -> Vec<PoolState> {
+        Self::states_vector(&self.pools).await
+    }
+
+    /// Returns a vector of replica states.
+    pub(crate) async fn get_replica_states(&self) -> Vec<ReplicaState> {
+        Self::states_vector(&self.replicas).await
+    }
+
+    /// Update the state of the resources with the latest runtime state.
+    /// If a runtime state of a resource is not provided, the resource is removed from the list.
+    async fn update_resource<I, S, R>(
+        resource_states: &mut HashMap<I, Arc<Mutex<S>>>,
+        runtime_state: Vec<R>,
+    ) where
+        I: From<String> + Eq + Hash,
+        R: UuidString,
+        S: From<R>,
+    {
+        resource_states.clear();
+        for state in runtime_state {
+            let uuid = state.uuid_as_string().into();
+            let resource_state = state.into();
+            match resource_states.get(&uuid) {
+                Some(locked_state) => {
+                    debug!("Updating {}", std::any::type_name::<S>());
+                    let mut state = locked_state.lock().await;
+                    *state = resource_state;
+                }
+                None => {
+                    resource_states.insert(uuid, Arc::new(Mutex::new(resource_state)));
+                }
+            }
+        }
+    }
+
+    /// Returns a vector of states.
+    async fn states_vector<I, S>(resource_states: &HashMap<I, Arc<Mutex<S>>>) -> Vec<S>
+    where
+        S: Clone,
+    {
+        let mut states = vec![];
+        for nexus_state in resource_states.values() {
+            let object = nexus_state.lock().await;
+            states.push(object.clone());
+        }
+        states
+    }
+}

--- a/control-plane/agents/core/src/node/mod.rs
+++ b/control-plane/agents/core/src/node/mod.rs
@@ -10,7 +10,7 @@ use common_lib::mbus_api::{v0::*, *};
 
 use async_trait::async_trait;
 use common_lib::types::v0::message_bus::{
-    ChannelVs, Deregister, GetBlockDevices, GetNodes, GetSpecs, Register,
+    ChannelVs, Deregister, GetBlockDevices, GetNodes, GetSpecs, GetStates, Register,
 };
 use std::{convert::TryInto, marker::PhantomData};
 use structopt::StructOpt;
@@ -23,6 +23,7 @@ pub(crate) fn configure(builder: Service) -> Service {
         .with_subscription(handler_publish!(Register))
         .with_subscription(handler_publish!(Deregister))
         .with_subscription(handler!(GetSpecs))
+        .with_subscription(handler!(GetStates))
         .with_channel(ChannelVs::Node)
         .with_subscription(handler!(GetNodes))
         .with_subscription(handler!(GetBlockDevices))

--- a/control-plane/agents/core/src/node/service.rs
+++ b/control-plane/agents/core/src/node/service.rs
@@ -4,7 +4,7 @@ use common::{
     errors::{GrpcRequestError, NodeNotFound, SvcError},
     v0::msg_translation::RpcToMessageBus,
 };
-use common_lib::types::v0::message_bus::{GetSpecs, Node, NodeId, NodeState, Specs};
+use common_lib::types::v0::message_bus::{GetSpecs, Node, NodeId, NodeState, Specs, States};
 use rpc::mayastor::ListBlockDevicesRequest;
 use snafu::{OptionExt, ResultExt};
 use std::sync::Arc;
@@ -160,16 +160,29 @@ impl Service {
 
     /// Get specs from the registry
     pub(crate) async fn get_specs(&self, _request: &GetSpecs) -> Result<Specs, SvcError> {
-        let registry = self.registry.specs.write().await;
-        let nexuses = registry.get_nexuses().await;
-        let replicas = registry.get_replicas().await;
-        let volumes = registry.get_volumes().await;
-        let pools = registry.get_pools().await;
+        let specs = self.registry.specs.write().await;
+        let nexuses = specs.get_nexuses().await;
+        let replicas = specs.get_replicas().await;
+        let volumes = specs.get_volumes().await;
+        let pools = specs.get_pools().await;
         Ok(Specs {
             volumes,
             nexuses,
             replicas,
             pools,
+        })
+    }
+
+    /// Get states from the registry
+    pub(crate) async fn get_states(&self, _request: &GetStates) -> Result<States, SvcError> {
+        let states = self.registry.states.write().await;
+        let nexuses = states.get_nexus_states().await;
+        let replicas = states.get_replica_states().await;
+        let pools = states.get_pool_states().await;
+        Ok(States {
+            nexuses,
+            pools,
+            replicas,
         })
     }
 }

--- a/control-plane/rest/service/src/v0/mod.rs
+++ b/control-plane/rest/service/src/v0/mod.rs
@@ -10,6 +10,7 @@ pub mod nodes;
 pub mod pools;
 pub mod replicas;
 pub mod specs;
+pub mod states;
 pub mod swagger_ui;
 pub mod volumes;
 pub mod watches;
@@ -48,6 +49,7 @@ fn configure(cfg: &mut actix_web::web::ServiceConfig) {
     block_devices::configure(cfg);
     watches::configure(cfg);
     specs::configure(cfg);
+    states::configure(cfg);
 }
 
 fn json_error(err: impl std::fmt::Display, _req: &actix_web::HttpRequest) -> actix_web::Error {

--- a/control-plane/rest/service/src/v0/states.rs
+++ b/control-plane/rest/service/src/v0/states.rs
@@ -1,0 +1,12 @@
+use super::*;
+use common_lib::types::v0::message_bus::{GetStates, States};
+use mbus_api::message_bus::v0::{MessageBus, MessageBusTrait};
+
+pub(super) fn configure(cfg: &mut actix_web::web::ServiceConfig) {
+    cfg.service(get_states);
+}
+
+#[get("/states")]
+async fn get_states() -> Result<Json<States>, RestError> {
+    RestRespond::result(MessageBus::get_states(GetStates {}).await)
+}

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -16,6 +16,7 @@ pub use common_lib::{
     },
 };
 
+use common_lib::types::v0::message_bus::States;
 use serde::{Deserialize, Serialize};
 use std::{
     convert::TryFrom,
@@ -249,6 +250,8 @@ pub trait RestClient {
         -> ClientResult<()>;
     /// Get resource specs
     async fn get_specs(&self) -> ClientResult<Specs>;
+    /// Get resource states
+    async fn get_states(&self) -> ClientResult<States>;
 }
 
 #[derive(Display, Debug)]
@@ -532,6 +535,11 @@ impl RestClient for ActixRestClient {
 
     async fn get_specs(&self) -> ClientResult<Specs> {
         let urn = "/v0/specs".to_string();
+        self.get(urn).await
+    }
+
+    async fn get_states(&self) -> ClientResult<States> {
+        let urn = "/v0/states".to_string();
         self.get(urn).await
     }
 }


### PR DESCRIPTION
Allow the runtime states of the various resources to be exposed through
the REST API. The runtime state is updated periodically by querying the
various Mayastor instances through gRPC calls.

Note: Runtime node information is not currently supported.