### PR TITLE
feat: initial reconciliation scaffolding

### DIFF
--- a/common/src/types/v0/message_bus/pool.rs
+++ b/common/src/types/v0/message_bus/pool.rs
@@ -12,9 +12,9 @@ pub struct GetPools {
     pub filter: Filter,
 }
 
-/// State of the Pool
+/// Status of the Pool
 #[derive(Serialize, Deserialize, Debug, Clone, EnumString, ToString, Eq, PartialEq)]
-pub enum PoolState {
+pub enum PoolStatus {
     /// unknown state
     Unknown = 0,
     /// the pool is in normal working order
@@ -25,12 +25,12 @@ pub enum PoolState {
     Faulted = 3,
 }
 
-impl Default for PoolState {
+impl Default for PoolStatus {
     fn default() -> Self {
         Self::Unknown
     }
 }
-impl From<i32> for PoolState {
+impl From<i32> for PoolStatus {
     fn from(src: i32) -> Self {
         match src {
             1 => Self::Online,
@@ -40,17 +40,17 @@ impl From<i32> for PoolState {
         }
     }
 }
-impl From<PoolState> for models::PoolState {
-    fn from(src: PoolState) -> Self {
+impl From<PoolStatus> for models::PoolState {
+    fn from(src: PoolStatus) -> Self {
         match src {
-            PoolState::Unknown => Self::Unknown,
-            PoolState::Online => Self::Online,
-            PoolState::Degraded => Self::Degraded,
-            PoolState::Faulted => Self::Faulted,
+            PoolStatus::Unknown => Self::Unknown,
+            PoolStatus::Online => Self::Online,
+            PoolStatus::Degraded => Self::Degraded,
+            PoolStatus::Faulted => Self::Faulted,
         }
     }
 }
-impl From<models::PoolState> for PoolState {
+impl From<models::PoolState> for PoolStatus {
     fn from(src: models::PoolState) -> Self {
         match src {
             models::PoolState::Unknown => Self::Unknown,
@@ -72,7 +72,7 @@ pub struct Pool {
     /// absolute disk paths claimed by the pool
     pub disks: Vec<PoolDeviceUri>,
     /// current state of the pool
-    pub state: PoolState,
+    pub state: PoolStatus,
     /// size of the pool in bytes
     pub capacity: u64,
     /// used bytes from the pool
@@ -107,32 +107,32 @@ impl From<models::Pool> for Pool {
 bus_impl_string_id!(PoolId, "ID of a mayastor pool");
 
 // online > degraded > unknown/faulted
-impl PartialOrd for PoolState {
+impl PartialOrd for PoolStatus {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self {
-            PoolState::Unknown => match other {
-                PoolState::Unknown => None,
-                PoolState::Online => Some(Ordering::Less),
-                PoolState::Degraded => Some(Ordering::Less),
-                PoolState::Faulted => None,
+            PoolStatus::Unknown => match other {
+                PoolStatus::Unknown => None,
+                PoolStatus::Online => Some(Ordering::Less),
+                PoolStatus::Degraded => Some(Ordering::Less),
+                PoolStatus::Faulted => None,
             },
-            PoolState::Online => match other {
-                PoolState::Unknown => Some(Ordering::Greater),
-                PoolState::Online => Some(Ordering::Equal),
-                PoolState::Degraded => Some(Ordering::Greater),
-                PoolState::Faulted => Some(Ordering::Greater),
+            PoolStatus::Online => match other {
+                PoolStatus::Unknown => Some(Ordering::Greater),
+                PoolStatus::Online => Some(Ordering::Equal),
+                PoolStatus::Degraded => Some(Ordering::Greater),
+                PoolStatus::Faulted => Some(Ordering::Greater),
             },
-            PoolState::Degraded => match other {
-                PoolState::Unknown => Some(Ordering::Greater),
-                PoolState::Online => Some(Ordering::Less),
-                PoolState::Degraded => Some(Ordering::Equal),
-                PoolState::Faulted => Some(Ordering::Greater),
+            PoolStatus::Degraded => match other {
+                PoolStatus::Unknown => Some(Ordering::Greater),
+                PoolStatus::Online => Some(Ordering::Less),
+                PoolStatus::Degraded => Some(Ordering::Equal),
+                PoolStatus::Faulted => Some(Ordering::Greater),
             },
-            PoolState::Faulted => match other {
-                PoolState::Unknown => None,
-                PoolState::Online => Some(Ordering::Less),
-                PoolState::Degraded => Some(Ordering::Less),
-                PoolState::Faulted => Some(Ordering::Equal),
+            PoolStatus::Faulted => match other {
+                PoolStatus::Unknown => None,
+                PoolStatus::Online => Some(Ordering::Less),
+                PoolStatus::Degraded => Some(Ordering::Less),
+                PoolStatus::Faulted => Some(Ordering::Equal),
             },
         }
     }

--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -31,13 +31,13 @@ pub struct Replica {
     pub share: Protocol,
     /// uri usable by nexus to access it
     pub uri: String,
-    /// state of the replica
-    pub state: ReplicaState,
+    /// status of the replica
+    pub status: ReplicaStatus,
 }
 impl Replica {
     /// check if the replica is online
     pub fn online(&self) -> bool {
-        self.state.online()
+        self.status.online()
     }
 }
 
@@ -48,7 +48,7 @@ impl From<Replica> for models::Replica {
             src.pool,
             src.share,
             src.size,
-            src.state,
+            src.status,
             src.thin,
             src.uri,
             apis::Uuid::try_from(src.uuid).unwrap(),
@@ -65,7 +65,7 @@ impl From<models::Replica> for Replica {
             size: src.size,
             share: src.share.into(),
             uri: src.uri,
-            state: src.state.into(),
+            status: src.state.into(),
         }
     }
 }
@@ -298,7 +298,7 @@ impl From<models::ReplicaShareProtocol> for ReplicaShareProtocol {
 #[derive(Serialize, Deserialize, Debug, Clone, EnumString, ToString, Eq, PartialEq)]
 #[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
-pub enum ReplicaState {
+pub enum ReplicaStatus {
     /// unknown state
     Unknown = 0,
     /// the replica is in normal working order
@@ -308,19 +308,19 @@ pub enum ReplicaState {
     /// the replica is completely inaccessible
     Faulted = 3,
 }
-impl ReplicaState {
+impl ReplicaStatus {
     /// check if the state is online
     pub fn online(&self) -> bool {
         self == &Self::Online
     }
 }
 
-impl Default for ReplicaState {
+impl Default for ReplicaStatus {
     fn default() -> Self {
         Self::Unknown
     }
 }
-impl From<i32> for ReplicaState {
+impl From<i32> for ReplicaStatus {
     fn from(src: i32) -> Self {
         match src {
             1 => Self::Online,
@@ -330,17 +330,17 @@ impl From<i32> for ReplicaState {
         }
     }
 }
-impl From<ReplicaState> for models::ReplicaState {
-    fn from(src: ReplicaState) -> Self {
+impl From<ReplicaStatus> for models::ReplicaState {
+    fn from(src: ReplicaStatus) -> Self {
         match src {
-            ReplicaState::Unknown => Self::Unknown,
-            ReplicaState::Online => Self::Online,
-            ReplicaState::Degraded => Self::Degraded,
-            ReplicaState::Faulted => Self::Faulted,
+            ReplicaStatus::Unknown => Self::Unknown,
+            ReplicaStatus::Online => Self::Online,
+            ReplicaStatus::Degraded => Self::Degraded,
+            ReplicaStatus::Faulted => Self::Faulted,
         }
     }
 }
-impl From<models::ReplicaState> for ReplicaState {
+impl From<models::ReplicaState> for ReplicaStatus {
     fn from(src: models::ReplicaState) -> Self {
         match src {
             models::ReplicaState::Unknown => Self::Unknown,

--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -15,32 +15,32 @@ use strum_macros::ToString;
 
 /// Enum defining the various states that a resource spec can be in.
 #[derive(Serialize, Deserialize, Debug, Clone, ToString, PartialEq)]
-pub enum SpecState<T> {
+pub enum SpecStatus<T> {
     Creating,
     Created(T),
     Deleting,
     Deleted,
 }
 
-impl<T> Default for SpecState<T> {
+impl<T> Default for SpecStatus<T> {
     fn default() -> Self {
         Self::Creating
     }
 }
 
 // todo: change openapi spec to support enum variants
-impl<T> From<SpecState<T>> for models::SpecState {
-    fn from(src: SpecState<T>) -> Self {
+impl<T> From<SpecStatus<T>> for models::SpecState {
+    fn from(src: SpecStatus<T>) -> Self {
         match src {
-            SpecState::Creating => Self::Creating,
-            SpecState::Created(_) => Self::Created,
-            SpecState::Deleting => Self::Deleting,
-            SpecState::Deleted => Self::Deleted,
+            SpecStatus::Creating => Self::Creating,
+            SpecStatus::Created(_) => Self::Created,
+            SpecStatus::Deleting => Self::Deleting,
+            SpecStatus::Deleted => Self::Deleted,
         }
     }
 }
 
-impl<T: std::cmp::PartialEq> SpecState<T> {
+impl<T: std::cmp::PartialEq> SpecStatus<T> {
     pub fn creating(&self) -> bool {
         self == &Self::Creating
     }

--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -9,7 +9,7 @@ use crate::types::v0::{
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
         nexus_child::NexusChild,
-        SpecState, SpecTransaction, UuidString,
+        SpecStatus, SpecTransaction, UuidString,
     },
 };
 
@@ -71,8 +71,8 @@ impl StorableObject for NexusState {
     }
 }
 
-/// State of the Nexus Spec
-pub type NexusSpecStatus = SpecState<message_bus::NexusStatus>;
+/// Status of the Nexus Spec
+pub type NexusSpecStatus = SpecStatus<message_bus::NexusStatus>;
 
 /// User specification of a nexus.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
@@ -164,10 +164,10 @@ impl SpecTransaction<NexusOperation> for NexusSpec {
         if let Some(op) = self.operation.clone() {
             match op.operation {
                 NexusOperation::Destroy => {
-                    self.spec_status = SpecState::Deleted;
+                    self.spec_status = SpecStatus::Deleted;
                 }
                 NexusOperation::Create => {
-                    self.spec_status = SpecState::Created(message_bus::NexusStatus::Online);
+                    self.spec_status = SpecStatus::Created(message_bus::NexusStatus::Online);
                 }
                 NexusOperation::Share(share) => {
                     self.share = share.into();

--- a/control-plane/agents/common/src/v0/msg_translation.rs
+++ b/control-plane/agents/common/src/v0/msg_translation.rs
@@ -1,7 +1,7 @@
 //! Converts rpc messages to message bus messages and vice versa.
 
 use common_lib::types::v0::{
-    message_bus::{self, ChildState, NexusStatus, Protocol, ReplicaState},
+    message_bus::{self, ChildState, NexusStatus, Protocol, ReplicaStatus},
     openapi::apis::IntoVec,
 };
 use rpc::mayastor as rpc;
@@ -103,7 +103,7 @@ impl RpcToMessageBus for rpc::Replica {
             size: self.size,
             share: self.share.into(),
             uri: self.uri.clone(),
-            state: ReplicaState::Online,
+            status: ReplicaStatus::Online,
         }
     }
 }

--- a/control-plane/agents/core/src/core/mod.rs
+++ b/control-plane/agents/core/src/core/mod.rs
@@ -2,6 +2,8 @@
 
 /// gRPC helpers
 pub mod grpc;
+/// reconciliation logic
+pub mod reconciler;
 /// registry with node and all its resources
 pub mod registry;
 /// generic resources
@@ -12,6 +14,8 @@ pub(crate) mod scheduling;
 pub mod specs;
 /// registry with all the resource states
 pub mod states;
+/// generic task pollers (eg used by the reconcilers)
+mod task_poller;
 /// helper wrappers over the resources
 pub mod wrapper;
 

--- a/control-plane/agents/core/src/core/reconciler/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/mod.rs
@@ -1,3 +1,4 @@
+mod persistent_store;
 pub mod poller;
 mod volume;
 

--- a/control-plane/agents/core/src/core/reconciler/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/mod.rs
@@ -1,0 +1,44 @@
+pub mod poller;
+mod volume;
+
+use crate::core::task_poller::{PollContext, PollEvent, TaskPoller};
+use poller::ReconcilerWorker;
+
+use crate::core::registry::Registry;
+use parking_lot::Mutex;
+
+/// Used to start and stop the reconcile pollers
+#[derive(Debug)]
+pub(crate) struct ReconcilerControl {
+    worker: Mutex<Option<ReconcilerWorker>>,
+    event_channel: tokio::sync::mpsc::Sender<PollEvent>,
+    shutdown_channel: tokio::sync::mpsc::Sender<()>,
+}
+
+impl ReconcilerControl {
+    /// Return a new `Self`
+    pub(crate) fn new() -> Self {
+        let mut worker = ReconcilerWorker::new();
+        Self {
+            event_channel: worker.take_event_channel(),
+            shutdown_channel: worker.take_shutdown_channel(),
+            worker: Mutex::new(Some(worker)),
+        }
+    }
+
+    /// Starts the polling of the registered reconciliation loops
+    pub(crate) async fn start(&self, registry: Registry) {
+        let worker = self.worker.lock().take().expect("Can only start once");
+        tokio::spawn(async move {
+            tracing::info!("Starting the reconciler control loop");
+            worker.poller(registry).await;
+        });
+    }
+
+    /// Send the shutdown signal to the poller's main loop
+    /// (does not wait for the pollers to stop)
+    #[allow(dead_code)]
+    pub(crate) async fn shutdown(&self) {
+        self.shutdown_channel.send(()).await.ok();
+    }
+}

--- a/control-plane/agents/core/src/core/reconciler/persistent_store.rs
+++ b/control-plane/agents/core/src/core/reconciler/persistent_store.rs
@@ -1,0 +1,30 @@
+use crate::core::task_poller::{PollContext, PollResult, PollerState, TaskPoller};
+
+/// Reconcile dirty specs in the persistent store.
+/// This happens when we fail to update the persistent store and we have a "live" spec that
+/// differs to what's written in the persistent store.
+/// This reconciler basically attempts to write the dirty specs to the persistent store.
+#[derive(Debug)]
+pub(super) struct PersistentStoreReconciler {}
+impl PersistentStoreReconciler {
+    /// Return new `Self`
+    pub(super) fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for PersistentStoreReconciler {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let specs = &context.registry().specs;
+        let dirty_replicas = specs.reconcile_dirty_replicas(context.registry()).await;
+        let dirty_nexuses = specs.reconcile_dirty_nexuses(context.registry()).await;
+        let dirty_volumes = specs.reconcile_dirty_volumes(context.registry()).await;
+
+        if dirty_nexuses || dirty_replicas || dirty_volumes {
+            PollResult::Ok(PollerState::Busy)
+        } else {
+            PollResult::Ok(PollerState::Idle)
+        }
+    }
+}

--- a/control-plane/agents/core/src/core/reconciler/poller.rs
+++ b/control-plane/agents/core/src/core/reconciler/poller.rs
@@ -1,0 +1,98 @@
+use crate::core::{
+    reconciler::volume,
+    registry::Registry,
+    task_poller::{squash_results, PollContext, PollEvent, PollResult, PollerState, TaskPoller},
+};
+
+/// Reconciliation worker that polls all reconciliation loops
+/// The loops are polled one at a time to avoid any potential contention
+/// and also hopefully making the logging clearer
+pub(super) struct ReconcilerWorker {
+    poll_targets: Vec<Box<dyn TaskPoller>>,
+    event_channel: tokio::sync::mpsc::Receiver<PollEvent>,
+    shutdown_channel: tokio::sync::mpsc::Receiver<()>,
+    event_channel_sender: Option<tokio::sync::mpsc::Sender<PollEvent>>,
+    shutdown_channel_sender: Option<tokio::sync::mpsc::Sender<()>>,
+}
+
+impl std::fmt::Debug for ReconcilerWorker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Reconciler").finish()
+    }
+}
+impl ReconcilerWorker {
+    /// Create a new `Self` with the provided communication channels
+    pub(super) fn new() -> Self {
+        let poll_targets: Vec<Box<dyn TaskPoller>> =
+            vec![Box::new(volume::VolumeReconciler::new())];
+
+        let event_channel = tokio::sync::mpsc::channel(poll_targets.len());
+        let shutdown_channel = tokio::sync::mpsc::channel(1);
+        Self {
+            poll_targets,
+            event_channel: event_channel.1,
+            shutdown_channel: shutdown_channel.1,
+            event_channel_sender: Some(event_channel.0),
+            shutdown_channel_sender: Some(shutdown_channel.0),
+        }
+    }
+    /// Take the shutdown channel sender (can only be called once)
+    pub(super) fn take_shutdown_channel(&mut self) -> tokio::sync::mpsc::Sender<()> {
+        self.shutdown_channel_sender
+            .take()
+            .expect("initialised shutdown sender")
+    }
+    /// Take the event channel sender (can only be called once)
+    pub(super) fn take_event_channel(&mut self) -> tokio::sync::mpsc::Sender<PollEvent> {
+        self.event_channel_sender
+            .take()
+            .expect("initialised event sender")
+    }
+}
+
+impl ReconcilerWorker {
+    /// Start polling the registered reconciliation loops
+    /// The polling will continue until we receive the shutdown signal
+    #[tracing::instrument(skip(registry))]
+    pub(super) async fn poller(mut self, registry: Registry) {
+        // kick-off the first run
+        let mut event = PollEvent::TimedRun;
+        loop {
+            let result = match &event {
+                PollEvent::Shutdown => {
+                    tracing::warn!("Shutting down... (reconcilers will NOT be polled again)");
+                    return;
+                }
+                PollEvent::TimedRun | PollEvent::Triggered(_) => {
+                    self.poller_work(PollContext::from(&event, &registry)).await
+                }
+            };
+
+            event = tokio::select! {
+                _shutdown = self.shutdown_channel.recv() => {
+                    PollEvent::Shutdown
+                },
+                event = self.event_channel.recv() => {
+                    event.unwrap_or(PollEvent::Shutdown)
+                },
+                _timed = tokio::time::sleep(if result.unwrap_or(PollerState::Busy) == PollerState::Busy {
+                    registry.reconcile_period
+                } else {
+                    registry.reconcile_idle_period
+                }) => {
+                    PollEvent::TimedRun
+                }
+            };
+        }
+    }
+
+    async fn poller_work(&mut self, context: PollContext) -> PollResult {
+        tracing::trace!("Entering the reconcile loop...");
+        let mut results = vec![];
+        for target in &mut self.poll_targets {
+            results.push(target.try_poll(&context).await);
+        }
+        tracing::trace!("Leaving the reconcile loop...");
+        squash_results(results)
+    }
+}

--- a/control-plane/agents/core/src/core/reconciler/poller.rs
+++ b/control-plane/agents/core/src/core/reconciler/poller.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    reconciler::volume,
+    reconciler::{persistent_store::PersistentStoreReconciler, volume},
     registry::Registry,
     task_poller::{squash_results, PollContext, PollEvent, PollResult, PollerState, TaskPoller},
 };
@@ -23,8 +23,10 @@ impl std::fmt::Debug for ReconcilerWorker {
 impl ReconcilerWorker {
     /// Create a new `Self` with the provided communication channels
     pub(super) fn new() -> Self {
-        let poll_targets: Vec<Box<dyn TaskPoller>> =
-            vec![Box::new(volume::VolumeReconciler::new())];
+        let poll_targets: Vec<Box<dyn TaskPoller>> = vec![
+            Box::new(volume::VolumeReconciler::new()),
+            Box::new(PersistentStoreReconciler::new()),
+        ];
 
         let event_channel = tokio::sync::mpsc::channel(poll_targets.len());
         let shutdown_channel = tokio::sync::mpsc::channel(1);

--- a/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
@@ -1,0 +1,58 @@
+use crate::core::{
+    reconciler::{PollContext, TaskPoller},
+    specs::SpecOperations,
+    task_poller::{PollEvent, PollResult, PollTimer, PollerState},
+};
+
+use common_lib::types::v0::store::volume::VolumeSpec;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Volume Garbage Collector reconciler
+#[derive(Debug)]
+pub(super) struct GarbageCollector {
+    counter: PollTimer,
+}
+impl GarbageCollector {
+    /// Return a new `Self`
+    pub(super) fn new() -> Self {
+        Self {
+            counter: PollTimer::from(5),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for GarbageCollector {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let volumes = context.registry().specs.get_locked_volumes();
+        for volume in volumes {
+            let _ = garbage_collector_reconcile(volume, context).await;
+        }
+        PollResult::Ok(PollerState::Idle)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        self.counter.poll()
+    }
+
+    async fn poll_event(&mut self, context: &PollContext) -> bool {
+        match context.event() {
+            PollEvent::TimedRun => true,
+            PollEvent::Shutdown | PollEvent::Triggered(_) => false,
+        }
+    }
+}
+
+async fn garbage_collector_reconcile(
+    volume: Arc<Mutex<VolumeSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let uuid = volume.lock().uuid.clone();
+    let state = context.registry().get_volume_state(&uuid).await?;
+    if volume.lock().state_synced(&state) {
+        // todo: find all resources related to this volume Id and clean them up, if unused
+        tracing::trace!("Collecting garbage for volume '{}'", uuid);
+    }
+    PollResult::Ok(PollerState::Idle)
+}

--- a/control-plane/agents/core/src/core/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/hot_spare.rs
@@ -1,0 +1,42 @@
+use crate::core::{
+    reconciler::{PollContext, TaskPoller},
+    specs::SpecOperations,
+    task_poller::{PollResult, PollerState},
+};
+
+use common_lib::types::v0::store::volume::VolumeSpec;
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Volume HotSpare reconciler
+#[derive(Debug)]
+pub(super) struct HotSpareReconciler {}
+impl HotSpareReconciler {
+    /// Return a new `Self`
+    pub(super) fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for HotSpareReconciler {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let mut results = vec![];
+        let volumes = context.registry().specs.get_locked_volumes();
+        for volume in volumes {
+            results.push(hot_spare_reconcile(volume, context).await);
+        }
+        Self::squash_results(results)
+    }
+}
+
+async fn hot_spare_reconcile(volume: Arc<Mutex<VolumeSpec>>, context: &PollContext) -> PollResult {
+    let uuid = volume.lock().uuid.clone();
+    let state = context.registry().get_volume_state(&uuid).await?;
+    if !volume.lock().state_synced(&state) {
+        // todo: reconcile the volume object
+        tracing::warn!("Volume '{}' needs to be reconciled", uuid);
+    }
+
+    PollResult::Ok(PollerState::Idle)
+}

--- a/control-plane/agents/core/src/core/reconciler/volume/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/mod.rs
@@ -1,0 +1,48 @@
+mod garbage_collector;
+mod hot_spare;
+
+use crate::core::task_poller::{PollContext, PollPeriods, PollResult, PollTimer, TaskPoller};
+
+use crate::core::reconciler::volume::{
+    garbage_collector::GarbageCollector, hot_spare::HotSpareReconciler,
+};
+
+/// Volume Reconciler loop which:
+/// 1. does the replica replacement
+/// 2. volume garbage collection
+#[derive(Debug)]
+pub struct VolumeReconciler {
+    counter: PollTimer,
+    poll_targets: Vec<Box<dyn TaskPoller>>,
+}
+impl VolumeReconciler {
+    /// Return new `Self` with the provided period
+    pub fn from(period: PollPeriods) -> Self {
+        VolumeReconciler {
+            counter: PollTimer::from(period),
+            poll_targets: vec![
+                Box::new(HotSpareReconciler::new()),
+                Box::new(GarbageCollector::new()),
+            ],
+        }
+    }
+    /// Return new `Self` with the default period
+    pub fn new() -> Self {
+        Self::from(1)
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for VolumeReconciler {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let mut results = vec![];
+        for target in &mut self.poll_targets {
+            results.push(target.try_poll(context).await);
+        }
+        Self::squash_results(results)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        self.counter.poll()
+    }
+}

--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -164,8 +164,7 @@ impl Registry {
             registry.poller().await;
         });
         let registry = self.clone();
-        self.specs.start(registry.clone());
-        self.reconciler.start(registry.clone()).await;
+        self.reconciler.start(registry).await;
     }
 
     /// Initialise the registry with the content of the persistent store.

--- a/control-plane/agents/core/src/core/scheduling/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/mod.rs
@@ -7,7 +7,7 @@ use crate::core::scheduling::{
     resources::{ChildItem, PoolItem, ReplicaItem},
     volume::GetSuitablePoolsContext,
 };
-use common_lib::types::v0::message_bus::PoolState;
+use common_lib::types::v0::message_bus::PoolStatus;
 use std::{cmp::Ordering, collections::HashMap, future::Future};
 
 #[async_trait::async_trait(?Send)]
@@ -68,7 +68,7 @@ impl PoolFilters {
     }
     /// Should only attempt to use usable (not faulted) pools
     pub(crate) fn usable(_: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
-        item.pool.state != PoolState::Faulted && item.pool.state != PoolState::Unknown
+        item.pool.state != PoolStatus::Faulted && item.pool.state != PoolStatus::Unknown
     }
 }
 

--- a/control-plane/agents/core/src/core/specs.rs
+++ b/control-plane/agents/core/src/core/specs.rs
@@ -20,7 +20,7 @@ use common_lib::types::v0::{
 use crate::core::resource_map::ResourceMap;
 use async_trait::async_trait;
 use common::errors::SvcError;
-use common_lib::{mbus_api::ResourceKind, types::v0::store::SpecState};
+use common_lib::{mbus_api::ResourceKind, types::v0::store::SpecStatus};
 use serde::de::DeserializeOwned;
 use snafu::{ResultExt, Snafu};
 use std::fmt::Debug;
@@ -47,8 +47,8 @@ enum SpecError {
 pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
     type Create: Debug + PartialEq + Sync + Send;
     type Owners: Default + Sync + Send;
-    type State: PartialEq;
-    type Status: PartialEq + Sync + Send;
+    type Status: PartialEq;
+    type State: PartialEq + Sync + Send;
     type UpdateOp: Sync + Send;
 
     /// Start a create operation and attempt to log the transaction to the store.
@@ -57,7 +57,7 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
         locked_spec: &Arc<Mutex<Self>>,
         registry: &Registry,
         request: &Self::Create,
-    ) -> Result<(), SvcError>
+    ) -> Result<Self, SvcError>
     where
         Self: PartialEq<Self::Create>,
         Self: SpecTransaction<O>,
@@ -68,7 +68,8 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
             spec.start_create_inner(request)?;
             spec.clone()
         };
-        Self::store_operation_log(registry, locked_spec, &spec_clone).await
+        Self::store_operation_log(registry, locked_spec, &spec_clone).await?;
+        Ok(spec_clone)
     }
 
     /// When a create request is issued we need to validate by verifying that:
@@ -80,7 +81,7 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
     {
         // we're busy with another request, try again later
         let _ = self.busy()?;
-        if self.state().creating() {
+        if self.status().creating() {
             if self != request {
                 Err(SvcError::ReCreateMismatch {
                     id: self.uuid(),
@@ -92,7 +93,7 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
                 self.start_create_op();
                 Ok(())
             }
-        } else if self.state().created() {
+        } else if self.status().created() {
             Err(SvcError::AlreadyExists {
                 kind: self.kind(),
                 id: self.uuid(),
@@ -185,7 +186,7 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
         {
             let mut spec = locked_spec.lock();
             let _ = spec.busy()?;
-            if spec.state().deleted() {
+            if spec.status().deleted() {
                 return Ok(());
             } else if !ignore_owners {
                 spec.disown(owners);
@@ -217,7 +218,7 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
             let mut spec = locked_spec.lock();
 
             // once we've started, there's no going back...
-            spec.set_state(SpecState::Deleting);
+            spec.set_status(SpecStatus::Deleting);
 
             spec.start_destroy_op();
             spec.clone()
@@ -282,17 +283,17 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
     async fn start_update(
         registry: &Registry,
         locked_spec: &Arc<Mutex<Self>>,
-        status: &Self::Status,
+        state: &Self::State,
         update_operation: Self::UpdateOp,
     ) -> Result<Self, SvcError>
     where
-        Self: PartialEq<Self::Status>,
+        Self: PartialEq<Self::State>,
         Self: SpecTransaction<Self::UpdateOp>,
         Self: StorableObject,
     {
         let spec_clone = {
             let mut spec = locked_spec.lock();
-            spec.start_update_inner(status, update_operation, false)?
+            spec.start_update_inner(state, update_operation, false)?
         };
 
         Self::store_operation_log(registry, locked_spec, &spec_clone).await?;
@@ -302,38 +303,38 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
     /// Checks that the object ready to accept a new update operation
     fn start_update_inner(
         &mut self,
-        status: &Self::Status,
+        state: &Self::State,
         operation: Self::UpdateOp,
         reconciling: bool,
     ) -> Result<Self, SvcError>
     where
-        Self: PartialEq<Self::Status>,
+        Self: PartialEq<Self::State>,
     {
         // we're busy right now, try again later
         let _ = self.busy()?;
 
-        match self.state() {
-            SpecState::Creating => Err(SvcError::PendingCreation {
+        match self.status() {
+            SpecStatus::Creating => Err(SvcError::PendingCreation {
                 id: self.uuid(),
                 kind: self.kind(),
             }),
-            SpecState::Deleted | SpecState::Deleting => Err(SvcError::PendingDeletion {
+            SpecStatus::Deleted | SpecStatus::Deleting => Err(SvcError::PendingDeletion {
                 id: self.uuid(),
                 kind: self.kind(),
             }),
-            SpecState::Created(_) => {
+            SpecStatus::Created(_) => {
                 // if it's not part of a reconcile effort then the status should match up with
                 // what the spec defines, otherwise it's probably not a good idea to allow this
                 // "frontend" operation to go through
                 // todo: should we also compare the "state"? (online vs degraded)?
-                if !reconciling && !self.status_synced(status) {
+                if !reconciling && !self.state_synced(state) {
                     Err(SvcError::NotReady {
                         id: self.uuid(),
                         kind: self.kind(),
                     })
                 } else {
                     // start the requested operation (which also checks if it's a valid transition)
-                    self.start_update_op(status, operation)?;
+                    self.start_update_op(state, operation)?;
                     Ok(self.clone())
                 }
             }
@@ -458,7 +459,7 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
     /// Start an update operation (not all resources support this currently)
     fn start_update_op(
         &mut self,
-        _status: &Self::Status,
+        _state: &Self::State,
         _operation: Self::UpdateOp,
     ) -> Result<(), SvcError> {
         unimplemented!();
@@ -470,13 +471,13 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
     ) -> Result<(), SvcError> {
         Ok(())
     }
-    /// Check if the status is in sync with the spec
-    fn status_synced(&self, status: &Self::Status) -> bool
+    /// Check if the state is in sync with the spec
+    fn state_synced(&self, state: &Self::State) -> bool
     where
-        Self: PartialEq<Self::Status>,
+        Self: PartialEq<Self::State>,
     {
         // todo: do the check explicitly on each specialization rather than using PartialEq
-        self == status
+        self == state
     }
     /// Start a create transaction
     fn start_create_op(&mut self);
@@ -495,9 +496,9 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject {
     /// Get the UUID as a string (for log messages)
     fn uuid(&self) -> String;
     /// Get the state of the object
-    fn state(&self) -> SpecState<Self::State>;
+    fn status(&self) -> SpecStatus<Self::Status>;
     /// Set the state of the object
-    fn set_state(&mut self, state: SpecState<Self::State>);
+    fn set_status(&mut self, state: SpecStatus<Self::Status>);
     /// Check if the object is owned by another
     fn owned(&self) -> bool {
         false

--- a/control-plane/agents/core/src/core/specs.rs
+++ b/control-plane/agents/core/src/core/specs.rs
@@ -638,27 +638,4 @@ impl ResourceSpecsLocked {
         };
         Ok(())
     }
-
-    /// Start worker threads
-    /// 1. test store connections and commit dirty specs to the store
-    pub(crate) fn start(&self, registry: Registry) {
-        let this = self.clone();
-        tokio::spawn(async move { this.reconcile_dirty_specs(registry).await });
-    }
-
-    /// Reconcile dirty specs to the persistent store
-    async fn reconcile_dirty_specs(&self, registry: Registry) {
-        loop {
-            let dirty_replicas = self.reconcile_dirty_replicas(&registry).await;
-            let dirty_nexuses = self.reconcile_dirty_nexuses(&registry).await;
-
-            let period = if dirty_nexuses || dirty_replicas {
-                registry.reconcile_period
-            } else {
-                registry.reconcile_idle_period
-            };
-
-            tokio::time::sleep(period).await;
-        }
-    }
 }

--- a/control-plane/agents/core/src/core/task_poller.rs
+++ b/control-plane/agents/core/src/core/task_poller.rs
@@ -1,0 +1,169 @@
+use crate::core::registry::Registry;
+use common::errors::SvcError;
+
+/// Poll Event that identifies why a poll is running
+#[derive(Debug, Clone)]
+pub(crate) enum PollEvent {
+    /// Poller period elapsed
+    TimedRun,
+    /// Request Triggered by another component
+    /// example: A node has come back online so it could be a good idea to run the
+    /// reconciliation loop's as soon as possible
+    #[allow(dead_code)]
+    Triggered(PollTriggerEvent),
+    /// Shutdown the pollers
+    Shutdown,
+}
+
+/// Poll Trigger source
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+pub(crate) enum PollTriggerEvent {
+    /// A node state has changed
+    NodeStateChange,
+}
+
+/// State of a poller
+#[derive(Eq, PartialEq)]
+pub(crate) enum PollerState {
+    /// No immediate work remains to be done
+    Idle,
+    /// There is still work outstanding
+    Busy,
+}
+/// Result of a poll with the poller state
+pub(crate) type PollResult = Result<PollerState, SvcError>;
+
+/// The period at which a reconciliation loop is polled
+/// It's defined as a number of ticks
+/// Each tick has the period of the base poll period
+pub(crate) type PollPeriods = u32;
+
+/// PollTimer polls a timer and returns true to indicate that the reconciler should be polled
+/// If true, the timer is reloaded back to the setup period
+#[derive(Debug)]
+pub(crate) struct PollTimer {
+    period: PollPeriods,
+    timer: PollPeriods,
+}
+
+impl PollTimer {
+    /// Create a new `Self` for the given period
+    pub(crate) fn from(period: PollPeriods) -> Self {
+        Self {
+            period,
+            timer: period,
+        }
+    }
+    /// True when the timer reaches the bottom indicating the reconciler should be polled
+    /// (the counter is auto-reloaded)
+    pub(crate) fn poll(&mut self) -> bool {
+        if self.ready() {
+            self.reload();
+            true
+        } else {
+            self.decrement();
+            false
+        }
+    }
+    fn ready(&self) -> bool {
+        self.timer <= 1
+    }
+    fn decrement(&mut self) {
+        self.timer -= 1;
+    }
+    fn reload(&mut self) {
+        self.timer = self.period;
+    }
+}
+
+/// Poll Context passed around the poll handlers
+pub(crate) struct PollContext {
+    /// Event that triggered this poll
+    event: PollEvent,
+    /// Core Registry
+    registry: Registry,
+}
+impl PollContext {
+    /// Create a context for a `PollEvent` with the global `Registry`
+    pub(crate) fn from(event: &PollEvent, registry: &Registry) -> Self {
+        Self {
+            event: event.clone(),
+            registry: registry.clone(),
+        }
+    }
+    /// Get a reference to the core registry
+    pub(crate) fn registry(&self) -> &Registry {
+        &self.registry
+    }
+
+    #[allow(dead_code)]
+    /// Get a reference to the event that triggered this poll
+    pub(crate) fn event(&self) -> &PollEvent {
+        &self.event
+    }
+}
+
+/// Trait used by all reconciliation loops
+#[async_trait::async_trait]
+pub(crate) trait TaskPoller: Send + Sync + std::fmt::Debug {
+    /// Attempts to poll this poller, which will poll itself depending on the `PollEvent`
+    #[tracing::instrument(skip(context), err)]
+    async fn try_poll(&mut self, context: &PollContext) -> PollResult {
+        tracing::trace!("Entering trace call");
+        let result = if self.poll_ready(context).await {
+            self.poll(context).await
+        } else {
+            PollResult::Ok(PollerState::Idle)
+        };
+        tracing::trace!("Leaving trace call");
+        result
+    }
+
+    /// Force poll the poller
+    async fn poll(&mut self, context: &PollContext) -> PollResult;
+
+    /// Polls the ready state and returns true if ready
+    async fn poll_ready(&mut self, context: &PollContext) -> bool {
+        match context.event() {
+            PollEvent::TimedRun => self.poll_timer(context).await,
+            _ => self.poll_event(context).await,
+        }
+    }
+
+    /// Polls the `PollTimer` and returns true if ready
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        true
+    }
+
+    /// Determine if self should be polled for this `PollEvent`
+    async fn poll_event(&mut self, context: &PollContext) -> bool {
+        match context.event() {
+            PollEvent::TimedRun => true,
+            PollEvent::Triggered(_event) => true,
+            PollEvent::Shutdown => true,
+        }
+    }
+
+    /// Convert from a vector of results to a single result
+    fn squash_results(results: Vec<PollResult>) -> PollResult
+    where
+        Self: Sized,
+    {
+        squash_results(results)
+    }
+}
+
+/// Convert from a vector of results to a single result
+pub(crate) fn squash_results(results: Vec<PollResult>) -> PollResult {
+    let mut results = results.into_iter();
+    match results.find(|r| r.is_err()) {
+        Some(error) => error,
+        None => {
+            match results.find(|r| r.as_ref().unwrap_or(&PollerState::Busy) == &PollerState::Busy) {
+                Some(busy) => busy,
+                None => PollResult::Ok(PollerState::Idle),
+            }
+        }
+    }
+}

--- a/control-plane/agents/core/src/core/wrapper.rs
+++ b/control-plane/agents/core/src/core/wrapper.rs
@@ -7,8 +7,8 @@ use common_lib::{
     mbus_api::ResourceKind,
     types::v0::message_bus::{
         AddNexusChild, Child, CreateNexus, CreatePool, CreateReplica, DestroyNexus, DestroyPool,
-        DestroyReplica, Nexus, NexusId, Node, NodeId, NodeState, Pool, PoolId, PoolState, Protocol,
-        RemoveNexusChild, Replica, ReplicaId, ShareNexus, ShareReplica, UnshareNexus,
+        DestroyReplica, Nexus, NexusId, Node, NodeId, NodeState, Pool, PoolId, PoolStatus,
+        Protocol, RemoveNexusChild, Replica, ReplicaId, ShareNexus, ShareReplica, UnshareNexus,
         UnshareReplica,
     },
 };
@@ -704,7 +704,7 @@ impl PoolWrapper {
 
     /// Set pool state as unknown
     pub fn set_unknown(&mut self) {
-        self.pool.state = PoolState::Unknown;
+        self.pool.state = PoolStatus::Unknown;
     }
 
     /// Add replica to list

--- a/control-plane/agents/core/src/pool/tests.rs
+++ b/control-plane/agents/core/src/pool/tests.rs
@@ -5,7 +5,7 @@ use common_lib::{
     mbus_api::TimeoutOptions,
     types::v0::{
         message_bus::{
-            GetNodes, GetSpecs, Protocol, Replica, ReplicaId, ReplicaShareProtocol, ReplicaState,
+            GetNodes, GetSpecs, Protocol, Replica, ReplicaId, ReplicaShareProtocol, ReplicaStatus,
         },
         store::replica::ReplicaSpec,
     },
@@ -66,7 +66,7 @@ async fn pool() {
             size: 12582912,
             share: Protocol::None,
             uri,
-            state: ReplicaState::Online
+            status: ReplicaStatus::Online
         }
     );
 

--- a/control-plane/agents/core/src/server.rs
+++ b/control-plane/agents/core/src/server.rs
@@ -6,8 +6,9 @@ pub mod volume;
 pub mod watcher;
 
 use crate::core::registry;
-use common::*;
+use common::Service;
 use common_lib::types::v0::message_bus::ChannelVs;
+
 use structopt::StructOpt;
 use tracing::info;
 

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -29,7 +29,7 @@ use common_lib::{
             nexus_child::NexusChild,
             replica::ReplicaSpec,
             volume::{VolumeOperation, VolumeSpec},
-            SpecState, SpecTransaction,
+            SpecStatus, SpecTransaction,
         },
     },
 };
@@ -179,6 +179,11 @@ impl ResourceSpecsLocked {
         let specs = self.read();
         specs.get_volumes()
     }
+    /// Gets a copy of all locked VolumeSpec's
+    pub(crate) fn get_locked_volumes(&self) -> Vec<Arc<Mutex<VolumeSpec>>> {
+        let specs = self.read();
+        specs.volumes.to_vec()
+    }
 
     /// Get a list of nodes currently used as replicas
     pub(crate) fn get_volume_data_nodes(&self, id: &VolumeId) -> Vec<NodeId> {
@@ -251,12 +256,14 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         request: &CreateVolume,
     ) -> Result<Volume, SvcError> {
+        let volume = self.get_or_create_volume(request);
+        let volume_clone = SpecOperations::start_create(&volume, registry, request).await?;
+
         // todo: pick nodes and pools using the Node&Pool Topology
         // todo: virtually increase the pool usage to avoid a race for space with concurrent calls
-        let create_replicas = get_create_volume_replicas(registry, request).await?;
-
-        let volume = self.get_or_create_volume(request);
-        SpecOperations::start_create(&volume, registry, request).await?;
+        let result = get_create_volume_replicas(registry, request).await;
+        let create_replicas =
+            SpecOperations::validate_update_step(registry, result, &volume, &volume_clone).await?;
 
         let mut replicas = Vec::<Replica>::new();
         for replica in &create_replicas {
@@ -846,20 +853,20 @@ async fn get_volume_target_node(
 impl SpecOperations for VolumeSpec {
     type Create = CreateVolume;
     type Owners = ();
-    type State = VolumeStatus;
-    type Status = VolumeState;
+    type Status = VolumeStatus;
+    type State = VolumeState;
     type UpdateOp = VolumeOperation;
 
     fn start_update_op(
         &mut self,
-        status: &Self::Status,
+        state: &Self::State,
         operation: Self::UpdateOp,
     ) -> Result<(), SvcError> {
         // No ANA support, there can only be more than 1 nexus if we've recreated the nexus
         // on another node and original nexus reappears.
         // In this case, the reconciler will destroy one of them.
-        if (self.target_node.is_some() && status.children.len() != 1)
-            || self.target_node.is_none() && !status.children.is_empty()
+        if (self.target_node.is_some() && state.children.len() != 1)
+            || self.target_node.is_none() && !state.children.is_empty()
         {
             return Err(SvcError::NotReady {
                 kind: self.kind(),
@@ -871,8 +878,13 @@ impl SpecOperations for VolumeSpec {
             VolumeOperation::Share(_) if self.protocol.shared() => Err(SvcError::AlreadyShared {
                 kind: self.kind(),
                 id: self.uuid(),
-                share: status.protocol.to_string(),
+                share: state.protocol.to_string(),
             }),
+            VolumeOperation::Share(_) if self.target_node.is_none() => {
+                Err(SvcError::VolumeNotPublished {
+                    vol_id: self.uuid(),
+                })
+            }
             VolumeOperation::Share(_) => Ok(()),
             VolumeOperation::Unshare if !self.protocol.shared() => Err(SvcError::NotShared {
                 kind: self.kind(),
@@ -892,7 +904,7 @@ impl SpecOperations for VolumeSpec {
             }
 
             VolumeOperation::Publish(_) => Ok(()),
-            VolumeOperation::Unpublish => get_volume_nexus(status).map(|_| ()),
+            VolumeOperation::Unpublish => get_volume_nexus(state).map(|_| ()),
 
             VolumeOperation::SetReplica(replica_count) => {
                 if *replica_count == self.num_replicas {
@@ -906,12 +918,12 @@ impl SpecOperations for VolumeSpec {
                     })
                 } else if (*replica_count as i16 - self.num_replicas as i16).abs() > 1 {
                     Err(SvcError::ReplicaChangeCount {})
-                } else if status.status != VolumeStatus::Online
+                } else if state.status != VolumeStatus::Online
                     && (*replica_count > self.num_replicas)
                 {
                     Err(SvcError::ReplicaIncrease {
                         volume_id: self.uuid(),
-                        volume_state: status.status.to_string(),
+                        volume_state: state.status.to_string(),
                     })
                 } else {
                     Ok(())
@@ -949,10 +961,10 @@ impl SpecOperations for VolumeSpec {
     fn uuid(&self) -> String {
         self.uuid.to_string()
     }
-    fn state(&self) -> SpecState<Self::State> {
-        self.state.clone()
+    fn status(&self) -> SpecStatus<Self::Status> {
+        self.status.clone()
     }
-    fn set_state(&mut self, state: SpecState<Self::State>) {
-        self.state = state;
+    fn set_status(&mut self, status: SpecStatus<Self::Status>) {
+        self.status = status;
     }
 }


### PR DESCRIPTION
chore: correct remaining state/status naming

feat: add initial reconciliation task scaffolding
Add reconciliation pollers that get polled at a certain interval. Each poller may then mux
Added example volume pollers for replica hotspare and garbage collection.

refactor: update old dirty specs reconciler
Use the new reconciler poller to reconcile dirty specs into the persistent store

