### PR TITLE
feat: implement volume hotspare reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
  "once_cell",
  "oneshot",
  "openapi",
+ "parking_lot",
  "percent-encoding",
  "rpc",
  "serde",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,6 +31,7 @@ once_cell = "1.4.1"
 tracing-futures = "0.2.4"
 tracing-subscriber = "0.2"
 openapi = { path = "../openapi" }
+parking_lot = "0.11.1"
 
 [dev-dependencies]
 composer = { path = "../composer" }

--- a/common/src/types/mod.rs
+++ b/common/src/types/mod.rs
@@ -14,7 +14,7 @@ use std::{fmt::Debug, str::FromStr};
 pub mod v0;
 
 /// Available Message Bus channels
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 #[allow(non_camel_case_types)]
 pub enum Channel {
     /// Version 0 of the Channels

--- a/common/src/types/v0/message_bus/child.rs
+++ b/common/src/types/v0/message_bus/child.rs
@@ -72,6 +72,12 @@ pub enum ChildState {
     /// unrecoverable error (control plane must act)
     Faulted = 3,
 }
+impl ChildState {
+    /// Check if the child is `Faulted`
+    pub fn faulted(&self) -> bool {
+        self == &Self::Faulted
+    }
+}
 impl PartialOrd for ChildState {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match &self {
@@ -150,7 +156,16 @@ pub struct RemoveNexusChild {
     /// URI of the child device to be removed
     pub uri: ChildUri,
 }
-
+impl RemoveNexusChild {
+    /// Return new `Self`
+    pub fn new(node: &NodeId, nexus: &NexusId, uri: &ChildUri) -> Self {
+        Self {
+            node: node.clone(),
+            nexus: nexus.clone(),
+            uri: uri.clone(),
+        }
+    }
+}
 impl From<AddNexusChild> for RemoveNexusChild {
     fn from(add: AddNexusChild) -> Self {
         Self {

--- a/common/src/types/v0/message_bus/mod.rs
+++ b/common/src/types/v0/message_bus/mod.rs
@@ -38,7 +38,7 @@ pub use crate::{
 pub const VERSION: &str = "v0";
 
 /// Versioned Channels
-#[derive(Clone, Debug, EnumString, ToString)]
+#[derive(Clone, Debug, EnumString, ToString, PartialEq)]
 #[strum(serialize_all = "camelCase")]
 pub enum ChannelVs {
     /// Default

--- a/common/src/types/v0/message_bus/nexus.rs
+++ b/common/src/types/v0/message_bus/nexus.rs
@@ -36,6 +36,12 @@ pub struct Nexus {
     /// protocol used for exposing the nexus
     pub share: Protocol,
 }
+impl Nexus {
+    /// Check if the nexus contains the provided `ChildUri`
+    pub fn contains_child(&self, uri: &ChildUri) -> bool {
+        self.children.iter().any(|c| &c.uri == uri)
+    }
+}
 
 impl From<Nexus> for models::Nexus {
     fn from(src: Nexus) -> Self {

--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -12,6 +12,14 @@ pub struct GetReplicas {
     /// Filter request
     pub filter: Filter,
 }
+impl GetReplicas {
+    /// Return new `Self` to fetch a replica by its `ReplicaId`
+    pub fn new(uuid: &ReplicaId) -> Self {
+        Self {
+            filter: Filter::Replica(uuid.clone()),
+        }
+    }
+}
 
 /// Replica information
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
@@ -185,6 +193,17 @@ pub struct DestroyReplica {
     pub uuid: ReplicaId,
     /// delete by owners
     pub disowners: ReplicaOwners,
+}
+impl DestroyReplica {
+    /// Return a new `Self` from the provided arguments
+    pub fn new(node: &NodeId, pool: &PoolId, uuid: &ReplicaId, disowners: &ReplicaOwners) -> Self {
+        Self {
+            node: node.clone(),
+            pool: pool.clone(),
+            uuid: uuid.clone(),
+            disowners: disowners.clone(),
+        }
+    }
 }
 
 /// Share Replica Request
@@ -364,6 +383,17 @@ pub struct AddNexusReplica {
     /// auto start rebuilding
     pub auto_rebuild: bool,
 }
+impl AddNexusReplica {
+    /// Return new `Self` from it's properties
+    pub fn new(node: &NodeId, nexus: &NexusId, replica: &ReplicaUri, auto_rebuild: bool) -> Self {
+        Self {
+            node: node.clone(),
+            nexus: nexus.clone(),
+            replica: replica.clone(),
+            auto_rebuild,
+        }
+    }
+}
 
 impl From<&AddNexusReplica> for AddNexusChild {
     fn from(add: &AddNexusReplica) -> Self {
@@ -388,7 +418,16 @@ pub struct RemoveNexusReplica {
     /// UUID and URI of the replica to be added
     pub replica: ReplicaUri,
 }
-
+impl RemoveNexusReplica {
+    /// Return new `Self`
+    pub fn new(node: &NodeId, nexus: &NexusId, replica: &ReplicaUri) -> Self {
+        Self {
+            node: node.clone(),
+            nexus: nexus.clone(),
+            replica: replica.clone(),
+        }
+    }
+}
 impl From<&RemoveNexusReplica> for RemoveNexusChild {
     fn from(rm: &RemoveNexusReplica) -> Self {
         Self {

--- a/common/src/types/v0/message_bus/volume.rs
+++ b/common/src/types/v0/message_bus/volume.rs
@@ -32,6 +32,11 @@ impl Volume {
         self.spec.clone()
     }
 
+    /// Get the volume's uuid.
+    pub fn uuid(&self) -> &VolumeId {
+        &self.spec.uuid
+    }
+
     /// Get the volume state.
     pub fn get_state(&self) -> Option<VolumeState> {
         self.state.clone()
@@ -78,7 +83,7 @@ impl From<VolumeState> for models::VolumeState {
             children: volume.children.into_vec(),
             protocol: volume.protocol.into(),
             size: volume.size,
-            status: Some(volume.status.into()),
+            status: volume.status.into(),
             uuid: apis::Uuid::try_from(volume.uuid).unwrap(),
         }
     }
@@ -89,7 +94,7 @@ impl From<models::VolumeState> for VolumeState {
         Self {
             uuid: state.uuid.to_string().into(),
             size: state.size,
-            status: state.status.unwrap_or(models::VolumeStatus::Unknown).into(),
+            status: state.status.into(),
             protocol: state.protocol.into(),
             children: state.children.into_vec(),
         }
@@ -320,6 +325,14 @@ pub struct GetVolumes {
     /// filter volumes
     pub filter: Filter,
 }
+impl GetVolumes {
+    /// Return new `Self` to retrieve the specified volume
+    pub fn new(volume: &VolumeId) -> Self {
+        Self {
+            filter: Filter::Volume(volume.clone()),
+        }
+    }
+}
 
 /// Create volume
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
@@ -450,7 +463,7 @@ pub struct SetVolumeReplica {
     pub replicas: u8,
 }
 impl SetVolumeReplica {
-    /// Create new `SetVolumeReplica` based on the provided arguments
+    /// Create new `Self` based on the provided arguments
     pub fn new(uuid: VolumeId, replicas: u8) -> Self {
         Self { uuid, replicas }
     }
@@ -462,4 +475,16 @@ impl SetVolumeReplica {
 pub struct DestroyVolume {
     /// uuid of the volume
     pub uuid: VolumeId,
+}
+impl DestroyVolume {
+    /// Create new `Self` to destroy the specified volume
+    pub fn new(volume: &VolumeId) -> Self {
+        Self {
+            uuid: volume.clone(),
+        }
+    }
+    /// Get the volume's identification
+    pub fn uuid(&self) -> &VolumeId {
+        &self.uuid
+    }
 }

--- a/control-plane/agents/common/src/lib.rs
+++ b/control-plane/agents/common/src/lib.rs
@@ -22,7 +22,10 @@ use crate::errors::SvcError;
 use common_lib::{
     mbus_api,
     mbus_api::*,
-    types::{v0::message_bus::Liveness, Channel},
+    types::{
+        v0::message_bus::{ChannelVs, Liveness},
+        Channel,
+    },
 };
 
 /// Agent level errors
@@ -307,7 +310,9 @@ impl Service {
 
             let context = Context::new(&bus, state.deref());
             let args = Arguments::new(&context, &message);
-            debug!("Processing message: {{ {} }}", args.request);
+            if args.request.channel() != Channel::v0(ChannelVs::Registry) {
+                debug!("Processing message: {{ {} }}", args.request);
+            }
 
             if let Err(error) = Self::process_message(args, subscriptions).await {
                 error!("Error processing message: {}", error.full_string());

--- a/control-plane/agents/core/src/core/reconciler/README.md
+++ b/control-plane/agents/core/src/core/reconciler/README.md
@@ -1,0 +1,179 @@
+# Replica HotSpare Reconciliation
+
+Volumes can be created with a replica count greater than 1 which is intended to make them highly available. If one of
+the replicas fails, then the volume remains available by making use of the remaining healthy replicas.
+
+## Why do we need to replace faulted replicas
+
+In such a scenario where 1 of the replicas fails, the control plane tries to add another replica to replace the faulted
+one. This way, it can reestablish the previous level of redundancy and thus becoming robust to another potential fault.
+
+**Volume created with 2 replicas**
+```
+         ┌────────┐
+         │ Volume │
+         │        │
+       ┌─┴────────┴─┐
+       │            │
+   ┌───▼───┐    ┌───▼───┐
+   │Replica│    │Replica│
+   │   1   │    │   2   │
+   └───────┘    └───────┘
+```
+If `Replica1` fails the volume remains accessible through `Replica2`. If `Replica 2` also fails, then the volume becomes
+inaccessible!
+
+**Volume created with 2 replicas**
+```
+         ┌────────┐
+         │ Volume │
+         │        │
+       ┌─┴────────┴─┐
+       │            │
+   ┌───▼───┐    ┌───▼───┐
+   │Replica│    │Replica│
+   │   1   │    │   2   │
+   └───────┘    └───────┘
+```
+If `Replica1` fails the volume remains accessible through `Replica2`.
+
+The hotspare logic replaces `Replica1` with a brand-new replica `Replica3`. A rebuild is now running as we must rebuild
+the user data from `Replica2` into `Replica3`.
+
+Before the rebuild completes, `Replica 2` fails. The volume becomes inaccessible!
+
+**Volume created with 2 replicas**
+```
+         ┌────────┐
+         │ Volume │
+         │        │
+       ┌─┴────────┴─┐
+       │            │
+   ┌───▼───┐    ┌───▼───┐
+   │Replica│    │Replica│
+   │   1   │    │   2   │
+   └───────┘    └───────┘
+```
+If `Replica1` fails the volume remains accessible through `Replica2`.
+
+The hotspare logic replaces `Replica1` with a brand-new replica `Replica3`. A rebuild is now running as we must rebuild
+the user data from `Replica2` into `Replica3`. The rebuild completes successfully.
+`Replica 2` fails.
+
+The volume is still accessible through `Replica 3`.
+#
+It's clear now, that we need to replace faulted replicas with new ones, and we need to rebuild them before we're able
+to sustain further failures.
+#
+
+
+## Scenarios
+
+### Scenario One
+
+```gherkin
+Scenario: Replacing faulty replicas
+  Given a degraded volume
+  When a nexus state has faulty children
+  Then they should eventually be removed from the state and spec
+  And the replicas should eventually be destroyed
+```
+
+#### The reconciliation loop example:
+
+#
+1. finds a degraded volume
+2. finds the nexus with a faulty child
+3. removes the faulty child
+4. disowns the replica from the volume
+5. deletes the replica (if accessible, otherwise it'll be garbage collected)
+#
+
+### Scenario Two
+
+```gherkin
+Scenario: Replacing unknown replicas
+  Given a volume
+  When a nexus state has children that are not present in the spec
+  Then the children should eventually be removed from the state
+  And the uri's should not be destroyed
+```
+
+#### The reconciliation loop example:
+
+#
+1. finds a volume
+2. finds the nexus with an unknown child
+3. removes the unknown child
+#
+
+### Scenario Three
+
+```gherkin
+Scenario: Replacing missing replicas
+  Given a degraded volume
+  When a nexus spec has children that are not present in the state
+  Then the children should eventually be removed from the spec
+  And the replicas should eventually be destroyed
+```
+
+#### The reconciliation loop example:
+
+#
+1. finds a degraded volume
+2. finds the nexus with a missing replica
+3. forgets about the missing replica (might have been removed for a specific reason?)
+4. disowns the missing replica
+5. deletes the replica (if accessible, otherwise it'll be garbage collected)
+#
+
+### Scenario Four
+
+```gherkin
+Scenario: Nexus is out of sync with its volume
+  Given a degraded volume
+  When the nexus spec has a different number of children to the number of volume replicas
+  Then the nexus spec should eventually have as many children as the number of volume replicas
+```
+
+#### The reconciliation loop examples:
+
+#
+1. finds a degraded volume
+2. finds the nexus out of sync, with more replicas than required
+3. removes excess replicas from the nexus
+#
+1. finds a degraded volume
+2. finds a 1 replica nexus for a 2 replica volume
+3. finds an unused volume replica
+4. adds the unused replica to the nexus
+#
+
+### Scenario Five
+
+```gherkin
+Scenario: Number of volume replicas out of sync with replica requirements
+  Given a degraded volume
+  When the number of created volume replicas is different to the required number of replicas
+  Then the number of created volume replicas should eventually match the required number of replicas
+```
+
+#### The reconciliation loop examples:
+
+#
+1. finds a degraded volume
+2. finds a degraded volume missing 1 replica
+3. creates a new replica
+#
+1. finds a degraded volume
+2. finds a degraded volume with 1 extra replica
+3. finds an unused volume replica and deletes it
+#
+1. finds a degraded volume
+2. finds a degraded volume with 1 extra replica
+3. tries to find an unused volume replica (can't find it)
+4. finds a nexus with 1 more replica than required
+5. removes the replica from its nexus
+6. finds a degraded volume with 1 extra replica
+7. finds an unused volume replica and deletes it
+#

--- a/control-plane/agents/core/src/core/reconciler/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/mod.rs
@@ -1,3 +1,4 @@
+mod nexus;
 mod persistent_store;
 pub mod poller;
 mod volume;

--- a/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
@@ -1,0 +1,130 @@
+use crate::core::task_poller::{PollContext, PollResult, PollerState};
+use common_lib::{
+    mbus_api::ErrorChain,
+    types::v0::store::{nexus::NexusSpec, OperationMode},
+};
+
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Find and removes faulted children from the given nexus
+/// If the child is a replica it also disowns and destroys it
+pub(super) async fn faulted_children_remover(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let nexus_uuid = nexus_spec.lock().uuid.clone();
+    let nexus_state = context.registry().get_nexus(&nexus_uuid).await?;
+    for child in nexus_state.children.iter().filter(|c| c.state.faulted()) {
+        tracing::warn!(
+            "Faulted child '{}' of Nexus '{}' needs to be replaced",
+            child.uri,
+            nexus_spec.lock().uuid
+        );
+        if let Err(error) = context
+            .registry()
+            .specs
+            .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, true, mode)
+            .await
+        {
+            tracing::error!(
+                "Failed to remove faulted child '{}' of nexus '{}', error: '{}'",
+                child.uri,
+                nexus_state.uuid,
+                error.full_string(),
+            );
+        } else {
+            tracing::info!(
+                "Successfully removed faulted child '{}' of Nexus '{}'.",
+                child.uri,
+                nexus_spec.lock().uuid
+            );
+        }
+    }
+
+    PollResult::Ok(PollerState::Idle)
+}
+
+/// Find and removes unknown children from the given nexus
+/// If the child is a replica it also disowns and destroys it
+pub(super) async fn unknown_children_remover(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let nexus_uuid = nexus_spec.lock().uuid.clone();
+    let nexus_state = context.registry().get_nexus(&nexus_uuid).await?;
+    let state_children = nexus_state.children.iter();
+    let spec_children = nexus_spec.lock().children.clone();
+
+    for child in state_children.filter(|c| !spec_children.iter().any(|spec| spec.uri() == c.uri)) {
+        tracing::warn!(
+            "Unknown child '{}' of Nexus '{}' needs to be removed",
+            child.uri,
+            nexus_spec.lock().uuid
+        );
+        if let Err(error) = context
+            .registry()
+            .specs
+            .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, false, mode)
+            .await
+        {
+            tracing::error!(
+                "Failed to remove unknown child '{}' of Nexus '{}', error: '{}'",
+                child.uri,
+                nexus_state.uuid,
+                error.full_string(),
+            );
+        } else {
+            tracing::info!(
+                "Successfully removed unknown child '{}' of Nexus '{}'.",
+                child.uri,
+                nexus_spec.lock().uuid
+            );
+        }
+    }
+
+    PollResult::Ok(PollerState::Idle)
+}
+
+/// Find missing children from the given nexus
+/// They are removed from the spec as we don't know why they got removed, so it's safer
+/// to just disown and destroy them.
+pub(super) async fn missing_children_remover(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let nexus_uuid = nexus_spec.lock().uuid.clone();
+    let nexus_state = context.registry().get_nexus(&nexus_uuid).await?;
+    let spec_children = nexus_spec.lock().children.clone().into_iter();
+
+    let mut result = PollResult::Ok(PollerState::Idle);
+    for child in
+        spec_children.filter(|spec| !nexus_state.children.iter().any(|c| c.uri == spec.uri()))
+    {
+        tracing::warn!(
+            "Child '{}' is missing from Nexus '{}'. It may have been removed for a reason so it will be replaced with another",
+            child.uri(),
+            nexus_spec.lock().uuid
+        );
+
+        if let Err(error) = context
+            .registry()
+            .specs
+            .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri(), true, mode)
+            .await
+        {
+            tracing::error!(
+                "Failed to remove child '{}' from the spec of nexus '{}', error: '{}'",
+                child.uri(),
+                nexus_state.uuid,
+                error.full_string(),
+            );
+            result = PollResult::Err(error);
+        }
+    }
+
+    result
+}

--- a/control-plane/agents/core/src/core/reconciler/volume/hot_spare.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/hot_spare.rs
@@ -1,12 +1,24 @@
-use crate::core::{
-    reconciler::{PollContext, TaskPoller},
-    specs::SpecOperations,
-    task_poller::{PollResult, PollerState},
+use crate::{
+    core::{
+        reconciler::{nexus, PollContext, TaskPoller},
+        specs::OperationSequenceGuard,
+        task_poller::{squash_results, PollResult, PollerState},
+    },
+    volume::specs::get_volume_replica_candidates,
 };
 
-use common_lib::types::v0::store::volume::VolumeSpec;
+use common::errors::NexusNotFound;
+use common_lib::{
+    mbus_api::ErrorChain,
+    types::v0::{
+        message_bus::{VolumeState, VolumeStatus},
+        store::{nexus::NexusSpec, volume::VolumeSpec, OperationMode},
+    },
+};
+
 use parking_lot::Mutex;
-use std::sync::Arc;
+use snafu::OptionExt;
+use std::{cmp::Ordering, sync::Arc};
 
 /// Volume HotSpare reconciler
 #[derive(Debug)]
@@ -24,19 +36,287 @@ impl TaskPoller for HotSpareReconciler {
         let mut results = vec![];
         let volumes = context.registry().specs.get_locked_volumes();
         for volume in volumes {
-            results.push(hot_spare_reconcile(volume, context).await);
+            results.push(hot_spare_reconcile(&volume, context).await);
         }
         Self::squash_results(results)
     }
 }
 
-async fn hot_spare_reconcile(volume: Arc<Mutex<VolumeSpec>>, context: &PollContext) -> PollResult {
-    let uuid = volume.lock().uuid.clone();
-    let state = context.registry().get_volume_state(&uuid).await?;
-    if !volume.lock().state_synced(&state) {
-        // todo: reconcile the volume object
-        tracing::warn!("Volume '{}' needs to be reconciled", uuid);
+async fn hot_spare_reconcile(
+    volume_spec: &Arc<Mutex<VolumeSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let uuid = volume_spec.lock().uuid.clone();
+    let volume_state = context.registry().get_volume_state(&uuid).await?;
+    let _guard = match volume_spec.operation_guard(OperationMode::ReconcileStart) {
+        Ok(guard) => guard,
+        Err(_) => return PollResult::Ok(PollerState::Busy),
+    };
+    let mode = OperationMode::ReconcileStep;
+
+    if volume_spec.lock().status.created() {
+        match volume_state.status {
+            VolumeStatus::Online => {
+                volume_replica_count_reconciler(volume_spec, context, mode).await
+            }
+            VolumeStatus::Unknown | VolumeStatus::Degraded => {
+                hot_spare_nexus_reconcile(volume_spec, &volume_state, context).await
+            }
+            VolumeStatus::Faulted => PollResult::Ok(PollerState::Idle),
+        }
+    } else {
+        PollResult::Ok(PollerState::Idle)
+    }
+}
+
+async fn hot_spare_nexus_reconcile(
+    volume_spec: &Arc<Mutex<VolumeSpec>>,
+    volume_state: &VolumeState,
+    context: &PollContext,
+) -> PollResult {
+    let mode = OperationMode::ReconcileStep;
+    let mut results = vec![];
+
+    // todo: ANA will have more than 1 nexus
+    if let Some(nexus) = volume_state.children.first() {
+        let nexus_spec = context.registry().specs.get_nexus(&nexus.uuid);
+        let nexus_spec = nexus_spec.context(NexusNotFound {
+            nexus_id: nexus.uuid.to_string(),
+        })?;
+        let _guard = match nexus_spec.operation_guard(OperationMode::ReconcileStart) {
+            Ok(guard) => guard,
+            Err(_) => return PollResult::Ok(PollerState::Busy),
+        };
+
+        // generic nexus reconciliation (does not matter that it belongs to a volume)
+        results.push(generic_nexus_reconciler(&nexus_spec, context, mode).await);
+
+        // fixup the volume replica count: creates new replicas when we're behind
+        // removes extra replicas but only if they're UNUSED (by a nexus)
+        results.push(volume_replica_count_reconciler(volume_spec, context, mode).await);
+        // fixup the nexus replica count to match the volume's replica count
+        results.push(nexus_replica_count_reconciler(volume_spec, &nexus_spec, context, mode).await);
+    } else {
+        results.push(volume_replica_count_reconciler(volume_spec, context, mode).await);
     }
 
-    PollResult::Ok(PollerState::Idle)
+    squash_results(results)
+}
+
+async fn generic_nexus_reconciler(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let mut results = vec![];
+    results.push(faulted_children_remover(nexus_spec, context, mode).await);
+    results.push(unknown_children_remover(nexus_spec, context, mode).await);
+    results.push(missing_children_remover(nexus_spec, context, mode).await);
+    squash_results(results)
+}
+
+/// Given a degraded volume
+/// When a nexus state has faulty children
+/// Then they should eventually be removed from the state and spec
+/// And the replicas should eventually be destroyed
+async fn faulted_children_remover(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    nexus::faulted_children_remover(nexus_spec, context, mode).await
+}
+
+/// Given a degraded volume
+/// When a nexus state has children that are not present in the spec
+/// Then the children should eventually be removed from the state
+/// And the uri's should not be destroyed
+async fn unknown_children_remover(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    nexus::unknown_children_remover(nexus_spec, context, mode).await
+}
+
+/// Given a degraded volume
+/// When a nexus spec has children that are not present in the state
+/// Then the children should eventually be removed from the spec
+/// And the replicas should eventually be destroyed
+async fn missing_children_remover(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    nexus::missing_children_remover(nexus_spec, context, mode).await
+}
+
+/// Given a degraded volume
+/// When the nexus spec has a different number of children to the number of volume replicas
+/// Then the nexus spec should eventually have as many children as the number of volume replicas
+async fn nexus_replica_count_reconciler(
+    volume_spec: &Arc<Mutex<VolumeSpec>>,
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let nexus_uuid = nexus_spec.lock().uuid.clone();
+    let nexus_state = context.registry().get_nexus(&nexus_uuid).await?;
+
+    let vol_spec_clone = volume_spec.lock().clone();
+    let nexus_spec_clone = nexus_spec.lock().clone();
+    let volume_replicas = vol_spec_clone.num_replicas as usize;
+    let nexus_replica_children =
+        nexus_spec_clone
+            .children
+            .iter()
+            .fold(0usize, |mut counter, child| {
+                let registry = context.registry();
+                // only account for children which are lvol replicas
+                if let Some(replica) = child.as_replica() {
+                    if registry.specs.get_replica(replica.uuid()).is_some() {
+                        counter += 1;
+                    }
+                }
+                counter
+            });
+
+    match nexus_replica_children.cmp(&volume_replicas) {
+        Ordering::Less => {
+            tracing::warn!(
+                "Nexus '{}' of Volume '{}' only has '{}' replica(s) but the volume requires '{}' replica(s)",
+                nexus_spec_clone.uuid,
+                vol_spec_clone.uuid,
+                nexus_replica_children,
+                volume_replicas
+            );
+            context
+                .registry()
+                .specs
+                .attach_replicas_to_nexus(
+                    context.registry(),
+                    volume_spec,
+                    nexus_spec,
+                    &nexus_state,
+                    mode,
+                )
+                .await?;
+        }
+        Ordering::Greater => {
+            tracing::warn!(
+                "Nexus '{}' of Volume '{}' has more replicas(s) ('{}') than the required replica count ('{}')",
+                nexus_spec_clone.uuid,
+                vol_spec_clone.uuid,
+                nexus_replica_children,
+                volume_replicas
+            );
+            context
+                .registry()
+                .specs
+                .remove_excess_replicas_from_nexus(
+                    context.registry(),
+                    volume_spec,
+                    nexus_spec,
+                    &nexus_state,
+                    mode,
+                )
+                .await?;
+        }
+        Ordering::Equal => {}
+    }
+
+    PollResult::Ok(if nexus_spec.lock().children.len() == volume_replicas {
+        PollerState::Idle
+    } else {
+        PollerState::Busy
+    })
+}
+
+/// Given a degraded volume
+/// When the number of created volume replicas is different to the required number of replicas
+/// Then the number of created volume replicas should eventually match the required number of
+/// replicas
+async fn volume_replica_count_reconciler(
+    volume_spec: &Arc<Mutex<VolumeSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let volume_spec_clone = volume_spec.lock().clone();
+    let volume_uuid = volume_spec_clone.uuid.clone();
+    let required_replica_count = volume_spec_clone.num_replicas as usize;
+
+    let current_replicas = context.registry().specs.get_volume_replicas(&volume_uuid);
+    let mut current_replica_count = current_replicas.len();
+
+    match current_replica_count.cmp(&required_replica_count) {
+        Ordering::Less => {
+            tracing::warn!(
+                "Volume '{}' only has '{}' replica(s) but it should have '{}'. Creating more...",
+                volume_spec_clone.uuid,
+                current_replica_count,
+                required_replica_count
+            );
+            let diff = required_replica_count - current_replica_count;
+            let candidates =
+                get_volume_replica_candidates(context.registry(), &volume_spec_clone).await?;
+
+            match context
+                .registry()
+                .specs
+                .create_volume_replicas(context.registry(), &volume_uuid, candidates, diff, mode)
+                .await
+            {
+                result if result > 0 => {
+                    current_replica_count += result;
+                    tracing::info!(
+                        "Successfully created '{}' new replica(s) for volume '{}'",
+                        result,
+                        volume_spec_clone.uuid,
+                    );
+                }
+                _ => {
+                    tracing::error!(
+                        "Failed to create replicas for volume '{}'",
+                        volume_spec_clone.uuid,
+                    );
+                }
+            }
+        }
+        Ordering::Greater => {
+            tracing::warn!(
+                "Volume '{}' has '{}' replica(s) but it should only have '{}'. Removing...",
+                volume_spec_clone.uuid,
+                current_replica_count,
+                required_replica_count
+            );
+            let diff = current_replica_count - required_replica_count;
+            match context
+                .registry()
+                .specs
+                .remove_unused_volume_replicas(context.registry(), volume_spec, diff, mode)
+                .await
+            {
+                Ok(_) => {
+                    tracing::info!(
+                        "Successfully removed unused replicas from Volume '{}'",
+                        volume_spec_clone.uuid,
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(
+                        "Failed to remove unused replicas from volume '{}', error: '{}'",
+                        volume_spec_clone.uuid,
+                        error.full_string()
+                    );
+                }
+            }
+        }
+        Ordering::Equal => {}
+    }
+
+    PollResult::Ok(if current_replica_count == required_replica_count {
+        PollerState::Idle
+    } else {
+        PollerState::Busy
+    })
 }

--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -207,12 +207,7 @@ impl Registry {
                 // update node in the registry
                 *node.lock().await = node_clone;
             }
-            self.trace_all().await;
             tokio::time::sleep(self.cache_period).await;
         }
-    }
-    async fn trace_all(&self) {
-        let registry = self.nodes.read().await;
-        tracing::trace!("Registry update: {:?}", registry);
     }
 }

--- a/control-plane/agents/core/src/core/scheduling/volume.rs
+++ b/control-plane/agents/core/src/core/scheduling/volume.rs
@@ -1,13 +1,23 @@
 use crate::core::{
     registry::Registry,
     scheduling::{
-        resources::{PoolItem, PoolItemLister, ReplicaItem, ReplicaItemLister},
+        resources::{PoolItem, PoolItemLister, ReplicaItem},
         ChildSorters, NodeFilters, PoolFilters, PoolSorters, ResourceFilter,
     },
 };
+
+use crate::core::scheduling::{
+    resources::{ChildItem, NexusChildItem},
+    AddReplicaFilters, AddReplicaSorters, NexusChildSorter,
+};
+use common::errors::SvcError;
 use common_lib::types::v0::{
-    message_bus::{CreateVolume, VolumeState},
-    store::volume::VolumeSpec,
+    message_bus::{ChildUri, CreateVolume, VolumeState},
+    store::{
+        nexus::NexusSpec,
+        nexus_persistence::{NexusInfo, NexusInfoKey},
+        volume::VolumeSpec,
+    },
 };
 use itertools::Itertools;
 use std::{collections::HashMap, ops::Deref};
@@ -32,8 +42,14 @@ impl From<&VolumeSpec> for GetSuitablePools {
 
 #[derive(Clone)]
 pub(crate) struct GetSuitablePoolsContext {
-    pub(crate) registry: Registry,
+    registry: Registry,
     spec: VolumeSpec,
+}
+impl GetSuitablePoolsContext {
+    /// Get the registry
+    pub(crate) fn registry(&self) -> &Registry {
+        &self.registry
+    }
 }
 
 impl Deref for GetSuitablePoolsContext {
@@ -51,22 +67,26 @@ impl Deref for GetSuitablePools {
     }
 }
 
+/// Add replicas to a volume
+/// Selects the best pool candidates to create lvol replicas on
 #[derive(Clone)]
-pub(crate) struct IncreaseVolumeReplica {
+pub(crate) struct AddVolumeReplica {
     context: GetSuitablePoolsContext,
     list: Vec<PoolItem>,
 }
 
-impl IncreaseVolumeReplica {
-    pub(crate) async fn builder(request: impl Into<GetSuitablePools>, registry: &Registry) -> Self {
+impl AddVolumeReplica {
+    async fn builder(request: impl Into<GetSuitablePools>, registry: &Registry) -> Self {
+        let request = request.into();
         Self {
             context: GetSuitablePoolsContext {
                 registry: registry.clone(),
-                spec: request.into().spec,
+                spec: request.spec.clone(),
             },
             list: PoolItemLister::list(registry).await,
         }
     }
+    /// Default rules for pool selection when creating replicas for a volume
     pub(crate) async fn builder_with_defaults(
         request: impl Into<GetSuitablePools>,
         registry: &Registry,
@@ -92,7 +112,7 @@ impl IncreaseVolumeReplica {
 }
 
 #[async_trait::async_trait(?Send)]
-impl ResourceFilter for IncreaseVolumeReplica {
+impl ResourceFilter for AddVolumeReplica {
     type Request = GetSuitablePoolsContext;
     type Item = PoolItem;
 
@@ -123,49 +143,132 @@ impl ResourceFilter for IncreaseVolumeReplica {
     }
 }
 
+/// Decrease a volume's replicas when it exceeds the required count
 #[derive(Clone)]
 pub(crate) struct DecreaseVolumeReplica {
     context: GetChildForRemovalContext,
     list: Vec<ReplicaItem>,
 }
 
+/// Request to decrease volume replicas
+/// Specifies the volume spec, state and whether to only remove currently unused replicas
 #[derive(Clone)]
 pub(crate) struct GetChildForRemoval {
     spec: VolumeSpec,
     state: VolumeState,
+    /// Used when we have more replicas than we need, so we can be picky and try to remove
+    /// unused replicas first (replicas which are not attached to a nexus)
+    unused_only: bool,
 }
 
 impl GetChildForRemoval {
-    pub(crate) fn new(spec: &VolumeSpec, state: &VolumeState) -> Self {
+    /// Return a new `Self` from the provided parameters
+    pub(crate) fn new(spec: &VolumeSpec, state: &VolumeState, unused_only: bool) -> Self {
         Self {
             spec: spec.clone(),
             state: state.clone(),
+            unused_only,
         }
     }
 }
 
+/// Used to filter nexus children in order to choose the best candidates for removal
+/// when the volume's replica count is being reduced.
 #[derive(Clone)]
 pub(crate) struct GetChildForRemovalContext {
-    pub(crate) registry: Registry,
+    registry: Registry,
     spec: VolumeSpec,
+    state: VolumeState,
+    unused_only: bool,
+}
+
+impl GetChildForRemovalContext {
+    async fn list(&self) -> Vec<ReplicaItem> {
+        let replicas = self.registry.specs.get_volume_replicas(&self.spec.uuid);
+        let nexuses = self.registry.specs.get_volume_nexuses(&self.spec.uuid);
+        let replicas = replicas.iter().map(|r| r.lock().clone());
+
+        let replica_states = self.registry.get_replicas().await;
+        replicas
+            .map(|replica_spec| {
+                ReplicaItem::new(
+                    replica_spec.clone(),
+                    replica_states
+                        .iter()
+                        .find(|replica_state| replica_state.uuid == replica_spec.uuid)
+                        .map(|replica_state| {
+                            nexuses
+                                .iter()
+                                .filter_map(|nexus_spec| {
+                                    nexus_spec
+                                        .lock()
+                                        .children
+                                        .iter()
+                                        .find(|child| child.uri() == replica_state.uri)
+                                        .map(|child| child.uri())
+                                })
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default(),
+                    replica_states
+                        .iter()
+                        .find(|replica_state| replica_state.uuid == replica_spec.uuid)
+                        .map(|replica_state| {
+                            self.state
+                                .children
+                                .iter()
+                                .filter_map(|nexus_state| {
+                                    nexus_state
+                                        .children
+                                        .iter()
+                                        .find(|child| child.uri.as_str() == replica_state.uri)
+                                })
+                                .cloned()
+                                .collect::<Vec<_>>()
+                        })
+                        .unwrap_or_default(),
+                    nexuses
+                        .iter()
+                        .filter_map(|nexus_spec| {
+                            nexus_spec
+                                .lock()
+                                .children
+                                .iter()
+                                .find(|child| {
+                                    child.as_replica().map(|uri| uri.uuid().clone())
+                                        == Some(replica_spec.uuid.clone())
+                                })
+                                .cloned()
+                        })
+                        .collect(),
+                )
+            })
+            .collect::<Vec<_>>()
+    }
 }
 
 impl DecreaseVolumeReplica {
-    pub(crate) async fn builder(request: &GetChildForRemoval, registry: &Registry) -> Self {
+    async fn builder(request: &GetChildForRemoval, registry: &Registry) -> Self {
+        let context = GetChildForRemovalContext {
+            registry: registry.clone(),
+            spec: request.spec.clone(),
+            state: request.state.clone(),
+            unused_only: request.unused_only,
+        };
         Self {
-            context: GetChildForRemovalContext {
-                registry: registry.clone(),
-                spec: request.spec.clone(),
-            },
-            list: ReplicaItemLister::list(registry, &request.spec, &request.state).await,
+            list: context.list().await,
+            context,
         }
     }
+    /// Create new `Self` from the given arguments with a default list of filters and sorting rules
     pub(crate) async fn builder_with_defaults(
         request: &GetChildForRemoval,
         registry: &Registry,
     ) -> Self {
         Self::builder(request, registry)
             .await
+            // if requested filter for replicas which are not currently used for a nexus
+            .filter(|request, item| !(request.unused_only && item.child_spec().is_some()))
             .sort(ChildSorters::sort)
     }
 }
@@ -187,6 +290,290 @@ impl ResourceFilter for DecreaseVolumeReplica {
 
     fn sort<P: FnMut(&Self::Item, &Self::Item) -> std::cmp::Ordering>(mut self, sort: P) -> Self {
         self.list = self.list.into_iter().sorted_by(sort).collect();
+        self
+    }
+
+    fn collect(self) -> Vec<Self::Item> {
+        self.list
+    }
+
+    fn group_by<K, V, F: Fn(&Self::Request, &Vec<Self::Item>) -> HashMap<K, V>>(
+        self,
+        group: F,
+    ) -> HashMap<K, V> {
+        group(&self.context, &self.list)
+    }
+}
+
+/// Used to determine the nexus child removal candidates when a nexus has "too many" replicas
+#[derive(Clone)]
+pub(crate) struct GetNexusChildForRemovalContext {
+    registry: Registry,
+    vol_spec: VolumeSpec,
+    nexus_spec: NexusSpec,
+}
+
+/// Decrease a nexus replica count when it has more than required by its volume
+#[derive(Clone)]
+pub(crate) struct DecreaseNexusReplica {
+    context: GetNexusChildForRemovalContext,
+    list: Vec<NexusChildItem>,
+}
+
+impl GetNexusChildForRemovalContext {
+    async fn list(&self) -> Vec<NexusChildItem> {
+        let nexus = self.registry.get_nexus(&self.nexus_spec.uuid).await.ok();
+        let replicas = self.registry.specs.get_volume_replicas(&self.vol_spec.uuid);
+        let mut replicas = replicas.iter().map(|r| r.lock().clone());
+
+        self.nexus_spec
+            .children
+            .iter()
+            .map(|child| {
+                let spec = child
+                    .as_replica()
+                    .map(|r| replicas.find(|s| &s.uuid == r.uuid()))
+                    .flatten();
+                let child_state = nexus
+                    .as_ref()
+                    .map(|n| n.children.iter().find(|c| c.uri == child.uri()));
+
+                NexusChildItem::new(spec, child.uri(), child_state.flatten())
+            })
+            .collect::<Vec<_>>()
+    }
+}
+
+impl DecreaseNexusReplica {
+    async fn builder(vol_spec: &VolumeSpec, nexus_spec: &NexusSpec, registry: &Registry) -> Self {
+        let context = GetNexusChildForRemovalContext {
+            registry: registry.clone(),
+            vol_spec: vol_spec.clone(),
+            nexus_spec: nexus_spec.clone(),
+        };
+        Self {
+            list: context.list().await,
+            context,
+        }
+    }
+    /// Create a new `Self` from the given arguments
+    pub(crate) async fn builder_with_defaults(
+        vol_spec: &VolumeSpec,
+        nexus_spec: &NexusSpec,
+        registry: &Registry,
+    ) -> Self {
+        Self::builder(vol_spec, nexus_spec, registry)
+            .await
+            .sort(NexusChildSorter::sort)
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ResourceFilter for DecreaseNexusReplica {
+    type Request = GetNexusChildForRemovalContext;
+    type Item = NexusChildItem;
+
+    fn filter<P: FnMut(&Self::Request, &Self::Item) -> bool>(mut self, mut filter: P) -> Self {
+        let request = self.context.clone();
+        self.list = self
+            .list
+            .into_iter()
+            .filter(|v| filter(&request, v))
+            .collect();
+        self
+    }
+
+    fn sort<P: FnMut(&Self::Item, &Self::Item) -> std::cmp::Ordering>(mut self, sort: P) -> Self {
+        self.list = self.list.into_iter().sorted_by(sort).collect();
+        self
+    }
+
+    fn collect(self) -> Vec<Self::Item> {
+        self.list
+    }
+
+    fn group_by<K, V, F: Fn(&Self::Request, &Vec<Self::Item>) -> HashMap<K, V>>(
+        self,
+        group: F,
+    ) -> HashMap<K, V> {
+        group(&self.context, &self.list)
+    }
+}
+
+/// `VolumeReplicasForNexusCtx` context used by the filter functions for `AddVolumeNexusReplicas`
+/// which is used to add replicas to a volume nexus
+#[derive(Clone)]
+pub(crate) struct VolumeReplicasForNexusCtx {
+    registry: Registry,
+    vol_spec: VolumeSpec,
+    nexus_spec: NexusSpec,
+    nexus_info: Option<NexusInfo>,
+}
+
+impl VolumeReplicasForNexusCtx {
+    /// Get the volume spec
+    pub(crate) fn vol_spec(&self) -> &VolumeSpec {
+        &self.vol_spec
+    }
+    /// Get the nexus spec
+    pub(crate) fn nexus_spec(&self) -> &NexusSpec {
+        &self.nexus_spec
+    }
+    /// Get the current nexus persistent information
+    #[allow(dead_code)]
+    pub(crate) fn nexus_info(&self) -> &Option<NexusInfo> {
+        &self.nexus_info
+    }
+    /// Get the registry
+    #[allow(dead_code)]
+    pub(crate) fn registry(&self) -> &Registry {
+        &self.registry
+    }
+}
+
+impl VolumeReplicasForNexusCtx {
+    async fn new(
+        registry: &Registry,
+        vol_spec: &VolumeSpec,
+        nx_spec: &NexusSpec,
+    ) -> Result<Self, SvcError> {
+        let nexus_info = match registry
+            .load_obj::<NexusInfo>(&NexusInfoKey::from(&nx_spec.uuid))
+            .await
+        {
+            Ok(mut info) => {
+                info.uuid = nx_spec.uuid.clone();
+                Some(info)
+            }
+            Err(SvcError::StoreMissingEntry { .. }) => None,
+            Err(error) => return Err(error),
+        };
+
+        Ok(Self {
+            registry: registry.clone(),
+            vol_spec: vol_spec.clone(),
+            nexus_spec: nx_spec.clone(),
+            nexus_info,
+        })
+    }
+    async fn list(&self) -> Vec<ChildItem> {
+        // find all replica states
+        let state_replicas = self.registry.get_replicas().await;
+        // find all replica specs which are not yet part of the nexus
+        let spec_replicas = self
+            .registry
+            .specs
+            .get_volume_replicas(&self.vol_spec.uuid)
+            .into_iter()
+            .filter(|r| !self.nexus_spec.contains_replica(&r.lock().uuid));
+        let pool_wrappers = self.registry.get_pool_wrappers().await;
+
+        spec_replicas
+            .filter_map(|replica_spec| {
+                let replica_spec = replica_spec.lock().clone();
+                let replica_state = state_replicas
+                    .iter()
+                    .find(|state| state.uuid == replica_spec.uuid);
+                let child_info = self
+                    .nexus_info
+                    .as_ref()
+                    .map(|n| {
+                        n.children.iter().find(|c| {
+                            if let Some(replica_state) = replica_state {
+                                ChildUri::from(&replica_state.uri).uuid_str().as_ref()
+                                    == Some(&c.uuid)
+                            } else {
+                                false
+                            }
+                        })
+                    })
+                    .flatten();
+
+                pool_wrappers
+                    .iter()
+                    .find(|p| p.id == replica_spec.pool)
+                    .map(|pool| {
+                        replica_state.map(|replica_state| {
+                            ChildItem::new(&replica_spec, replica_state, child_info, pool)
+                        })
+                    })
+                    .flatten()
+            })
+            .collect()
+    }
+}
+
+/// Retrieve a list of healthy replicas to add to a volume nexus.
+#[derive(Clone)]
+pub(crate) struct AddVolumeNexusReplicas {
+    context: VolumeReplicasForNexusCtx,
+    list: Vec<ChildItem>,
+}
+
+impl AddVolumeNexusReplicas {
+    async fn builder(
+        vol_spec: &VolumeSpec,
+        nx_spec: &NexusSpec,
+        registry: &Registry,
+    ) -> Result<Self, SvcError> {
+        let context = VolumeReplicasForNexusCtx::new(registry, vol_spec, nx_spec).await?;
+        let list = context.list().await;
+        Ok(Self { list, context })
+    }
+
+    /// Builder used to retrieve a list of healthy replicas to add to a volume nexus.
+    /// The list follows a set of filters for replicas according to the following
+    /// criteria (any order):
+    /// 1. replicas which are not part of the given nexus already
+    /// 2. use only replicas which report the status of online by their state
+    /// 3. use only replicas which are large enough for the volume
+    /// Sorted by:
+    /// 1. nexus local replicas
+    /// 2. replicas which have never been marked as faulted by mayastor
+    /// 3. replicas from pools with more free space
+    pub(crate) async fn builder_with_defaults(
+        vol_spec: &VolumeSpec,
+        nx_spec: &NexusSpec,
+        registry: &Registry,
+    ) -> Result<Self, SvcError> {
+        Ok(Self::builder(vol_spec, nx_spec, registry)
+            .await?
+            .filter(AddReplicaFilters::online)
+            .filter(AddReplicaFilters::size)
+            .sort_ctx(AddReplicaSorters::sort))
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl ResourceFilter for AddVolumeNexusReplicas {
+    type Request = VolumeReplicasForNexusCtx;
+    type Item = ChildItem;
+
+    fn filter<P: FnMut(&Self::Request, &Self::Item) -> bool>(mut self, mut filter: P) -> Self {
+        let request = self.context.clone();
+        self.list = self
+            .list
+            .into_iter()
+            .filter(|v| filter(&request, v))
+            .collect();
+        self
+    }
+
+    fn sort<P: FnMut(&Self::Item, &Self::Item) -> std::cmp::Ordering>(mut self, sort: P) -> Self {
+        self.list = self.list.into_iter().sorted_by(sort).collect();
+        self
+    }
+
+    fn sort_ctx<P: FnMut(&Self::Request, &Self::Item, &Self::Item) -> std::cmp::Ordering>(
+        mut self,
+        mut sort: P,
+    ) -> Self {
+        let context = self.context.clone();
+        self.list = self
+            .list
+            .into_iter()
+            .sorted_by(|a, b| sort(&context, a, b))
+            .collect();
         self
     }
 

--- a/control-plane/agents/core/src/nexus/service.rs
+++ b/control-plane/agents/core/src/nexus/service.rs
@@ -2,9 +2,12 @@ use crate::core::registry::Registry;
 use common::errors::SvcError;
 use common_lib::{
     mbus_api::message_bus::v0::Nexuses,
-    types::v0::message_bus::{
-        AddNexusChild, Child, CreateNexus, DestroyNexus, Filter, GetNexuses, Nexus,
-        RemoveNexusChild, ShareNexus, UnshareNexus,
+    types::v0::{
+        message_bus::{
+            AddNexusChild, Child, CreateNexus, DestroyNexus, Filter, GetNexuses, Nexus,
+            RemoveNexusChild, ShareNexus, UnshareNexus,
+        },
+        store::OperationMode,
     },
 };
 
@@ -43,7 +46,7 @@ impl Service {
     pub(super) async fn create_nexus(&self, request: &CreateNexus) -> Result<Nexus, SvcError> {
         self.registry
             .specs
-            .create_nexus(&self.registry, request)
+            .create_nexus(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -52,7 +55,7 @@ impl Service {
     pub(super) async fn destroy_nexus(&self, request: &DestroyNexus) -> Result<(), SvcError> {
         self.registry
             .specs
-            .destroy_nexus(&self.registry, request, true)
+            .destroy_nexus(&self.registry, request, true, OperationMode::Exclusive)
             .await
     }
 
@@ -61,7 +64,7 @@ impl Service {
     pub(super) async fn share_nexus(&self, request: &ShareNexus) -> Result<String, SvcError> {
         self.registry
             .specs
-            .share_nexus(&self.registry, request)
+            .share_nexus(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -70,7 +73,7 @@ impl Service {
     pub(super) async fn unshare_nexus(&self, request: &UnshareNexus) -> Result<(), SvcError> {
         self.registry
             .specs
-            .unshare_nexus(&self.registry, request)
+            .unshare_nexus(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -79,7 +82,7 @@ impl Service {
     pub(super) async fn add_nexus_child(&self, request: &AddNexusChild) -> Result<Child, SvcError> {
         self.registry
             .specs
-            .add_nexus_child(&self.registry, request)
+            .add_nexus_child(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -91,7 +94,7 @@ impl Service {
     ) -> Result<(), SvcError> {
         self.registry
             .specs
-            .remove_nexus_child(&self.registry, request)
+            .remove_nexus_child(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 }

--- a/control-plane/agents/core/src/pool/registry.rs
+++ b/control-plane/agents/core/src/pool/registry.rs
@@ -40,6 +40,16 @@ impl Registry {
         Ok(pools)
     }
 
+    /// Get all pool wrappers
+    pub(crate) async fn get_pool_wrappers(&self) -> Vec<PoolWrapper> {
+        let nodes = self.get_node_wrappers().await;
+        let mut pools = vec![];
+        for node in nodes {
+            pools.append(&mut node.pool_wrappers().await)
+        }
+        pools
+    }
+
     /// Get all pools from node `node_id`
     pub(crate) async fn get_node_pools(&self, node_id: &NodeId) -> Result<Vec<Pool>, SvcError> {
         let node = self.get_node_wrapper(node_id).await?;

--- a/control-plane/agents/core/src/pool/service.rs
+++ b/control-plane/agents/core/src/pool/service.rs
@@ -2,9 +2,12 @@ use crate::core::{registry::Registry, wrapper::GetterOps};
 use common::errors::{PoolNotFound, ReplicaNotFound, SvcError};
 use common_lib::{
     mbus_api::message_bus::v0::{Pools, Replicas},
-    types::v0::message_bus::{
-        CreatePool, CreateReplica, DestroyPool, DestroyReplica, Filter, GetPools, GetReplicas,
-        NodeId, Pool, PoolId, Replica, ShareReplica, UnshareReplica,
+    types::v0::{
+        message_bus::{
+            CreatePool, CreateReplica, DestroyPool, DestroyReplica, Filter, GetPools, GetReplicas,
+            NodeId, Pool, PoolId, Replica, ShareReplica, UnshareReplica,
+        },
+        store::OperationMode,
     },
 };
 use snafu::OptionExt;
@@ -128,7 +131,7 @@ impl Service {
     pub(super) async fn create_pool(&self, request: &CreatePool) -> Result<Pool, SvcError> {
         self.registry
             .specs
-            .create_pool(&self.registry, request)
+            .create_pool(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -137,7 +140,7 @@ impl Service {
     pub(super) async fn destroy_pool(&self, request: &DestroyPool) -> Result<(), SvcError> {
         self.registry
             .specs
-            .destroy_pool(&self.registry, request)
+            .destroy_pool(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -149,7 +152,7 @@ impl Service {
     ) -> Result<Replica, SvcError> {
         self.registry
             .specs
-            .create_replica(&self.registry, request)
+            .create_replica(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -158,7 +161,7 @@ impl Service {
     pub(super) async fn destroy_replica(&self, request: &DestroyReplica) -> Result<(), SvcError> {
         self.registry
             .specs
-            .destroy_replica(&self.registry, request, true)
+            .destroy_replica(&self.registry, request, false, OperationMode::Exclusive)
             .await
     }
 
@@ -167,7 +170,7 @@ impl Service {
     pub(super) async fn share_replica(&self, request: &ShareReplica) -> Result<String, SvcError> {
         self.registry
             .specs
-            .share_replica(&self.registry, request)
+            .share_replica(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -176,7 +179,7 @@ impl Service {
     pub(super) async fn unshare_replica(&self, request: &UnshareReplica) -> Result<(), SvcError> {
         self.registry
             .specs
-            .unshare_replica(&self.registry, request)
+            .unshare_replica(&self.registry, request, OperationMode::Exclusive)
             .await?;
         Ok(())
     }

--- a/control-plane/agents/core/src/server.rs
+++ b/control-plane/agents/core/src/server.rs
@@ -59,9 +59,15 @@ pub(crate) struct CliArgs {
 
 fn init_tracing() {
     if let Ok(filter) = tracing_subscriber::EnvFilter::try_from_default_env() {
-        tracing_subscriber::fmt().with_env_filter(filter).init();
+        tracing_subscriber::fmt()
+            .pretty()
+            .with_env_filter(filter)
+            .init();
     } else {
-        tracing_subscriber::fmt().with_env_filter("info").init();
+        tracing_subscriber::fmt()
+            .pretty()
+            .with_env_filter("info")
+            .init();
     }
 }
 

--- a/control-plane/agents/core/src/volume/service.rs
+++ b/control-plane/agents/core/src/volume/service.rs
@@ -2,9 +2,12 @@ use crate::core::registry::Registry;
 use common::errors::SvcError;
 use common_lib::{
     mbus_api::message_bus::v0::Volumes,
-    types::v0::message_bus::{
-        CreateVolume, DestroyVolume, Filter, GetVolumes, PublishVolume, SetVolumeReplica,
-        ShareVolume, UnpublishVolume, UnshareVolume, Volume,
+    types::v0::{
+        message_bus::{
+            CreateVolume, DestroyVolume, Filter, GetVolumes, PublishVolume, SetVolumeReplica,
+            ShareVolume, UnpublishVolume, UnshareVolume, Volume,
+        },
+        store::OperationMode,
     },
 };
 
@@ -42,7 +45,7 @@ impl Service {
     pub(super) async fn create_volume(&self, request: &CreateVolume) -> Result<Volume, SvcError> {
         self.registry
             .specs
-            .create_volume(&self.registry, request)
+            .create_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -51,7 +54,7 @@ impl Service {
     pub(super) async fn destroy_volume(&self, request: &DestroyVolume) -> Result<(), SvcError> {
         self.registry
             .specs
-            .destroy_volume(&self.registry, request)
+            .destroy_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -60,7 +63,7 @@ impl Service {
     pub(super) async fn share_volume(&self, request: &ShareVolume) -> Result<String, SvcError> {
         self.registry
             .specs
-            .share_volume(&self.registry, request)
+            .share_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -69,7 +72,7 @@ impl Service {
     pub(super) async fn unshare_volume(&self, request: &UnshareVolume) -> Result<(), SvcError> {
         self.registry
             .specs
-            .unshare_volume(&self.registry, request)
+            .unshare_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -78,7 +81,7 @@ impl Service {
     pub(super) async fn publish_volume(&self, request: &PublishVolume) -> Result<Volume, SvcError> {
         self.registry
             .specs
-            .publish_volume(&self.registry, request)
+            .publish_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -90,7 +93,7 @@ impl Service {
     ) -> Result<Volume, SvcError> {
         self.registry
             .specs
-            .unpublish_volume(&self.registry, request)
+            .unpublish_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 
@@ -102,7 +105,7 @@ impl Service {
     ) -> Result<Volume, SvcError> {
         self.registry
             .specs
-            .set_volume_replica(&self.registry, request)
+            .set_volume_replica(&self.registry, request, OperationMode::Exclusive)
             .await
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -5769,7 +5769,7 @@ components:
       example:
         grpcEndpoint: '10.1.0.5:10124'
         id: ksnode-1
-        state: Online
+        status: Online
       description: mayastor storage node information
       type: object
       properties:
@@ -6258,15 +6258,14 @@ components:
         - uuid
     VolumeSpec:
       example:
-        labels:
-          - ''
+        labels: null
         num_paths: 1
         num_replicas: 2
         operation: null
         protocol: none
         size: 80241024
         state: Created
-        target_node: null
+        target_node: ksnode-1
         uuid: 514ed1c8-7174-49ac-b9cd-ad44ef670a67
       description: User specification of a volume.
       type: object
@@ -6348,10 +6347,10 @@ components:
       description: current volume status
       type: string
       enum:
+        - Unknown
         - Online
         - Degraded
         - Faulted
-        - Unknown
     VolumeShareProtocol:
       description: Volume Share Protocol
       type: string
@@ -6403,7 +6402,7 @@ components:
             uuid: 61d6afc8-15c6-4127-b0aa-15a570198880
         protocol: none
         size: 80241024
-        state: Online
+        status: Online
         uuid: 4be37dbd-4b60-44f3-b807-08f6693522ac
       description: Runtime state of the volume
       type: object
@@ -6432,35 +6431,8 @@ components:
         - size
         - state
         - uuid
+        - status
     Volume:
-      example:
-        spec:
-          - labels: ''
-            num_paths: 1
-            num_replicas: 2
-            operation: null
-            protocol: none
-            size: 80241024
-            state: Created
-            target_node: null
-            uuid: 514ed1c8-7174-49ac-b9cd-ad44ef670a67
-        state:
-          - children:
-            - children:
-                - rebuildProgress: null
-                  state: Online
-                  uri: 'nvmf://10.1.0.5:8420/nqn.2019-05.io.openebs:nexus-a76adcd6-9df0-47a1-90a5-2d5bf4151572'
-              deviceUri: ''
-              node: ksnode-1
-              rebuilds: 0
-              share: none
-              size: 80241024
-              state: Online
-              uuid: 61d6afc8-15c6-4127-b0aa-15a570198880
-            protocol: none
-            size: 80241024
-            state: Online
-            uuid: 4be37dbd-4b60-44f3-b807-08f6693522ac
       description: |-
         Volumes
         Volume information

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -514,7 +514,7 @@ impl RestClient for ActixRestClient {
     }
 
     async fn destroy_volume(&self, args: DestroyVolume) -> ClientResult<()> {
-        let urn = format!("/v0/volumes/{}", &args.uuid);
+        let urn = format!("/v0/volumes/{}", &args.uuid());
         self.del(urn).await?;
         Ok(())
     }

--- a/deployer/src/infra/etcd.rs
+++ b/deployer/src/infra/etcd.rs
@@ -35,6 +35,13 @@ impl ComponentAction for Etcd {
             let mut store = EtcdStore::new("0.0.0.0:2379")
                 .await
                 .expect("Failed to connect to etcd.");
+
+            if !store.online().await {
+                // we seem to get in this situation on CI, let's log the result of a get key
+                // in case the result will be helpful
+                let result = store.get_kv(&"a".to_string()).await;
+                panic!("etcd get_kv result: {:#?}", result);
+            }
             assert!(store.online().await);
         }
         Ok(())

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -230,6 +230,14 @@ macro_rules! impl_component {
         pub struct Components(Vec<Component>, StartOptions);
         impl BuilderConfigure for Components {
             fn configure(&self, cfg: Builder) -> Result<Builder, Error> {
+                if self.1.build_all {
+                    let path = std::path::PathBuf::from(std::env!("CARGO_MANIFEST_DIR"));
+                    let status = std::process::Command::new("cargo")
+                        .current_dir(path.parent().expect("main workspace"))
+                        .args(&["build", "--bins"])
+                        .status()?;
+                    build_error("all the workspace binaries", status.code())?;
+                }
                 let mut cfg = cfg;
                 for component in &self.0 {
                     cfg = component.configure(&self.1, cfg)?;

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -94,6 +94,10 @@ pub struct StartOptions {
     #[structopt(short, long)]
     pub build: bool,
 
+    /// Cargo Build the workspace before deploying
+    #[structopt(long)]
+    pub build_all: bool,
+
     /// Use a dns resolver for the cluster: defreitas/dns-proxy-server
     /// Note this messes with your /etc/resolv.conf so use at your own risk
     #[structopt(short, long)]
@@ -179,6 +183,10 @@ impl StartOptions {
     }
     pub fn with_build(mut self, build: bool) -> Self {
         self.build = build;
+        self
+    }
+    pub fn with_build_all(mut self, build: bool) -> Self {
+        self.build_all = build;
         self
     }
     pub fn with_mayastors(mut self, mayastors: u32) -> Self {

--- a/openapi/api/openapi.yaml
+++ b/openapi/api/openapi.yaml
@@ -5897,7 +5897,7 @@ components:
       example:
         grpcEndpoint: 10.1.0.5:10124
         id: ksnode-1
-        state: Online
+        status: Online
       properties:
         grpcEndpoint:
           description: gRPC endpoint of the mayastor instance
@@ -5920,7 +5920,7 @@ components:
         state:
           grpcEndpoint: 10.1.0.5:10124
           id: ksnode-1
-          state: Online
+          status: Online
         spec:
           grpcEndpoint: 10.1.0.5:10124
           id: ksnode-1
@@ -6329,15 +6329,14 @@ components:
     VolumeSpec:
       description: User specification of a volume.
       example:
-        labels:
-        - ""
+        labels: null
         num_paths: 1
         num_replicas: 2
         operation: null
         protocol: none
         size: 80241024
         state: Created
-        target_node: null
+        target_node: ksnode-1
         uuid: 514ed1c8-7174-49ac-b9cd-ad44ef670a67
       properties:
         labels:
@@ -6395,10 +6394,10 @@ components:
     VolumeStatus:
       description: current volume status
       enum:
+      - Unknown
       - Online
       - Degraded
       - Faulted
-      - Unknown
       type: string
     VolumeShareProtocol:
       description: Volume Share Protocol
@@ -6452,7 +6451,7 @@ components:
           uuid: 61d6afc8-15c6-4127-b0aa-15a570198880
         protocol: none
         size: 80241024
-        state: Online
+        status: Online
         uuid: 4be37dbd-4b60-44f3-b807-08f6693522ac
       properties:
         children:
@@ -6478,6 +6477,7 @@ components:
       - protocol
       - size
       - state
+      - status
       - uuid
       type: object
     Volume:
@@ -6485,18 +6485,8 @@ components:
         Volumes
         Volume information
       example:
-        spec:
-        - labels: ""
-          num_paths: 1
-          num_replicas: 2
-          operation: null
-          protocol: none
-          size: 80241024
-          state: Created
-          target_node: null
-          uuid: 514ed1c8-7174-49ac-b9cd-ad44ef670a67
         state:
-        - children:
+          children:
           - children:
             - rebuildProgress: null
               state: Online
@@ -6510,8 +6500,18 @@ components:
             uuid: 61d6afc8-15c6-4127-b0aa-15a570198880
           protocol: none
           size: 80241024
-          state: Online
+          status: Online
           uuid: 4be37dbd-4b60-44f3-b807-08f6693522ac
+        spec:
+          labels: null
+          num_paths: 1
+          num_replicas: 2
+          operation: null
+          protocol: none
+          size: 80241024
+          state: Created
+          target_node: ksnode-1
+          uuid: 514ed1c8-7174-49ac-b9cd-ad44ef670a67
       properties:
         spec:
           $ref: '#/components/schemas/VolumeSpec'

--- a/openapi/docs/models/VolumeState.md
+++ b/openapi/docs/models/VolumeState.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **children** | [**Vec<crate::models::Nexus>**](Nexus.md) | array of children nexuses | 
 **protocol** | [**crate::models::Protocol**](Protocol.md) |  | 
 **size** | **u64** | size of the volume in bytes | 
-**status** | Option<[**crate::models::VolumeStatus**](VolumeStatus.md)> |  | [optional]
+**status** | [**crate::models::VolumeStatus**](VolumeStatus.md) |  | 
 **uuid** | [**uuid::Uuid**](uuid::Uuid.md) | name of the volume | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/openapi/src/models/volume_state.rs
+++ b/openapi/src/models/volume_state.rs
@@ -27,8 +27,8 @@ pub struct VolumeState {
     /// size of the volume in bytes
     #[serde(rename = "size")]
     pub size: u64,
-    #[serde(rename = "status", skip_serializing_if = "Option::is_none")]
-    pub status: Option<crate::models::VolumeStatus>,
+    #[serde(rename = "status")]
+    pub status: crate::models::VolumeStatus,
     /// name of the volume
     #[serde(rename = "uuid")]
     pub uuid: uuid::Uuid,
@@ -40,13 +40,14 @@ impl VolumeState {
         children: impl IntoVec<crate::models::Nexus>,
         protocol: impl Into<crate::models::Protocol>,
         size: impl Into<u64>,
+        status: impl Into<crate::models::VolumeStatus>,
         uuid: impl Into<uuid::Uuid>,
     ) -> VolumeState {
         VolumeState {
             children: children.into_vec(),
             protocol: protocol.into(),
             size: size.into(),
-            status: None,
+            status: status.into(),
             uuid: uuid.into(),
         }
     }
@@ -55,7 +56,7 @@ impl VolumeState {
         children: impl IntoVec<crate::models::Nexus>,
         protocol: impl Into<crate::models::Protocol>,
         size: impl Into<u64>,
-        status: impl Into<Option<crate::models::VolumeStatus>>,
+        status: impl Into<crate::models::VolumeStatus>,
         uuid: impl Into<uuid::Uuid>,
     ) -> VolumeState {
         VolumeState {

--- a/openapi/src/models/volume_status.rs
+++ b/openapi/src/models/volume_status.rs
@@ -19,29 +19,29 @@ use crate::apis::IntoVec;
 /// current volume status
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum VolumeStatus {
+    #[serde(rename = "Unknown")]
+    Unknown,
     #[serde(rename = "Online")]
     Online,
     #[serde(rename = "Degraded")]
     Degraded,
     #[serde(rename = "Faulted")]
     Faulted,
-    #[serde(rename = "Unknown")]
-    Unknown,
 }
 
 impl ToString for VolumeStatus {
     fn to_string(&self) -> String {
         match self {
+            Self::Unknown => String::from("Unknown"),
             Self::Online => String::from("Online"),
             Self::Degraded => String::from("Degraded"),
             Self::Faulted => String::from("Faulted"),
-            Self::Unknown => String::from("Unknown"),
         }
     }
 }
 
 impl Default for VolumeStatus {
     fn default() -> Self {
-        Self::Online
+        Self::Unknown
     }
 }

--- a/tests-mayastor/src/lib.rs
+++ b/tests-mayastor/src/lib.rs
@@ -37,6 +37,7 @@ pub fn default_options() -> StartOptions {
         .with_mayastors(1)
         .with_show_info(true)
         .with_cluster_name("rest_cluster")
+        .with_build_all(true)
 }
 
 /// Cluster with the composer, the rest client and the jaeger pipeline#
@@ -325,6 +326,16 @@ impl ClusterBuilder {
     /// Specify whether rest is enabled or not
     pub fn with_rest(mut self, enabled: bool) -> Self {
         self.opts = self.opts.with_rest(enabled);
+        self
+    }
+    /// Specify whether the components should be cargo built or not
+    pub fn with_build(mut self, enabled: bool) -> Self {
+        self.opts = self.opts.with_build(enabled);
+        self
+    }
+    /// Specify whether the workspace binaries should be cargo built or not
+    pub fn with_build_all(mut self, enabled: bool) -> Self {
+        self.opts = self.opts.with_build_all(enabled);
         self
     }
     /// Build into the resulting Cluster using a composer closure, eg:


### PR DESCRIPTION
fix: openapi volume status is required

feat(tests): build the binaries before running the cargo tests
Means we don't have to remember to build the agents&rest before running cargo test.

feat: implement volume hotspare reconciliation
Implements the hotspare reconciliation logic for volumes.
The logic is broken down in two:
1. reconcile the nexus which belongs to a volume (handles faulty children, etc)
2. reconcile the number of volume replicas (to match the user spec)

The work done is controlled by the status of the volume. This needs to be refined
as per: cas 1055.