### PR TITLE
chore: add InUse error when deleting a pool

### DIFF
--- a/common/src/mbus_api/mod.rs
+++ b/common/src/mbus_api/mod.rs
@@ -343,6 +343,7 @@ pub enum ReplyErrorKind {
     ReplicaChangeCount,
     ReplicaIncrease,
     VolumeNoReplicas,
+    InUse,
 }
 
 impl From<Error> for ReplyError {

--- a/common/src/types/mod.rs
+++ b/common/src/types/mod.rs
@@ -171,6 +171,10 @@ impl From<ReplyError> for RestError<RestJsonError> {
                 let error = RestJsonError::new(details, Kind::FailedPrecondition);
                 (StatusCode::PRECONDITION_FAILED, error)
             }
+            ReplyErrorKind::InUse => {
+                let error = RestJsonError::new(details, Kind::InUse);
+                (StatusCode::CONFLICT, error)
+            }
         };
 
         RestError::new(status, error)

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -147,7 +147,7 @@ pub enum SvcError {
     },
     #[snafu(display("{} Resource id {} needs to be reconciled. Please retry", kind.to_string(), id))]
     NotReady { kind: ResourceKind, id: String },
-    #[snafu(display("{} Resource id {} still in still use", kind.to_string(), id))]
+    #[snafu(display("{} Resource id {} still in use", kind.to_string(), id))]
     InUse { kind: ResourceKind, id: String },
     #[snafu(display("{} Resource id {} already exists", kind.to_string(), id))]
     AlreadyExists { kind: ResourceKind, id: String },
@@ -227,7 +227,7 @@ impl From<SvcError> for ReplyError {
                 extra: error.full_string(),
             },
             SvcError::InUse { kind, id } => ReplyError {
-                kind: ReplyErrorKind::Conflict,
+                kind: ReplyErrorKind::InUse,
                 resource: kind,
                 source: desc.to_string(),
                 extra: format!("id: {}", id),

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -5916,6 +5916,7 @@ components:
             - Conflict
             - FailedPersist
             - Deleting
+            - InUse
       required:
         - details
         - kind

--- a/openapi/api/openapi.yaml
+++ b/openapi/api/openapi.yaml
@@ -6041,6 +6041,7 @@ components:
           - Conflict
           - FailedPersist
           - Deleting
+          - InUse
           type: string
       required:
       - details

--- a/openapi/src/models/rest_json_error.rs
+++ b/openapi/src/models/rest_json_error.rs
@@ -93,6 +93,8 @@ pub enum Kind {
     FailedPersist,
     #[serde(rename = "Deleting")]
     Deleting,
+    #[serde(rename = "InUse")]
+    InUse,
 }
 
 impl Default for Kind {


### PR DESCRIPTION
Return an InUse error message when attempting to delete a pool which has
replicas on it.

Resolves: CAS-996