### PR TITLE
fix: create nexuses with only healthy replicas

### DIFF
--- a/common/src/types/v0/message_bus/child.rs
+++ b/common/src/types/v0/message_bus/child.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, fmt::Debug};
+use std::{cmp::Ordering, fmt::Debug, str::FromStr};
 
 /// Child information
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
@@ -37,6 +37,18 @@ impl From<models::Child> for Child {
 
 bus_impl_string_id_percent_decoding!(ChildUri, "URI of a mayastor nexus child");
 
+impl ChildUri {
+    /// Get the mayastor bdev uuid from the ChildUri
+    pub fn uuid_str(&self) -> Option<String> {
+        match url::Url::from_str(self.as_str()) {
+            Ok(url) => {
+                let uuid = url.query_pairs().find(|(name, _)| name == "uuid");
+                uuid.map(|(_, uuid)| uuid.to_string())
+            }
+            Err(_) => None,
+        }
+    }
+}
 impl PartialEq<Child> for ChildUri {
     fn eq(&self, other: &Child) -> bool {
         self == &other.uri

--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -34,6 +34,12 @@ pub struct Replica {
     /// state of the replica
     pub state: ReplicaState,
 }
+impl Replica {
+    /// check if the replica is online
+    pub fn online(&self) -> bool {
+        self.state.online()
+    }
+}
 
 impl From<Replica> for models::Replica {
     fn from(src: Replica) -> Self {
@@ -301,6 +307,12 @@ pub enum ReplicaState {
     Degraded = 2,
     /// the replica is completely inaccessible
     Faulted = 3,
+}
+impl ReplicaState {
+    /// check if the state is online
+    pub fn online(&self) -> bool {
+        self == &Self::Online
+    }
 }
 
 impl Default for ReplicaState {

--- a/common/src/types/v0/store/definitions.rs
+++ b/common/src/types/v0/store/definitions.rs
@@ -138,6 +138,7 @@ pub enum StorableObjectType {
     Nexus,
     NexusSpec,
     NexusState,
+    NexusInfo,
     Node,
     NodeSpec,
     Pool,

--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -2,6 +2,7 @@ pub mod child;
 pub mod definitions;
 pub mod nexus;
 pub mod nexus_child;
+pub mod nexus_persistence;
 pub mod node;
 pub mod pool;
 pub mod replica;

--- a/common/src/types/v0/store/nexus_persistence.rs
+++ b/common/src/types/v0/store/nexus_persistence.rs
@@ -1,0 +1,61 @@
+use crate::types::v0::{
+    message_bus::NexusId,
+    store::definitions::{ObjectKey, StorableObject, StorableObjectType},
+};
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+/// Definition of the nexus information that gets saved in the persistent
+/// store.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct NexusInfo {
+    #[serde(skip)]
+    /// uuid of the Nexus
+    pub uuid: NexusId,
+    /// Nexus destroyed successfully.
+    pub clean_shutdown: bool,
+    /// Information about children.
+    pub children: Vec<ChildInfo>,
+}
+
+/// Definition of the child information that gets saved in the persistent
+/// store.
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+pub struct ChildInfo {
+    /// UUID of the child.
+    pub uuid: String,
+    /// Child's state of health.
+    pub healthy: bool,
+}
+
+/// Key used by the store to uniquely identify a NexusInfo structure.
+pub struct NexusInfoKey(NexusId);
+
+impl From<&NexusId> for NexusInfoKey {
+    fn from(id: &NexusId) -> Self {
+        Self(id.clone())
+    }
+}
+
+impl ObjectKey for NexusInfoKey {
+    fn key(&self) -> String {
+        // no key prefix (as it's written by mayastor)
+        self.key_uuid()
+    }
+
+    fn key_type(&self) -> StorableObjectType {
+        StorableObjectType::NexusInfo
+    }
+
+    fn key_uuid(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl StorableObject for NexusInfo {
+    type Key = NexusInfoKey;
+
+    fn key(&self) -> Self::Key {
+        NexusInfoKey(self.uuid.clone())
+    }
+}

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -168,6 +168,8 @@ pub enum SvcError {
     },
     #[snafu(display("No suitable replica removal candidates found for Volume '{}'", id))]
     ReplicaRemovalNoCandidates { id: String },
+    #[snafu(display("No online replicas are available for Volume '{}'", id))]
+    NoOnlineReplicas { id: String },
 }
 
 impl From<StoreError> for SvcError {
@@ -467,6 +469,12 @@ impl From<SvcError> for ReplyError {
             },
             SvcError::ReplicaRemovalNoCandidates { .. } => ReplyError {
                 kind: ReplyErrorKind::ReplicaIncrease,
+                resource: ResourceKind::Volume,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+            SvcError::NoOnlineReplicas { .. } => ReplyError {
+                kind: ReplyErrorKind::VolumeNoReplicas,
                 resource: ResourceKind::Volume,
                 source: desc.to_string(),
                 extra: error.full_string(),

--- a/control-plane/agents/core/src/core/scheduling/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/mod.rs
@@ -1,8 +1,10 @@
+pub(crate) mod nexus;
 pub(crate) mod resources;
 pub(crate) mod volume;
 
 use crate::core::scheduling::{
-    resources::{PoolItem, ReplicaItem},
+    nexus::GetPersistedNexusChildrenCtx,
+    resources::{ChildItem, PoolItem, ReplicaItem},
     volume::GetSuitablePoolsContext,
 };
 use common_lib::types::v0::message_bus::PoolState;
@@ -24,11 +26,13 @@ pub(crate) trait ResourceFilter: Sized {
         filter(self).await
     }
     fn filter<F: FnMut(&Self::Request, &Self::Item) -> bool>(self, filter: F) -> Self;
-    async fn filter_async<Fn, Fut>(self, filter: Fn) -> Self
-    where
-        Fn: FnMut(&Self::Request, &Self::Item) -> Fut,
-        Fut: Future<Output = bool>;
     fn sort<F: FnMut(&Self::Item, &Self::Item) -> std::cmp::Ordering>(self, sort: F) -> Self;
+    fn sort_ctx<F: FnMut(&Self::Request, &Self::Item, &Self::Item) -> std::cmp::Ordering>(
+        self,
+        _sort: F,
+    ) -> Self {
+        unimplemented!();
+    }
     fn collect(self) -> Vec<Self::Item>;
     fn group_by<K, V, F: Fn(&Self::Request, &Vec<Self::Item>) -> HashMap<K, V>>(
         self,
@@ -41,15 +45,15 @@ pub(crate) trait ResourceFilter: Sized {
 pub(crate) struct NodeFilters {}
 impl NodeFilters {
     /// Should only attempt to use online nodes
-    pub(crate) fn online_nodes(_request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+    pub(crate) fn online(_request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
         item.node.is_online()
     }
     /// Should only attempt to use allowed nodes (by the topology)
-    pub(crate) fn allowed_nodes(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+    pub(crate) fn allowed(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
         request.allowed_nodes().is_empty() || request.allowed_nodes().contains(&item.pool.node)
     }
     /// Should only attempt to use nodes not currently used by the volume
-    pub(crate) fn unused_nodes(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+    pub(crate) fn unused(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
         let registry = &request.registry;
         let used_nodes = registry.specs.get_volume_data_nodes(&request.uuid);
         !used_nodes.contains(&item.pool.node)
@@ -59,11 +63,11 @@ impl NodeFilters {
 pub(crate) struct PoolFilters {}
 impl PoolFilters {
     /// Should only attempt to use pools with sufficient free space
-    pub(crate) fn enough_free_space(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+    pub(crate) fn free_space(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
         item.pool.free_space() > request.size
     }
     /// Should only attempt to use usable (not faulted) pools
-    pub(crate) fn usable_pools(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+    pub(crate) fn usable(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
         item.pool.state != PoolState::Faulted && item.pool.state != PoolState::Unknown
     }
 }
@@ -119,6 +123,48 @@ impl ChildSorters {
                     },
                 }
             }
+        }
+    }
+}
+
+pub(crate) struct ChildInfoFilters {}
+impl ChildInfoFilters {
+    /// Should only allow healthy children
+    pub(crate) fn healthy(request: &GetPersistedNexusChildrenCtx, item: &ChildItem) -> bool {
+        // on first creation there is no nexus_info/child_info so all children are deemed healthy
+        let first_create = request.nexus_info().is_none();
+        first_create || item.info().as_ref().map(|i| i.healthy).unwrap_or(false)
+    }
+}
+
+pub(crate) struct ReplicaFilters {}
+impl ReplicaFilters {
+    /// Should only allow children with corresponding online replicas
+    pub(crate) fn online(_request: &GetPersistedNexusChildrenCtx, item: &ChildItem) -> bool {
+        item.state().online()
+    }
+
+    /// Should only allow children with corresponding replicas with enough size
+    pub(crate) fn size(request: &GetPersistedNexusChildrenCtx, item: &ChildItem) -> bool {
+        item.state().size >= request.spec().size
+    }
+}
+
+pub(crate) struct ChildItemSorters {}
+impl ChildItemSorters {
+    /// Sort ChildItem's for volume nexus creation
+    /// Prefer children local to where the nexus will be created
+    pub(crate) fn sort_by_locality(
+        request: &GetPersistedNexusChildrenCtx,
+        a: &ChildItem,
+        b: &ChildItem,
+    ) -> std::cmp::Ordering {
+        let a_is_local = &a.state().node == request.target_node();
+        let b_is_local = &b.state().node == request.target_node();
+        match (a_is_local, b_is_local) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            (_, _) => std::cmp::Ordering::Equal,
         }
     }
 }

--- a/control-plane/agents/core/src/core/scheduling/nexus.rs
+++ b/control-plane/agents/core/src/core/scheduling/nexus.rs
@@ -1,0 +1,199 @@
+use crate::core::{
+    registry::Registry,
+    scheduling::{
+        resources::ChildItem, ChildInfoFilters, ChildItemSorters, ReplicaFilters, ResourceFilter,
+    },
+};
+use common::errors::SvcError;
+use common_lib::types::v0::{
+    message_bus::{ChildUri, NodeId},
+    store::{
+        nexus_persistence::{NexusInfo, NexusInfoKey},
+        volume::VolumeSpec,
+    },
+};
+use itertools::Itertools;
+use std::collections::HashMap;
+
+/// Request to retrieve a list of healthy nexus children which is used for nexus creation
+/// used by `CreateVolumeNexus`
+#[derive(Clone)]
+pub(crate) struct GetPersistedNexusChildren {
+    spec: VolumeSpec,
+    target_node: NodeId,
+}
+
+impl GetPersistedNexusChildren {
+    pub(crate) fn new(spec: &VolumeSpec, target_node: &NodeId) -> Self {
+        Self {
+            spec: spec.clone(),
+            target_node: target_node.clone(),
+        }
+    }
+}
+
+/// `GetPersistedNexusChildren` context used by the filter functions for `GetPersistedNexusChildren`
+#[derive(Clone)]
+pub(crate) struct GetPersistedNexusChildrenCtx {
+    registry: Registry,
+    spec: VolumeSpec,
+    target_node: NodeId,
+    nexus_info: Option<NexusInfo>,
+}
+
+impl GetPersistedNexusChildrenCtx {
+    /// Get the volume spec
+    pub(crate) fn spec(&self) -> &VolumeSpec {
+        &self.spec
+    }
+    /// Get the target node where the nexus will be created on
+    pub(crate) fn target_node(&self) -> &NodeId {
+        &self.target_node
+    }
+    /// Get the current nexus persistent information
+    pub(crate) fn nexus_info(&self) -> &Option<NexusInfo> {
+        &self.nexus_info
+    }
+}
+
+impl GetPersistedNexusChildrenCtx {
+    async fn new(
+        registry: &Registry,
+        request: &GetPersistedNexusChildren,
+    ) -> Result<Self, SvcError> {
+        let spec = request.spec.clone();
+        let nexus_info = if let Some(nexus_id) = &spec.last_nexus_id {
+            let mut nexus_info: NexusInfo =
+                registry.load_obj(&NexusInfoKey::from(nexus_id)).await?;
+            nexus_info.uuid = nexus_id.clone();
+            Some(nexus_info)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            registry: registry.clone(),
+            spec,
+            nexus_info,
+            target_node: request.target_node.clone(),
+        })
+    }
+    async fn list(&self) -> Vec<ChildItem> {
+        // find all replica status
+        let state_replicas = self.registry.get_replicas().await;
+        // find all replica specs for this volume
+        let spec_replicas = self.registry.specs.get_volume_replicas(&self.spec.uuid);
+
+        spec_replicas
+            .into_iter()
+            .filter_map(|replica_spec| {
+                let replica_spec = replica_spec.lock().clone();
+                let replica_state = state_replicas
+                    .iter()
+                    .find(|state| state.uuid == replica_spec.uuid);
+                let child_info = self
+                    .nexus_info
+                    .as_ref()
+                    .map(|n| {
+                        n.children.iter().find(|c| {
+                            if let Some(replica_state) = replica_state {
+                                ChildUri::from(&replica_state.uri).uuid_str().as_ref()
+                                    == Some(&c.uuid)
+                            } else {
+                                false
+                            }
+                        })
+                    })
+                    .flatten();
+                replica_state.map(|replica_state| {
+                    ChildItem::new(replica_spec, replica_state.clone(), child_info.cloned())
+                })
+            })
+            .collect()
+    }
+}
+
+/// Builder used to retrieve a list of healthy nexus children which is used for nexus creation
+#[derive(Clone)]
+pub(crate) struct CreateVolumeNexus {
+    context: GetPersistedNexusChildrenCtx,
+    list: Vec<ChildItem>,
+}
+
+impl CreateVolumeNexus {
+    async fn builder(
+        request: &GetPersistedNexusChildren,
+        registry: &Registry,
+    ) -> Result<Self, SvcError> {
+        let context = GetPersistedNexusChildrenCtx::new(registry, request).await?;
+        let list = context.list().await;
+        Ok(Self { list, context })
+    }
+
+    /// Get the inner context
+    pub(crate) fn context(&self) -> &GetPersistedNexusChildrenCtx {
+        &self.context
+    }
+
+    /// Get `Self` with a default set of filters for replicas/children according to the following
+    /// criteria (any order):
+    /// 1. if it's a nexus recreation, then use only children marked as healthy by mayastor
+    /// 2. use only replicas which report the status of online by their state
+    /// 3. use only replicas which are large enough for the volume
+    pub(crate) async fn builder_with_defaults(
+        request: &GetPersistedNexusChildren,
+        registry: &Registry,
+    ) -> Result<Self, SvcError> {
+        Ok(Self::builder(request, registry)
+            .await?
+            .filter(ChildInfoFilters::healthy)
+            .filter(ReplicaFilters::online)
+            .filter(ReplicaFilters::size)
+            .sort_ctx(ChildItemSorters::sort_by_locality))
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ResourceFilter for CreateVolumeNexus {
+    type Request = GetPersistedNexusChildrenCtx;
+    type Item = ChildItem;
+
+    fn filter<P: FnMut(&Self::Request, &Self::Item) -> bool>(mut self, mut filter: P) -> Self {
+        let request = self.context.clone();
+        self.list = self
+            .list
+            .into_iter()
+            .filter(|v| filter(&request, v))
+            .collect();
+        self
+    }
+
+    fn sort<P: FnMut(&Self::Item, &Self::Item) -> std::cmp::Ordering>(mut self, sort: P) -> Self {
+        self.list = self.list.into_iter().sorted_by(sort).collect();
+        self
+    }
+
+    fn sort_ctx<P: FnMut(&Self::Request, &Self::Item, &Self::Item) -> std::cmp::Ordering>(
+        mut self,
+        mut sort: P,
+    ) -> Self {
+        let context = self.context.clone();
+        self.list = self
+            .list
+            .into_iter()
+            .sorted_by(|a, b| sort(&context, a, b))
+            .collect();
+        self
+    }
+
+    fn collect(self) -> Vec<Self::Item> {
+        self.list
+    }
+
+    fn group_by<K, V, F: Fn(&Self::Request, &Vec<Self::Item>) -> HashMap<K, V>>(
+        self,
+        group: F,
+    ) -> HashMap<K, V> {
+        group(&self.context, &self.list)
+    }
+}

--- a/control-plane/agents/core/src/core/tests.rs
+++ b/control-plane/agents/core/src/core/tests.rs
@@ -19,14 +19,19 @@ async fn bootstrap_registry() {
         .await
         .unwrap();
 
-    let replica = format!("loopback:///{}", Cluster::replica(0, 0, 0));
+    let replica = cluster
+        .rest_v00()
+        .replicas_api()
+        .get_replica(Cluster::replica(0, 0, 0).as_str())
+        .await
+        .unwrap();
     cluster
         .rest_v0()
         .create_nexus(message_bus::CreateNexus {
             node: cluster.node(0),
             uuid: message_bus::NexusId::new(),
             size,
-            children: vec![replica.into()],
+            children: vec![replica.uri.into()],
             ..Default::default()
         })
         .await

--- a/control-plane/agents/core/src/nexus/registry.rs
+++ b/control-plane/agents/core/src/nexus/registry.rs
@@ -1,5 +1,5 @@
 use crate::core::{registry::Registry, wrapper::*};
-use common::errors::{NexusNotFound, NodeNotFound, SvcError};
+use common::errors::{NexusNotFound, SvcError};
 use common_lib::types::v0::message_bus::{Nexus, NexusId, NodeId};
 use snafu::OptionExt;
 
@@ -18,9 +18,7 @@ impl Registry {
 
     /// Get all nexuses from node `node_id`
     pub(crate) async fn get_node_nexuses(&self, node_id: &NodeId) -> Result<Vec<Nexus>, SvcError> {
-        let node = self.get_node_wrapper(node_id).await.context(NodeNotFound {
-            node_id: node_id.clone(),
-        })?;
+        let node = self.get_node_wrapper(node_id).await?;
         Ok(node.nexuses().await)
     }
 
@@ -30,9 +28,7 @@ impl Registry {
         node_id: &NodeId,
         nexus_id: &NexusId,
     ) -> Result<Nexus, SvcError> {
-        let node = self.get_node_wrapper(node_id).await.context(NodeNotFound {
-            node_id: node_id.clone(),
-        })?;
+        let node = self.get_node_wrapper(node_id).await?;
         let nexus = node.nexus(nexus_id).await.context(NexusNotFound {
             nexus_id: nexus_id.clone(),
         })?;

--- a/control-plane/agents/core/src/nexus/specs.rs
+++ b/control-plane/agents/core/src/nexus/specs.rs
@@ -1,14 +1,12 @@
 use parking_lot::Mutex;
 use std::sync::Arc;
 
-use snafu::OptionExt;
-
 use crate::core::{
     registry::Registry,
     specs::{ResourceSpecs, ResourceSpecsLocked, SpecOperations},
     wrapper::ClientOps,
 };
-use common::errors::{NodeNotFound, SvcError};
+use common::errors::SvcError;
 use common_lib::{
     mbus_api::ResourceKind,
     types::v0::{
@@ -159,12 +157,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &CreateNexus,
     ) -> Result<Nexus, SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         let nexus_spec = self.get_or_create_nexus(request);
         SpecOperations::start_create(&nexus_spec, registry, request).await?;
@@ -206,12 +199,7 @@ impl ResourceSpecsLocked {
         request: &DestroyNexus,
         delete_owned: bool,
     ) -> Result<(), SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(nexus) = self.get_nexus(&request.uuid) {
             SpecOperations::start_destroy(&nexus, registry, delete_owned).await?;
@@ -241,12 +229,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &ShareNexus,
     ) -> Result<String, SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(nexus_spec) = self.get_nexus(&request.uuid) {
             let status = registry.get_nexus(&request.uuid).await?;
@@ -270,12 +253,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &UnshareNexus,
     ) -> Result<(), SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(nexus_spec) = self.get_nexus(&request.uuid) {
             let status = registry.get_nexus(&request.uuid).await?;
@@ -299,12 +277,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &AddNexusChild,
     ) -> Result<Child, SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(nexus_spec) = self.get_nexus(&request.nexus) {
             let status = registry.get_nexus(&request.nexus).await?;
@@ -328,12 +301,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &AddNexusReplica,
     ) -> Result<Child, SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(nexus_spec) = self.get_nexus(&request.nexus) {
             let status = registry.get_nexus(&request.nexus).await?;
@@ -369,12 +337,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &RemoveNexusChild,
     ) -> Result<(), SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(nexus_spec) = self.get_nexus(&request.nexus) {
             let status = registry.get_nexus(&request.nexus).await?;
@@ -398,12 +361,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &RemoveNexusReplica,
     ) -> Result<(), SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(nexus_spec) = self.get_nexus(&request.nexus) {
             let status = registry.get_nexus(&request.nexus).await?;

--- a/control-plane/agents/core/src/nexus/tests.rs
+++ b/control-plane/agents/core/src/nexus/tests.rs
@@ -43,7 +43,7 @@ async fn nexus() {
     .await
     .unwrap();
 
-    let local = "malloc:///local?size_mb=12".into();
+    let local = "malloc:///local?size_mb=12&uuid=4a7b0566-8ec6-49e0-a8b2-1d9a292cf59b".into();
 
     let nexus = CreateNexus {
         node: mayastor.clone(),
@@ -125,7 +125,7 @@ async fn nexus_share_transaction() {
     let nodes = GetNodes {}.request().await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
-    let local = "malloc:///local?size_mb=12".into();
+    let local = "malloc:///local?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into();
     let nexus = CreateNexus {
         node: mayastor.clone(),
         uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
@@ -256,7 +256,7 @@ async fn nexus_share_transaction_store() {
         .unwrap();
     let mayastor = cluster.node(0);
 
-    let local = "malloc:///local?size_mb=12".into();
+    let local = "malloc:///local?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into();
     let nexus = CreateNexus {
         node: mayastor.clone(),
         uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
@@ -307,12 +307,12 @@ async fn nexus_child_transaction() {
     let nodes = GetNodes {}.request().await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
-    let child2 = "malloc:///ch2?size_mb=12";
+    let child2 = "malloc:///ch2?size_mb=12&uuid=4a7b0566-8ec6-49e0-a8b2-1d9a292cf59b";
     let nexus = CreateNexus {
         node: mayastor.clone(),
         uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
         size: 5242880,
-        children: vec!["malloc:///ch1?size_mb=12".into()],
+        children: vec!["malloc:///ch1?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into()],
         ..Default::default()
     }
     .request()
@@ -395,14 +395,14 @@ async fn nexus_child_transaction_store() {
         node: mayastor.clone(),
         uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
         size: 5242880,
-        children: vec!["malloc:///ch1?size_mb=12".into()],
+        children: vec!["malloc:///ch1?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into()],
         ..Default::default()
     }
     .request()
     .await
     .unwrap();
 
-    let child2 = "malloc:///ch2?size_mb=12";
+    let child2 = "malloc:///ch2?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0db";
     let add_child = AddNexusChild {
         node: mayastor.clone(),
         nexus: nexus.uuid.clone(),

--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -1,5 +1,5 @@
 use parking_lot::Mutex;
-use snafu::OptionExt;
+
 use std::sync::Arc;
 
 use crate::{
@@ -9,7 +9,7 @@ use crate::{
     },
     registry::Registry,
 };
-use common::errors::{NodeNotFound, SvcError};
+use common::errors::SvcError;
 use common_lib::{
     mbus_api::ResourceKind,
     types::v0::{
@@ -192,12 +192,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &CreatePool,
     ) -> Result<Pool, SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         let pool_spec = self.get_or_create_pool(request);
         SpecOperations::start_create(&pool_spec, registry, request).await?;
@@ -213,12 +208,7 @@ impl ResourceSpecsLocked {
     ) -> Result<(), SvcError> {
         // what if the node is never coming back?
         // do we need a way to forcefully "delete" things?
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         let pool_spec = self.get_pool(&request.id);
         if let Some(pool_spec) = &pool_spec {
@@ -236,12 +226,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &CreateReplica,
     ) -> Result<Replica, SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         let replica_spec = self.get_or_create_replica(request);
         SpecOperations::start_create(&replica_spec, registry, request).await?;
@@ -279,12 +264,7 @@ impl ResourceSpecsLocked {
         request: &DestroyReplica,
         delete_owned: bool,
     ) -> Result<(), SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         let replica = self.get_replica(&request.uuid);
         if let Some(replica) = &replica {
@@ -302,12 +282,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &ShareReplica,
     ) -> Result<String, SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(replica_spec) = self.get_replica(&request.uuid) {
             let status = registry.get_replica(&request.uuid).await?;
@@ -330,12 +305,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &UnshareReplica,
     ) -> Result<String, SvcError> {
-        let node = registry
-            .get_node_wrapper(&request.node)
-            .await
-            .context(NodeNotFound {
-                node_id: request.node.clone(),
-            })?;
+        let node = registry.get_node_wrapper(&request.node).await?;
 
         if let Some(replica_spec) = self.get_replica(&request.uuid) {
             let status = registry.get_replica(&request.uuid).await?;

--- a/control-plane/agents/core/src/volume/tests.rs
+++ b/control-plane/agents/core/src/volume/tests.rs
@@ -2,17 +2,24 @@
 
 use common_lib::{
     mbus_api,
-    mbus_api::{Message, ReplyError, ReplyErrorKind, ResourceKind},
-    types::v0::message_bus::{
-        ChildState, CreateVolume, DestroyVolume, GetNexuses, GetNodes, GetReplicas, GetVolumes,
-        PublishVolume, SetVolumeReplica, ShareVolume, UnpublishVolume, UnshareVolume, Volume,
-        VolumeShareProtocol, VolumeState,
+    mbus_api::{message_bus::v0::Replicas, Message, ReplyError, ReplyErrorKind, ResourceKind},
+    store::etcd::Etcd,
+    types::v0::{
+        message_bus::{
+            Child, ChildState, CreateVolume, DestroyVolume, ExplicitTopology, Filter, GetNexuses,
+            GetNodes, GetReplicas, GetVolumes, Nexus, NodeId, Protocol, PublishVolume,
+            SetVolumeReplica, ShareVolume, Topology, UnpublishVolume, UnshareVolume, Volume,
+            VolumeShareProtocol, VolumeState,
+        },
+        store::{
+            definitions::Store,
+            nexus_persistence::{NexusInfo, NexusInfoKey},
+        },
     },
 };
-use testlib::{
-    v0::{Filter, Protocol},
-    Cluster, ClusterBuilder,
-};
+use testlib::{Cluster, ClusterBuilder};
+
+use std::str::FromStr;
 
 #[actix_rt::test]
 async fn volume() {
@@ -33,6 +40,174 @@ async fn volume() {
 }
 
 async fn test_volume(cluster: &Cluster) {
+    smoke_test().await;
+    publishing_test(cluster).await;
+    replica_count_test().await;
+    nexus_persistence_test(cluster).await;
+}
+
+/// Either fault the local replica, the remote, or set the nexus as having an unclean shutdown
+#[derive(Debug)]
+enum FaultTest {
+    Local,
+    Remote,
+    Unclean,
+}
+
+async fn nexus_persistence_test(cluster: &Cluster) {
+    for (local, remote) in &vec![
+        (cluster.node(0), cluster.node(1)),
+        (cluster.node(1), cluster.node(0)),
+    ] {
+        for test in vec![FaultTest::Local, FaultTest::Remote, FaultTest::Unclean] {
+            nexus_persistence_test_iteration(local, remote, test).await;
+        }
+    }
+}
+async fn nexus_persistence_test_iteration(local: &NodeId, remote: &NodeId, fault: FaultTest) {
+    tracing::debug!("arguments ({:?}, {:?}, {:?})", local, remote, fault);
+
+    let volume = CreateVolume {
+        uuid: "6e3cf927-80c2-47a8-adf0-95c486bdd7b7".into(),
+        size: 5242880,
+        replicas: 2,
+        topology: Topology {
+            labelled: None,
+            explicit: Some(ExplicitTopology {
+                allowed_nodes: vec![local.clone(), remote.clone()],
+                preferred_nodes: vec![],
+            }),
+        },
+        ..Default::default()
+    }
+    .request()
+    .await
+    .unwrap();
+    tracing::info!("Volume: {:?}", volume);
+
+    let volume = PublishVolume {
+        uuid: volume.uuid.clone(),
+        // publish it on the remote first, to complicate things
+        target_node: Some(remote.clone()),
+        share: None,
+    }
+    .request()
+    .await
+    .unwrap();
+
+    let nexus = volume.children.first().unwrap().clone();
+    tracing::info!("Nexus: {:?}", nexus);
+    let nexus_uuid = nexus.uuid.clone();
+
+    UnpublishVolume {
+        uuid: volume.uuid.clone(),
+    }
+    .request()
+    .await
+    .unwrap();
+
+    let mut store = Etcd::new("0.0.0.0:2379")
+        .await
+        .expect("Failed to connect to etcd.");
+    let mut nexus_info: NexusInfo = store
+        .get_obj(&NexusInfoKey::from(&nexus_uuid))
+        .await
+        .unwrap();
+    nexus_info.uuid = nexus_uuid.clone();
+    tracing::info!("NexusInfo: {:?}", nexus_info);
+
+    let replicas = GetReplicas {
+        filter: Filter::Volume(volume.uuid.clone()),
+    }
+    .request()
+    .await
+    .unwrap();
+
+    let node_child = |node: &NodeId, nexus: &Nexus, replicas: Replicas| {
+        let replica = replicas.into_inner().into_iter().find(|r| &r.node == node);
+        nexus
+            .children
+            .iter()
+            .find(|c| Some(c.uri.as_str()) == replica.as_ref().map(|r| r.uri.as_str()))
+            .cloned()
+            .unwrap()
+    };
+
+    let mark_child_unhealthy = |c: &Child, ni: &mut NexusInfo| {
+        let uri = url::Url::from_str(c.uri.as_str()).unwrap();
+        let uuid = uri.query_pairs().find(|(q, _)| q == "uuid").unwrap().1;
+        let child_info = ni.children.iter_mut().find(|c| c.uuid == uuid);
+        child_info.unwrap().healthy = false;
+    };
+    match fault {
+        FaultTest::Local => {
+            let local_child = node_child(local, &nexus, replicas);
+            mark_child_unhealthy(&local_child, &mut nexus_info);
+        }
+        FaultTest::Remote => {
+            let remote_child = node_child(remote, &nexus, replicas);
+            mark_child_unhealthy(&remote_child, &mut nexus_info);
+        }
+        FaultTest::Unclean => {
+            nexus_info.clean_shutdown = false;
+        }
+    }
+    store.put_obj(&nexus_info).await.unwrap();
+    nexus_info = store
+        .get_obj(&NexusInfoKey::from(&nexus_uuid))
+        .await
+        .unwrap();
+    nexus_info.uuid = nexus_uuid.clone();
+    tracing::info!("NexusInfo: {:?}", nexus_info);
+
+    let volume = PublishVolume {
+        uuid: volume.uuid.clone(),
+        target_node: Some(local.clone()),
+        share: None,
+    }
+    .request()
+    .await
+    .unwrap();
+    tracing::info!("Volume: {:?}", volume);
+    let nexus = volume.children.first().unwrap().clone();
+    tracing::info!("Nexus: {:?}", nexus);
+    assert_eq!(nexus.children.len(), 1);
+
+    let replicas = GetReplicas {
+        filter: Filter::Volume(volume.uuid.clone()),
+    }
+    .request()
+    .await
+    .unwrap();
+
+    let child = nexus.children.first().unwrap();
+    match fault {
+        FaultTest::Local => {
+            let remote_child = node_child(remote, &nexus, replicas);
+            assert_eq!(child.uri, remote_child.uri);
+        }
+        FaultTest::Remote => {
+            let local_child = node_child(local, &nexus, replicas);
+            assert_eq!(child.uri, local_child.uri);
+        }
+        FaultTest::Unclean => {
+            // if the shutdown is not clean, then we prefer the local replica
+            let local_child = node_child(local, &nexus, replicas);
+            assert_eq!(child.uri, local_child.uri);
+        }
+    }
+
+    DestroyVolume { uuid: volume.uuid }
+        .request()
+        .await
+        .expect("Should be able to destroy the volume");
+
+    assert!(GetVolumes::default().request().await.unwrap().0.is_empty());
+    assert!(GetNexuses::default().request().await.unwrap().0.is_empty());
+    assert!(GetReplicas::default().request().await.unwrap().0.is_empty());
+}
+
+async fn publishing_test(cluster: &Cluster) {
     let volume = CreateVolume {
         uuid: "359b7e1a-b724-443b-98b4-e6d97fabbb40".into(),
         size: 5242880,
@@ -43,25 +218,8 @@ async fn test_volume(cluster: &Cluster) {
     let volume = volume.request().await.unwrap();
     let volumes = GetVolumes::default().request().await.unwrap().0;
     tracing::info!("Volumes: {:?}", volumes);
-
     assert_eq!(Some(&volume), volumes.first());
 
-    publishing_test(cluster, &volume).await;
-    replica_count_test(cluster, &volume).await;
-
-    DestroyVolume {
-        uuid: "359b7e1a-b724-443b-98b4-e6d97fabbb40".into(),
-    }
-    .request()
-    .await
-    .expect("Should be able to destroy the volume");
-
-    assert!(GetVolumes::default().request().await.unwrap().0.is_empty());
-    assert!(GetNexuses::default().request().await.unwrap().0.is_empty());
-    assert!(GetReplicas::default().request().await.unwrap().0.is_empty());
-}
-
-async fn publishing_test(cluster: &Cluster, volume: &Volume) {
     let volume = PublishVolume {
         uuid: volume.uuid.clone(),
         target_node: None,
@@ -186,6 +344,15 @@ async fn publishing_test(cluster: &Cluster, volume: &Volume) {
         volumes.0.first().unwrap().target_node(),
         Some(Some(cluster.node(1)))
     );
+
+    DestroyVolume { uuid: volume.uuid }
+        .request()
+        .await
+        .expect("Should be able to destroy the volume");
+
+    assert!(GetVolumes::default().request().await.unwrap().0.is_empty());
+    assert!(GetNexuses::default().request().await.unwrap().0.is_empty());
+    assert!(GetReplicas::default().request().await.unwrap().0.is_empty());
 }
 
 async fn get_volume(volume: &Volume) -> Volume {
@@ -213,7 +380,27 @@ async fn wait_for_volume_online(volume: &Volume) -> Result<Volume, ()> {
     }
 }
 
-async fn replica_count_test(_cluster: &Cluster, volume: &Volume) {
+async fn replica_count_test() {
+    let volume = CreateVolume {
+        uuid: "359b7e1a-b724-443b-98b4-e6d97fabbb40".into(),
+        size: 5242880,
+        replicas: 2,
+        ..Default::default()
+    };
+
+    let volume = volume.request().await.unwrap();
+    let volumes = GetVolumes::default().request().await.unwrap().0;
+    tracing::info!("Volumes: {:?}", volumes);
+    assert_eq!(Some(&volume), volumes.first());
+
+    let volume = PublishVolume {
+        uuid: volume.uuid.clone(),
+        ..Default::default()
+    }
+    .request()
+    .await
+    .unwrap();
+
     let volume = SetVolumeReplica {
         uuid: volume.uuid.clone(),
         replicas: 3,
@@ -332,4 +519,37 @@ async fn replica_count_test(_cluster: &Cluster, volume: &Volume) {
     .await
     .expect("Should be able to bring the replica count back to 3");
     tracing::info!("Volume: {:?}", volume);
+
+    DestroyVolume { uuid: volume.uuid }
+        .request()
+        .await
+        .expect("Should be able to destroy the volume");
+
+    assert!(GetVolumes::default().request().await.unwrap().0.is_empty());
+    assert!(GetNexuses::default().request().await.unwrap().0.is_empty());
+    assert!(GetReplicas::default().request().await.unwrap().0.is_empty());
+}
+
+async fn smoke_test() {
+    let volume = CreateVolume {
+        uuid: "359b7e1a-b724-443b-98b4-e6d97fabbb40".into(),
+        size: 5242880,
+        replicas: 2,
+        ..Default::default()
+    };
+
+    let volume = volume.request().await.unwrap();
+    let volumes = GetVolumes::default().request().await.unwrap().0;
+    tracing::info!("Volumes: {:?}", volumes);
+
+    assert_eq!(Some(&volume), volumes.first());
+
+    DestroyVolume { uuid: volume.uuid }
+        .request()
+        .await
+        .expect("Should be able to destroy the volume");
+
+    assert!(GetVolumes::default().request().await.unwrap().0.is_empty());
+    assert!(GetNexuses::default().request().await.unwrap().0.is_empty());
+    assert!(GetReplicas::default().request().await.unwrap().0.is_empty());
 }


### PR DESCRIPTION
When mayastor nexus faults a child it updates its persistent nexus information on etcd to
mark the child as not healthy.
Also when the nexus is not shutdown cleanly, then the clean flag remains unset on etcd.

The control plane now inspects this information on etcd before attempting to create a nexus.
It selects a list of replicas for nexus creation and filters them down according to the
information it retrieved from etcd.

Added tests for various cases where replicas are faulted. These faults are mocked.

Change node_wrapper getter to return an error if the node cannot be found.

Fix tests to use uuid as a query parameter when creating a nexus.