### PR TITLE
refactor(NodeWrapper): use ResourceStatesLocked

### DIFF
--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -150,10 +150,11 @@ impl Registry {
                 let _guard = lock.lock().await;
 
                 let mut node_clone = node.lock().await.clone();
-                if node_clone.reload(self).await.is_ok() {
-                    // update node in the registry
-                    *node.lock().await = node_clone;
+                if let Err(e) = node_clone.reload(self).await {
+                    tracing::trace!("Failed to reload node {}. Error {:?}.", node_clone.id, e);
                 }
+                // update node in the registry
+                *node.lock().await = node_clone;
             }
             self.trace_all().await;
             tokio::time::sleep(self.cache_period).await;

--- a/control-plane/agents/core/src/core/resource_map.rs
+++ b/control-plane/agents/core/src/core/resource_map.rs
@@ -27,8 +27,20 @@ where
     }
 
     /// Insert an element or update an existing entry in the map.
-    pub fn insert(&mut self, key: I, value: Arc<Mutex<S>>) {
-        self.map.insert(key, value);
+    pub fn insert(&mut self, value: S) -> Arc<Mutex<S>> {
+        let key = value.uuid_as_string().into();
+        match self.map.get(&key) {
+            Some(entry) => {
+                let mut e = entry.lock();
+                *e = value;
+                entry.clone()
+            }
+            None => {
+                let v = Arc::new(Mutex::new(value));
+                self.map.insert(key, v.clone());
+                v
+            }
+        }
     }
 
     /// Remove an element from the map.

--- a/control-plane/agents/core/src/core/states.rs
+++ b/control-plane/agents/core/src/core/states.rs
@@ -35,14 +35,14 @@ pub(crate) struct ResourceStates {
 
 impl ResourceStates {
     /// Update the various resource states.
-    /// This purges any previous updates.
     pub(crate) fn update(&mut self, pools: Vec<Pool>, replicas: Vec<Replica>, nexuses: Vec<Nexus>) {
-        self.replicas.clear();
-        self.replicas.populate(replicas);
+        self.update_replicas(replicas);
+        self.update_pools(pools);
+        self.update_nexuses(nexuses);
+    }
 
-        self.pools.clear();
-        self.pools.populate(pools);
-
+    /// Update nexus states.
+    pub(crate) fn update_nexuses(&mut self, nexuses: Vec<Nexus>) {
         self.nexuses.clear();
         self.nexuses.populate(nexuses);
     }
@@ -52,14 +52,50 @@ impl ResourceStates {
         Self::cloned_inner_states(self.nexuses.to_vec())
     }
 
+    /// Returns the nexus state for the nexus with the given ID.
+    pub(crate) fn get_nexus_state(&self, id: &NexusId) -> Option<NexusState> {
+        self.nexuses.get(id).map(|state| state.lock().clone())
+    }
+
+    /// Update pool states.
+    pub(crate) fn update_pools(&mut self, pools: Vec<Pool>) {
+        self.pools.clear();
+        self.pools.populate(pools);
+    }
+
     /// Returns a vector of pool states.
     pub(crate) fn get_pool_states(&self) -> Vec<PoolState> {
         Self::cloned_inner_states(self.pools.to_vec())
     }
 
+    /// Get a pool with the given ID.
+    pub(crate) fn get_pool_state(&self, id: &PoolId) -> Option<PoolState> {
+        let pool_state = self.pools.get(id)?;
+        Some(pool_state.lock().clone())
+    }
+
+    /// Update replica states.
+    pub(crate) fn update_replicas(&mut self, replicas: Vec<Replica>) {
+        self.replicas.clear();
+        self.replicas.populate(replicas);
+    }
+
     /// Returns a vector of replica states.
     pub(crate) fn get_replica_states(&self) -> Vec<ReplicaState> {
         Self::cloned_inner_states(self.replicas.to_vec())
+    }
+
+    /// Get a replica with the given ID.
+    pub(crate) fn get_replica_state(&self, id: &ReplicaId) -> Option<ReplicaState> {
+        let replica_state = self.replicas.get(id)?;
+        Some(replica_state.lock().clone())
+    }
+
+    /// Clear all state information.
+    pub(crate) fn clear_all(&mut self) {
+        self.nexuses.clear();
+        self.pools.clear();
+        self.replicas.clear();
     }
 
     /// Takes a vector of resources protected by an 'Arc' and 'Mutex' and returns a vector of

--- a/control-plane/agents/core/src/nexus/specs.rs
+++ b/control-plane/agents/core/src/nexus/specs.rs
@@ -144,12 +144,7 @@ impl ResourceSpecsLocked {
         if let Some(nexus) = specs.nexuses.get(&request.uuid) {
             nexus.clone()
         } else {
-            let spec = NexusSpec::from(request);
-            let locked_spec = Arc::new(Mutex::new(spec));
-            specs
-                .nexuses
-                .insert(request.uuid.clone(), locked_spec.clone());
-            locked_spec
+            specs.nexuses.insert(NexusSpec::from(request))
         }
     }
 

--- a/control-plane/agents/core/src/pool/registry.rs
+++ b/control-plane/agents/core/src/pool/registry.rs
@@ -1,5 +1,5 @@
 use crate::core::{registry::Registry, wrapper::*};
-use common::errors::{NodeNotFound, PoolNotFound, ReplicaNotFound, SvcError};
+use common::errors::{NodeNotFound, ReplicaNotFound, SvcError, SvcError::PoolNotFound};
 use common_lib::types::v0::message_bus::{NodeId, Pool, PoolId, Replica, ReplicaId};
 use snafu::OptionExt;
 
@@ -16,58 +16,49 @@ impl Registry {
         }
     }
 
-    /// Get wrapper pool `pool_id` from node `node_id`
-    pub(crate) async fn get_node_pool_wrapper(
-        &self,
-        node_id: &NodeId,
-        pool_id: &PoolId,
-    ) -> Result<PoolWrapper, SvcError> {
-        let node = self.get_node_wrapper(node_id).await.context(NodeNotFound {
-            node_id: node_id.clone(),
-        })?;
-        let pool = node.pool(pool_id).await.context(PoolNotFound {
-            pool_id: pool_id.clone(),
-        })?;
-        Ok(pool)
-    }
-
-    /// Get pool wrapper for `pool_id`
-    pub(crate) async fn get_pool_wrapper(&self, pool_id: &PoolId) -> Result<PoolWrapper, SvcError> {
-        let nodes = self.get_nodes_wrapper().await;
-        for node in nodes {
-            if let Some(pool) = node.pool(pool_id).await {
-                return Ok(pool);
-            }
-        }
-        Err(common::errors::SvcError::PoolNotFound {
-            pool_id: pool_id.clone(),
-        })
-    }
-
-    /// Get all pool wrappers
-    pub(crate) async fn get_pools_wrapper(&self) -> Result<Vec<PoolWrapper>, SvcError> {
-        let nodes = self.get_nodes_wrapper().await;
-        let mut pools = vec![];
-        for node in nodes {
-            pools.extend(node.pools().await);
-        }
-        Ok(pools)
-    }
-
     /// Get pool wrappers per node
     pub(crate) async fn get_node_pools_wrapper(&self) -> Result<Vec<Vec<PoolWrapper>>, SvcError> {
         let nodes = self.get_nodes_wrapper().await;
         let mut pools = vec![];
         for node in nodes {
-            pools.push(node.pools().await);
+            let mut pool_wrappers = vec![];
+            for pool in node.pools().await {
+                let replicas: Vec<Replica> = node
+                    .replicas()
+                    .await
+                    .iter()
+                    .filter(|r| r.pool == pool.id)
+                    .map(Clone::clone)
+                    .collect();
+                pool_wrappers.push(PoolWrapper::new(&pool, &replicas));
+            }
+            pools.push(pool_wrappers)
         }
         Ok(pools)
     }
 
+    /// Get pool wrappers for the pool ID.
+    pub(crate) async fn get_node_pool_wrapper(
+        &self,
+        pool_id: PoolId,
+    ) -> Result<PoolWrapper, SvcError> {
+        let nodes = self.get_nodes_wrapper().await;
+        for node in nodes {
+            if let Some(pool) = node.pool_wrapper(&pool_id).await {
+                return Ok(pool);
+            }
+        }
+        Err(PoolNotFound { pool_id })
+    }
+
     /// Get all pools
     pub(crate) async fn get_pools_inner(&self) -> Result<Vec<Pool>, SvcError> {
-        let nodes = self.get_pools_wrapper().await?;
-        Ok(nodes.iter().map(Pool::from).collect())
+        let nodes = self.get_nodes_wrapper().await;
+        let mut pools = vec![];
+        for node in nodes {
+            pools.append(&mut node.pools().await)
+        }
+        Ok(pools)
     }
 
     /// Get all pools from node `node_id`
@@ -75,27 +66,20 @@ impl Registry {
         let node = self.get_node_wrapper(node_id).await.context(NodeNotFound {
             node_id: node_id.clone(),
         })?;
-        Ok(node.pools().await.iter().map(Pool::from).collect())
+        Ok(node.pools().await)
     }
 }
 
 /// Replica helpers
 impl Registry {
-    /// Get all replicas from node `node_id` or from all nodes
-    pub(crate) async fn get_node_opt_replicas(
-        &self,
-        node_id: Option<NodeId>,
-    ) -> Result<Vec<Replica>, SvcError> {
-        match node_id {
-            None => self.get_replicas().await,
-            Some(node_id) => self.get_node_replicas(&node_id).await,
-        }
-    }
-
     /// Get all replicas
     pub(crate) async fn get_replicas(&self) -> Result<Vec<Replica>, SvcError> {
-        let nodes = self.get_pools_wrapper().await?;
-        Ok(nodes.iter().map(|pool| pool.replicas()).flatten().collect())
+        let nodes = self.get_nodes_wrapper().await;
+        let mut replicas = vec![];
+        for node in nodes {
+            replicas.append(&mut node.replicas().await);
+        }
+        Ok(replicas)
     }
 
     /// Get replica `replica_id`
@@ -119,52 +103,5 @@ impl Registry {
             node_id: node_id.clone(),
         })?;
         Ok(node.replicas().await)
-    }
-
-    /// Get replica `replica_id` from node `node_id`
-    pub(crate) async fn get_node_replica(
-        &self,
-        node_id: &NodeId,
-        replica_id: &ReplicaId,
-    ) -> Result<Replica, SvcError> {
-        let node = self.get_node_wrapper(node_id).await.context(NodeNotFound {
-            node_id: node_id.clone(),
-        })?;
-        let replica = node.replica(replica_id).await.context(ReplicaNotFound {
-            replica_id: replica_id.clone(),
-        })?;
-        Ok(replica)
-    }
-
-    /// Get replica `replica_id` from pool `pool_id`
-    pub(crate) async fn get_pool_replica(
-        &self,
-        pool_id: &PoolId,
-        replica_id: &ReplicaId,
-    ) -> Result<Replica, SvcError> {
-        let pool = self.get_pool_wrapper(pool_id).await?;
-        let replica = pool.replica(replica_id).context(ReplicaNotFound {
-            replica_id: replica_id.clone(),
-        })?;
-        Ok(replica.clone())
-    }
-
-    /// Get replica `replica_id` from pool `pool_id` on node `node_id`
-    pub(crate) async fn get_node_pool_replica(
-        &self,
-        node_id: &NodeId,
-        pool_id: &PoolId,
-        replica_id: &ReplicaId,
-    ) -> Result<Replica, SvcError> {
-        let node = self.get_node_wrapper(node_id).await.context(NodeNotFound {
-            node_id: node_id.clone(),
-        })?;
-        let pool = node.pool(pool_id).await.context(PoolNotFound {
-            pool_id: pool_id.clone(),
-        })?;
-        let replica = pool.replica(replica_id).context(ReplicaNotFound {
-            replica_id: replica_id.clone(),
-        })?;
-        Ok(replica.clone())
     }
 }

--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -328,12 +328,7 @@ impl ResourceSpecsLocked {
         if let Some(replica) = specs.replicas.get(&request.uuid) {
             replica.clone()
         } else {
-            let spec = ReplicaSpec::from(request);
-            let locked_spec = Arc::new(Mutex::new(spec));
-            specs
-                .replicas
-                .insert(request.uuid.clone(), locked_spec.clone());
-            locked_spec
+            specs.replicas.insert(ReplicaSpec::from(request))
         }
     }
     /// Get a protected ReplicaSpec for the given replica `id`, if it exists
@@ -348,10 +343,7 @@ impl ResourceSpecsLocked {
         if let Some(pool) = specs.pools.get(&request.id) {
             pool.clone()
         } else {
-            let spec = PoolSpec::from(request);
-            let locked_spec = Arc::new(Mutex::new(spec));
-            specs.pools.insert(request.id.clone(), locked_spec.clone());
-            locked_spec
+            specs.pools.insert(PoolSpec::from(request))
         }
     }
     /// Get a protected PoolSpec for the given pool `id`, if it exists

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -525,12 +525,7 @@ impl ResourceSpecsLocked {
         if let Some(volume) = specs.volumes.get(&request.uuid) {
             volume.clone()
         } else {
-            let spec = VolumeSpec::from(request);
-            let locked_spec = Arc::new(Mutex::new(spec));
-            specs
-                .volumes
-                .insert(request.uuid.clone(), locked_spec.clone());
-            locked_spec
+            specs.volumes.insert(VolumeSpec::from(request))
         }
     }
 }

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -279,7 +279,7 @@ async fn client_test(mayastor: &NodeId, test: &ComposeTest, auth: &bool) {
         }
     );
 
-    let child = client
+    let mut child = client
         .children_api()
         .put_node_nexus_child(
             &nexus.node,
@@ -294,6 +294,13 @@ async fn client_test(mayastor: &NodeId, test: &ComposeTest, auth: &bool) {
         .get_nexus_children(&nexus.uuid.to_string())
         .await
         .unwrap();
+
+    // It's possible that the rebuild progress will change between putting a child and getting the
+    // list of children. Just check that they are both rebuilding and then set them to the same
+    // thing so that we can compare them in subsequent asserts.
+    assert!(child.rebuild_progress.is_some());
+    assert!(children.last().unwrap().rebuild_progress.is_some());
+    child.rebuild_progress = children.last().unwrap().rebuild_progress;
     assert_eq!(Some(&child), children.last());
 
     client


### PR DESCRIPTION
The NodeWrapper now uses the ResourceStatesLocked structure to maintain
runtime information from Mayastor. The removes the need for the
NodeWrapper to maintain a separate pools and nexuses hashmap.

Resolves: CAS-985