### PR TITLE
refactor: use generic ResourceMap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /.idea
 /result*
 /openapi/Cargo.lock
+/package.json
+/default.etcd/
+/node_modules/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "lazy_static",
  "nats",
  "once_cell",
+ "parking_lot",
  "paste",
  "reqwest",
  "rpc",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,15 @@
 pub mod mbus_api;
 pub mod store;
 pub mod types;
+
+/// Helper to convert from Vec<F> into Vec<T>
+pub trait IntoVec<T>: Sized {
+    /// Performs the conversion.
+    fn into_vec(self) -> Vec<T>;
+}
+
+impl<F: Into<T>, T> IntoVec<T> for Vec<F> {
+    fn into_vec(self) -> Vec<T> {
+        self.into_iter().map(Into::into).collect()
+    }
+}

--- a/common/src/types/v0/message_bus/mod.rs
+++ b/common/src/types/v0/message_bus/mod.rs
@@ -160,7 +160,3 @@ pub enum MessageIdVs {
     /// Get States
     GetStates,
 }
-
-pub trait UuidString {
-    fn uuid_as_string(&self) -> String;
-}

--- a/common/src/types/v0/message_bus/nexus.rs
+++ b/common/src/types/v0/message_bus/nexus.rs
@@ -36,12 +36,6 @@ pub struct Nexus {
     pub share: Protocol,
 }
 
-impl UuidString for Nexus {
-    fn uuid_as_string(&self) -> String {
-        self.uuid.clone().into()
-    }
-}
-
 impl From<Nexus> for models::Nexus {
     fn from(src: Nexus) -> Self {
         models::Nexus::new(

--- a/common/src/types/v0/message_bus/pool.rs
+++ b/common/src/types/v0/message_bus/pool.rs
@@ -79,12 +79,6 @@ pub struct Pool {
     pub used: u64,
 }
 
-impl UuidString for Pool {
-    fn uuid_as_string(&self) -> String {
-        self.id.clone().into()
-    }
-}
-
 impl From<Pool> for models::Pool {
     fn from(src: Pool) -> Self {
         Self::new(

--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -34,12 +34,6 @@ pub struct Replica {
     pub state: ReplicaState,
 }
 
-impl UuidString for Replica {
-    fn uuid_as_string(&self) -> String {
-        self.uuid.clone().into()
-    }
-}
-
 impl From<Replica> for models::Replica {
     fn from(src: Replica) -> Self {
         Self::new(

--- a/common/src/types/v0/store/definitions.rs
+++ b/common/src/types/v0/store/definitions.rs
@@ -100,6 +100,7 @@ pub trait Store: Sync + Send + Clone {
 
     async fn get_obj<O: StorableObject>(&mut self, _key: &O::Key) -> Result<O, StoreError>;
 
+    /// Returns a vector of tuples. Each tuple represents a key-value pair.
     async fn get_values_prefix(
         &mut self,
         key_prefix: &str,

--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -19,6 +19,12 @@ pub enum SpecState<T> {
     Deleted,
 }
 
+impl<T> Default for SpecState<T> {
+    fn default() -> Self {
+        Self::Creating
+    }
+}
+
 // todo: change openapi spec to support enum variants
 impl<T> From<SpecState<T>> for models::SpecState {
     fn from(src: SpecState<T>) -> Self {
@@ -58,4 +64,9 @@ pub trait SpecTransaction<Operation> {
     fn start_op(&mut self, operation: Operation);
     /// Sets the result of the operation
     fn set_op_result(&mut self, result: bool);
+}
+
+/// Trait which allows a UUID to be returned as a string.
+pub trait UuidString {
+    fn uuid_as_string(&self) -> String;
 }

--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -11,7 +11,7 @@ use crate::types::v0::{
     },
 };
 
-use crate::types::v0::openapi::models;
+use crate::types::v0::{openapi::models, store::UuidString};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -25,7 +25,7 @@ pub struct Nexus {
 }
 
 /// Runtime state of the nexus.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 pub struct NexusState {
     /// Nexus information.
     pub nexus: message_bus::Nexus,
@@ -34,6 +34,12 @@ pub struct NexusState {
 impl From<MbusNexus> for NexusState {
     fn from(nexus: MbusNexus) -> Self {
         Self { nexus }
+    }
+}
+
+impl UuidString for NexusState {
+    fn uuid_as_string(&self) -> String {
+        self.nexus.uuid.clone().into()
     }
 }
 
@@ -68,7 +74,7 @@ impl StorableObject for NexusState {
 pub type NexusSpecState = SpecState<message_bus::NexusState>;
 
 /// User specification of a nexus.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct NexusSpec {
     /// Nexus Id
     pub uuid: NexusId,
@@ -91,6 +97,12 @@ pub struct NexusSpec {
     pub updating: bool,
     /// Record of the operation in progress
     pub operation: Option<NexusOperationState>,
+}
+
+impl UuidString for NexusSpec {
+    fn uuid_as_string(&self) -> String {
+        self.uuid.clone().into()
+    }
 }
 
 impl From<NexusSpec> for models::NexusSpec {

--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -2,7 +2,10 @@
 
 use crate::types::v0::{
     message_bus::{self, NodeId},
-    store::definitions::{ObjectKey, StorableObject, StorableObjectType},
+    store::{
+        definitions::{ObjectKey, StorableObject, StorableObjectType},
+        UuidString,
+    },
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -22,12 +25,18 @@ pub struct NodeState {
     pub node: message_bus::Node,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Default, Clone)]
 pub struct NodeSpec {
     /// Node identification.
     id: NodeId,
     /// Node labels.
     labels: NodeLabels,
+}
+
+impl UuidString for NodeSpec {
+    fn uuid_as_string(&self) -> String {
+        self.id.clone().into()
+    }
 }
 
 /// Key used by the store to uniquely identify a NodeSpec structure.

--- a/common/src/types/v0/store/pool.rs
+++ b/common/src/types/v0/store/pool.rs
@@ -8,7 +8,7 @@ use crate::types::v0::{
     },
 };
 
-use crate::types::v0::openapi::models;
+use crate::types::v0::{openapi::models, store::UuidString};
 use serde::{Deserialize, Serialize};
 use std::convert::From;
 
@@ -42,6 +42,12 @@ impl From<MbusPool> for PoolState {
     }
 }
 
+impl UuidString for PoolState {
+    fn uuid_as_string(&self) -> String {
+        self.pool.id.clone().into()
+    }
+}
+
 /// State of the Pool Spec
 pub type PoolSpecState = SpecState<message_bus::PoolState>;
 impl From<&CreatePool> for PoolSpec {
@@ -66,7 +72,7 @@ impl PartialEq<CreatePool> for PoolSpec {
 }
 
 /// User specification of a pool.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct PoolSpec {
     /// id of the mayastor instance
     pub node: NodeId,
@@ -83,6 +89,12 @@ pub struct PoolSpec {
     pub updating: bool,
     /// Record of the operation in progress
     pub operation: Option<PoolOperationState>,
+}
+
+impl UuidString for PoolSpec {
+    fn uuid_as_string(&self) -> String {
+        self.id.clone().into()
+    }
 }
 
 impl From<PoolSpec> for models::PoolSpec {

--- a/common/src/types/v0/store/replica.rs
+++ b/common/src/types/v0/store/replica.rs
@@ -8,7 +8,7 @@ use crate::types::v0::{
     openapi::models,
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
-        SpecState, SpecTransaction,
+        SpecState, SpecTransaction, UuidString,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -24,7 +24,7 @@ pub struct Replica {
 }
 
 /// Runtime state of a replica.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, Default)]
 pub struct ReplicaState {
     /// Replica information.
     pub replica: message_bus::Replica,
@@ -33,6 +33,12 @@ pub struct ReplicaState {
 impl From<MbusReplica> for ReplicaState {
     fn from(replica: MbusReplica) -> Self {
         Self { replica }
+    }
+}
+
+impl UuidString for ReplicaState {
+    fn uuid_as_string(&self) -> String {
+        self.replica.uuid.clone().into()
     }
 }
 
@@ -58,7 +64,7 @@ impl StorableObject for ReplicaState {
 }
 
 /// User specification of a replica.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct ReplicaSpec {
     /// uuid of the replica
     pub uuid: ReplicaId,
@@ -81,6 +87,12 @@ pub struct ReplicaSpec {
     pub updating: bool,
     /// Record of the operation in progress
     pub operation: Option<ReplicaOperationState>,
+}
+
+impl UuidString for ReplicaSpec {
+    fn uuid_as_string(&self) -> String {
+        self.uuid.clone().into()
+    }
 }
 
 impl From<ReplicaSpec> for models::ReplicaSpec {

--- a/common/src/types/v0/store/volume.rs
+++ b/common/src/types/v0/store/volume.rs
@@ -8,7 +8,7 @@ use crate::types::v0::{
     },
 };
 
-use crate::types::v0::openapi::models;
+use crate::types::v0::{openapi::models, store::UuidString};
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 
@@ -73,7 +73,7 @@ impl StorableObject for VolumeState {
 }
 
 /// User specification of a volume.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct VolumeSpec {
     /// Volume Id
     pub uuid: VolumeId,
@@ -96,6 +96,12 @@ pub struct VolumeSpec {
     pub updating: bool,
     /// Record of the operation in progress
     pub operation: Option<VolumeOperationState>,
+}
+
+impl UuidString for VolumeSpec {
+    fn uuid_as_string(&self) -> String {
+        self.uuid.clone().into()
+    }
 }
 
 /// Operation State for a Nexus spec resource

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -38,6 +38,7 @@ http = "0.2.3"
 paste = "1.0.4"
 common-lib = { path = "../../common" }
 reqwest = "0.11.4"
+parking_lot = "0.11.1"
 
 [dev-dependencies]
 composer = { path = "../../composer" }

--- a/control-plane/agents/core/src/core/mod.rs
+++ b/control-plane/agents/core/src/core/mod.rs
@@ -4,6 +4,8 @@
 pub mod grpc;
 /// registry with node and all its resources
 pub mod registry;
+/// generic resources
+mod resource_map;
 /// registry with all the resource specs
 pub mod specs;
 /// registry with all the resource states

--- a/control-plane/agents/core/src/core/resource_map.rs
+++ b/control-plane/agents/core/src/core/resource_map.rs
@@ -1,0 +1,59 @@
+use common_lib::{types::v0::store::UuidString, IntoVec};
+use parking_lot::Mutex;
+use std::{
+    collections::{hash_map::Values, HashMap},
+    hash::Hash,
+    sync::Arc,
+};
+
+#[derive(Default, Debug)]
+pub struct ResourceMap<I, S> {
+    map: HashMap<I, Arc<Mutex<S>>>,
+}
+
+impl<I, S> ResourceMap<I, S>
+where
+    I: Eq + Hash + From<String>,
+    S: Clone + UuidString,
+{
+    /// Get the resource with the given key.
+    pub fn get(&self, key: &I) -> Option<&Arc<Mutex<S>>> {
+        self.map.get(key)
+    }
+
+    /// Clear the contents of the map.
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+
+    /// Insert an element or update an existing entry in the map.
+    pub fn insert(&mut self, key: I, value: Arc<Mutex<S>>) {
+        self.map.insert(key, value);
+    }
+
+    /// Remove an element from the map.
+    pub fn remove(&mut self, key: &I) {
+        self.map.remove(key);
+    }
+
+    /// Populate the resource map.
+    /// Should only be called if the map is empty because a new Arc is created thereby invalidating
+    /// any references to the previous value.
+    pub fn populate(&mut self, values: impl IntoVec<S>) {
+        assert!(self.map.is_empty());
+        for value in values.into_vec() {
+            self.map
+                .insert(value.uuid_as_string().into(), Arc::new(Mutex::new(value)));
+        }
+    }
+
+    /// Get all the resources as a vector.
+    pub fn to_vec(&self) -> Vec<Arc<Mutex<S>>> {
+        self.map.values().cloned().collect()
+    }
+
+    /// Return the maps values.
+    pub fn values(&self) -> Values<'_, I, Arc<Mutex<S>>> {
+        self.map.values()
+    }
+}

--- a/control-plane/agents/core/src/core/wrapper.rs
+++ b/control-plane/agents/core/src/core/wrapper.rs
@@ -157,10 +157,8 @@ impl NodeWrapper {
 
             {
                 // Update resource states in the registry.
-                let mut states = registry.states.write().await;
-                states
-                    .update(pools.clone(), replicas.clone(), nexuses.clone())
-                    .await;
+                let mut states = registry.states.write();
+                states.update(pools.clone(), replicas.clone(), nexuses.clone());
             }
 
             self.pools.clear();
@@ -278,7 +276,7 @@ impl NodeWrapper {
     }
 
     /// Fetch all replicas from this node via gRPC
-    async fn fetch_replicas(&self) -> Result<Vec<Replica>, SvcError> {
+    pub(crate) async fn fetch_replicas(&self) -> Result<Vec<Replica>, SvcError> {
         let mut ctx = self.grpc_client().await?;
         let rpc_replicas = ctx
             .client
@@ -296,7 +294,7 @@ impl NodeWrapper {
         Ok(pools)
     }
     /// Fetch all pools from this node via gRPC
-    async fn fetch_pools(&self) -> Result<Vec<Pool>, SvcError> {
+    pub(crate) async fn fetch_pools(&self) -> Result<Vec<Pool>, SvcError> {
         let mut ctx = self.grpc_client().await?;
         let rpc_pools = ctx
             .client
@@ -314,7 +312,7 @@ impl NodeWrapper {
         Ok(pools)
     }
     /// Fetch all nexuses from the node via gRPC
-    async fn fetch_nexuses(&self) -> Result<Vec<Nexus>, SvcError> {
+    pub(crate) async fn fetch_nexuses(&self) -> Result<Vec<Nexus>, SvcError> {
         let mut ctx = self.grpc_client().await?;
         let rpc_nexuses = ctx
             .client

--- a/control-plane/agents/core/src/node/service.rs
+++ b/control-plane/agents/core/src/node/service.rs
@@ -160,29 +160,22 @@ impl Service {
 
     /// Get specs from the registry
     pub(crate) async fn get_specs(&self, _request: &GetSpecs) -> Result<Specs, SvcError> {
-        let specs = self.registry.specs.write().await;
-        let nexuses = specs.get_nexuses().await;
-        let replicas = specs.get_replicas().await;
-        let volumes = specs.get_volumes().await;
-        let pools = specs.get_pools().await;
+        let specs = self.registry.specs.write();
         Ok(Specs {
-            volumes,
-            nexuses,
-            replicas,
-            pools,
+            volumes: specs.get_volumes(),
+            nexuses: specs.get_nexuses(),
+            replicas: specs.get_replicas(),
+            pools: specs.get_pools(),
         })
     }
 
     /// Get states from the registry
     pub(crate) async fn get_states(&self, _request: &GetStates) -> Result<States, SvcError> {
-        let states = self.registry.states.write().await;
-        let nexuses = states.get_nexus_states().await;
-        let replicas = states.get_replica_states().await;
-        let pools = states.get_pool_states().await;
+        let states = &*self.registry.states.read();
         Ok(States {
-            nexuses,
-            pools,
-            replicas,
+            nexuses: states.get_nexus_states(),
+            pools: states.get_pool_states(),
+            replicas: states.get_replica_states(),
         })
     }
 }


### PR DESCRIPTION
The ResourceSpecs and ResourceMaps have been made generic through the
use of a ResourceMap. This simplifies the interactions with these
resources.

As part of this change, the ResourceSpecs no longer require the use of
an async mutex. Instead, a sync mutex is used.

Resolves: CAS-1010