### PR TITLE
chore: remove states from registry

### DIFF
--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -13,7 +13,7 @@
 //!
 //! Each instance also contains the known nexus, pools and replicas that live in
 //! said instance.
-use super::{specs::*, states::ResourceStatesLocked, wrapper::NodeWrapper};
+use super::{specs::*, wrapper::NodeWrapper};
 use crate::core::wrapper::InternalOps;
 use common::errors::SvcError;
 use common_lib::{
@@ -36,8 +36,6 @@ pub struct RegistryInner<S: Store> {
     pub(crate) nodes: Arc<RwLock<HashMap<NodeId, Arc<Mutex<NodeWrapper>>>>>,
     /// spec (aka desired state) of the various resources
     pub(crate) specs: ResourceSpecsLocked,
-    /// state (aka actual state) of the various resources
-    pub(crate) states: ResourceStatesLocked,
     /// period to refresh the cache
     cache_period: std::time::Duration,
     pub(crate) store: Arc<Mutex<S>>,
@@ -66,7 +64,6 @@ impl Registry {
         let registry = Self {
             nodes: Default::default(),
             specs: ResourceSpecsLocked::new(),
-            states: ResourceStatesLocked::new(),
             cache_period,
             store: Arc::new(Mutex::new(store)),
             store_timeout,

--- a/control-plane/agents/core/src/core/wrapper.rs
+++ b/control-plane/agents/core/src/core/wrapper.rs
@@ -134,6 +134,10 @@ impl NodeWrapper {
             })
             .collect()
     }
+    /// Get all pool states
+    pub(crate) fn pool_states(&self) -> Vec<store::pool::PoolState> {
+        self.states.read().get_pool_states()
+    }
     /// Get pool from `pool_id` or None
     pub(crate) fn pool(&self, pool_id: &PoolId) -> Option<Pool> {
         self.states.read().get_pool_state(pool_id).map(|p| p.pool)
@@ -162,6 +166,10 @@ impl NodeWrapper {
             .map(|r| r.replica.clone())
             .collect()
     }
+    /// Get all replica states
+    pub(crate) fn replica_states(&self) -> Vec<ReplicaState> {
+        self.states.read().get_replica_states()
+    }
     /// Get all nexuses
     fn nexuses(&self) -> Vec<Nexus> {
         self.states
@@ -170,6 +178,10 @@ impl NodeWrapper {
             .iter()
             .map(|nexus_state| nexus_state.nexus.clone())
             .collect()
+    }
+    /// Get all nexus states
+    pub(crate) fn nexus_states(&self) -> Vec<NexusState> {
+        self.states.read().get_nexus_states()
     }
     /// Get nexus
     fn nexus(&self, nexus_id: &NexusId) -> Option<Nexus> {
@@ -320,6 +332,10 @@ use crate::{
     node::service::NodeCommsTimeout,
 };
 use async_trait::async_trait;
+use common_lib::types::v0::{
+    store,
+    store::{nexus::NexusState, replica::ReplicaState},
+};
 use std::{ops::Deref, sync::Arc};
 
 /// CRUD Operations on a locked mayastor `NodeWrapper` such as:


### PR DESCRIPTION
The state information for resources are store per node in the
NodeWrapper, therefore remove the states from the registry as this is no
longer needed.