### PR TITLE
feat: improve tracing of volumes, nexus and operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ dependencies = [
  "actix-web",
  "awc",
  "futures",
- "opentelemetry 0.15.0",
+ "opentelemetry",
  "opentelemetry-semantic-conventions",
  "serde",
 ]
@@ -245,6 +245,8 @@ dependencies = [
  "lazy_static",
  "nats",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry-jaeger",
  "parking_lot",
  "paste",
  "reqwest",
@@ -259,6 +261,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-futures",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
 ]
@@ -929,7 +932,7 @@ dependencies = [
  "common-lib",
  "composer",
  "deployer",
- "opentelemetry 0.15.0",
+ "opentelemetry",
  "opentelemetry-jaeger",
  "rest",
  "tracing",
@@ -2001,23 +2004,6 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492848ff47f11b7f9de0443b404e2c5775f695e1af6b7076ca25f999581d547a"
-dependencies = [
- "async-trait",
- "crossbeam-channel 0.5.1",
- "futures",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand 0.8.4",
- "thiserror",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff27b33e30432e7b9854936693ca103d8591b0501f7ae9f633de48cda3bf2a67"
@@ -2045,7 +2031,7 @@ checksum = "09a9fc8192722e7daa0c56e59e2336b797122fb8598383dcb11c8852733b435c"
 dependencies = [
  "async-trait",
  "lazy_static",
- "opentelemetry 0.15.0",
+ "opentelemetry",
  "thiserror",
  "thrift",
  "tokio",
@@ -2057,7 +2043,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "748502c9b5621d7f0fe9cf26cb75bc773a04ce8f1c2b9ce44c3e01045aac6b6d"
 dependencies = [
- "opentelemetry 0.15.0",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -2496,7 +2482,7 @@ dependencies = [
  "futures",
  "http",
  "jsonwebtoken",
- "opentelemetry 0.15.0",
+ "opentelemetry",
  "opentelemetry-jaeger",
  "rpc",
  "rustls 0.19.1",
@@ -3479,11 +3465,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2f4cb277b92a8ba1170b3b911056428ce2ef9993351baf5965bb0359a2e5963"
+checksum = "c47440f2979c4cd3138922840eec122e3c0ba2148bc290f756bd7fd60fc97fff"
 dependencies = [
- "opentelemetry 0.14.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/common/src/types/v0/store/volume.rs
+++ b/common/src/types/v0/store/volume.rs
@@ -127,6 +127,17 @@ impl VolumeSpec {
             .unwrap_or_default()
             .allowed_nodes
     }
+    /// target volume replica count if during `SetReplica` operation
+    /// or otherwise the current num_replicas
+    pub fn target_num_replicas(&self) -> u8 {
+        match &self.operation {
+            Some(operation) => match operation.operation {
+                VolumeOperation::SetReplica(count) => count,
+                _ => self.num_replicas,
+            },
+            _ => self.num_replicas,
+        }
+    }
 }
 
 impl UuidString for VolumeSpec {

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -30,9 +30,6 @@ snafu = "0.6"
 lazy_static = "1.4.0"
 humantime = "2.0.1"
 state = "0.4.2"
-tracing = "0.1"
-tracing-subscriber = "0.2"
-tracing-futures = "0.2.4"
 rpc = "0.1.0"
 http = "0.2.3"
 paste = "1.0.4"
@@ -41,10 +38,13 @@ reqwest = "0.11.4"
 parking_lot = "0.11.1"
 itertools = "0.10.0"
 
-# todo: tracing
-#opentelemetry-jaeger = { version = "0.14", features = ["tokio"] }
-#tracing-opentelemetry = "0.14.0"
-#opentelemetry = "0.15.0"
+# Tracing
+opentelemetry-jaeger = { version = "0.14", features = ["tokio"] }
+tracing-opentelemetry = "0.14.0"
+opentelemetry = "0.15.0"
+tracing = "0.1"
+tracing-subscriber = "0.2"
+tracing-futures = "0.2.4"
 
 [dev-dependencies]
 composer = { path = "../../composer" }

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -468,7 +468,7 @@ impl From<SvcError> for ReplyError {
             },
             SvcError::LastHealthyReplica { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
-                resource: ResourceKind::ReplicaSpec,
+                resource: ResourceKind::Volume,
                 source: desc.to_string(),
                 extra: error.full_string(),
             },

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -151,8 +151,14 @@ pub enum SvcError {
     InUse { kind: ResourceKind, id: String },
     #[snafu(display("{} Resource id {} already exists", kind.to_string(), id))]
     AlreadyExists { kind: ResourceKind, id: String },
-    #[snafu(display("Cannot remove the last replica of volume '{}'", id))]
-    LastReplica { id: String },
+    #[snafu(display("Cannot remove the last replica '{}' of volume '{}'", replica, volume))]
+    LastReplica { replica: String, volume: String },
+    #[snafu(display(
+        "Cannot remove the last healthy replica '{}' of volume '{}'",
+        replica,
+        volume
+    ))]
+    LastHealthyReplica { replica: String, volume: String },
     #[snafu(display("Replica count of Volume '{}' is already '{}'", id, count))]
     ReplicaCountAchieved { id: String, count: u8 },
     #[snafu(display("Replica count only allowed to change by a maximum of one at a time"))]
@@ -457,6 +463,12 @@ impl From<SvcError> for ReplyError {
             SvcError::LastReplica { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
                 resource: ResourceKind::Volume,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+            SvcError::LastHealthyReplica { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPrecondition,
+                resource: ResourceKind::ReplicaSpec,
                 source: desc.to_string(),
                 extra: error.full_string(),
             },

--- a/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
@@ -4,42 +4,40 @@ use common_lib::{
     types::v0::store::{nexus::NexusSpec, OperationMode},
 };
 
+use common_lib::types::v0::store::{TraceSpan, TraceStrLog};
 use parking_lot::Mutex;
 use std::sync::Arc;
 
 /// Find and removes faulted children from the given nexus
 /// If the child is a replica it also disowns and destroys it
+#[tracing::instrument(skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid))]
 pub(super) async fn faulted_children_remover(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
     mode: OperationMode,
 ) -> PollResult {
-    let nexus_uuid = nexus_spec.lock().uuid.clone();
+    let nexus_spec_clone = nexus_spec.lock().clone();
+    let nexus_uuid = nexus_spec_clone.uuid.clone();
     let nexus_state = context.registry().get_nexus(&nexus_uuid).await?;
     for child in nexus_state.children.iter().filter(|c| c.state.faulted()) {
-        tracing::warn!(
-            "Faulted child '{}' of Nexus '{}' needs to be replaced",
-            child.uri,
-            nexus_spec.lock().uuid
-        );
+        nexus_spec_clone
+            .warn_span(|| tracing::warn!("Attempting to remove faulted child '{}'", child.uri));
         if let Err(error) = context
             .registry()
             .specs
             .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, true, mode)
             .await
         {
-            tracing::error!(
-                "Failed to remove faulted child '{}' of nexus '{}', error: '{}'",
+            nexus_spec_clone.error(&format!(
+                "Failed to remove faulted child '{}', error: '{}'",
                 child.uri,
-                nexus_state.uuid,
                 error.full_string(),
-            );
+            ));
         } else {
-            tracing::info!(
-                "Successfully removed faulted child '{}' of Nexus '{}'.",
+            nexus_spec_clone.info(&format!(
+                "Successfully removed faulted child '{}'",
                 child.uri,
-                nexus_spec.lock().uuid
-            );
+            ));
         }
     }
 
@@ -48,40 +46,37 @@ pub(super) async fn faulted_children_remover(
 
 /// Find and removes unknown children from the given nexus
 /// If the child is a replica it also disowns and destroys it
+#[tracing::instrument(skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid))]
 pub(super) async fn unknown_children_remover(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
     mode: OperationMode,
 ) -> PollResult {
-    let nexus_uuid = nexus_spec.lock().uuid.clone();
+    let nexus_spec_clone = nexus_spec.lock().clone();
+    let nexus_uuid = nexus_spec_clone.uuid.clone();
     let nexus_state = context.registry().get_nexus(&nexus_uuid).await?;
     let state_children = nexus_state.children.iter();
     let spec_children = nexus_spec.lock().children.clone();
 
     for child in state_children.filter(|c| !spec_children.iter().any(|spec| spec.uri() == c.uri)) {
-        tracing::warn!(
-            "Unknown child '{}' of Nexus '{}' needs to be removed",
-            child.uri,
-            nexus_spec.lock().uuid
-        );
+        nexus_spec_clone
+            .warn_span(|| tracing::warn!("Attempting to remove unknown child '{}'", child.uri));
         if let Err(error) = context
             .registry()
             .specs
             .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, false, mode)
             .await
         {
-            tracing::error!(
-                "Failed to remove unknown child '{}' of Nexus '{}', error: '{}'",
+            nexus_spec_clone.error(&format!(
+                "Failed to remove unknown child '{}', error: '{}'",
                 child.uri,
-                nexus_state.uuid,
                 error.full_string(),
-            );
+            ));
         } else {
-            tracing::info!(
-                "Successfully removed unknown child '{}' of Nexus '{}'.",
+            nexus_spec_clone.info(&format!(
+                "Successfully removed unknown child '{}'",
                 child.uri,
-                nexus_spec.lock().uuid
-            );
+            ));
         }
     }
 
@@ -91,12 +86,14 @@ pub(super) async fn unknown_children_remover(
 /// Find missing children from the given nexus
 /// They are removed from the spec as we don't know why they got removed, so it's safer
 /// to just disown and destroy them.
+#[tracing::instrument(skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid))]
 pub(super) async fn missing_children_remover(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
     mode: OperationMode,
 ) -> PollResult {
-    let nexus_uuid = nexus_spec.lock().uuid.clone();
+    let nexus_spec_clone = nexus_spec.lock().clone();
+    let nexus_uuid = nexus_spec_clone.uuid.clone();
     let nexus_state = context.registry().get_nexus(&nexus_uuid).await?;
     let spec_children = nexus_spec.lock().children.clone().into_iter();
 
@@ -104,11 +101,10 @@ pub(super) async fn missing_children_remover(
     for child in
         spec_children.filter(|spec| !nexus_state.children.iter().any(|c| c.uri == spec.uri()))
     {
-        tracing::warn!(
-            "Child '{}' is missing from Nexus '{}'. It may have been removed for a reason so it will be replaced with another",
+        nexus_spec_clone.warn_span(|| tracing::warn!(
+            "Attempting to remove missing child '{}'. It may have been removed for a reason so it will be replaced with another",
             child.uri(),
-            nexus_spec.lock().uuid
-        );
+        ));
 
         if let Err(error) = context
             .registry()
@@ -116,13 +112,21 @@ pub(super) async fn missing_children_remover(
             .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri(), true, mode)
             .await
         {
-            tracing::error!(
-                "Failed to remove child '{}' from the spec of nexus '{}', error: '{}'",
-                child.uri(),
-                nexus_state.uuid,
-                error.full_string(),
-            );
+            nexus_spec_clone.error_span(|| {
+                tracing::error!(
+                    "Failed to remove child '{}' from the nexus spec, error: '{}'",
+                    child.uri(),
+                    error.full_string(),
+                )
+            });
             result = PollResult::Err(error);
+        } else {
+            nexus_spec_clone.info_span(|| {
+                tracing::info!(
+                    "Successfully removed missing child '{}' from the nexus spec",
+                    child.uri(),
+                )
+            });
         }
     }
 

--- a/control-plane/agents/core/src/core/reconciler/poller.rs
+++ b/control-plane/agents/core/src/core/reconciler/poller.rs
@@ -55,7 +55,6 @@ impl ReconcilerWorker {
 impl ReconcilerWorker {
     /// Start polling the registered reconciliation loops
     /// The polling will continue until we receive the shutdown signal
-    #[tracing::instrument(skip(registry))]
     pub(super) async fn poller(mut self, registry: Registry) {
         // kick-off the first run
         let mut event = PollEvent::TimedRun;
@@ -88,6 +87,7 @@ impl ReconcilerWorker {
         }
     }
 
+    #[tracing::instrument(skip(context), level = "trace", err)]
     async fn poller_work(&mut self, context: PollContext) -> PollResult {
         tracing::trace!("Entering the reconcile loop...");
         let mut results = vec![];

--- a/control-plane/agents/core/src/core/scheduling/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/mod.rs
@@ -89,7 +89,7 @@ impl ChildSorters {
     /// Sort replicas by their nexus child (state and rebuild progress)
     /// todo: should we use weights instead (like moac)?
     pub(crate) fn sort(a: &ReplicaItem, b: &ReplicaItem) -> std::cmp::Ordering {
-        match Self::sort_by_healthy(a, b) {
+        match Self::sort_by_health(a, b) {
             Ordering::Equal => match Self::sort_by_child(a, b) {
                 Ordering::Equal => {
                     let childa_is_local = !a.spec().share.shared();
@@ -107,13 +107,13 @@ impl ChildSorters {
             ord => ord,
         }
     }
-    // remove unhealthy replicas first
-    fn sort_by_healthy(a: &ReplicaItem, b: &ReplicaItem) -> std::cmp::Ordering {
+    // sort replicas by their health: prefer healthy replicas over unhealthy
+    fn sort_by_health(a: &ReplicaItem, b: &ReplicaItem) -> std::cmp::Ordering {
         match a.child_info() {
             None => {
                 match b.child_info() {
                     Some(b_info) if b_info.healthy => {
-                        // remove unhealthy replicas first
+                        // sort replicas by their health: prefer healthy replicas over unhealthy
                         std::cmp::Ordering::Less
                     }
                     _ => std::cmp::Ordering::Equal,

--- a/control-plane/agents/core/src/core/scheduling/nexus.rs
+++ b/control-plane/agents/core/src/core/scheduling/nexus.rs
@@ -7,10 +7,7 @@ use crate::core::{
 use common::errors::SvcError;
 use common_lib::types::v0::{
     message_bus::{ChildUri, NodeId},
-    store::{
-        nexus_persistence::{NexusInfo, NexusInfoKey},
-        volume::VolumeSpec,
-    },
+    store::{nexus_persistence::NexusInfo, volume::VolumeSpec},
 };
 use itertools::Itertools;
 use std::collections::HashMap;
@@ -62,14 +59,9 @@ impl GetPersistedNexusChildrenCtx {
         request: &GetPersistedNexusChildren,
     ) -> Result<Self, SvcError> {
         let spec = request.spec.clone();
-        let nexus_info = if let Some(nexus_id) = &spec.last_nexus_id {
-            let mut nexus_info: NexusInfo =
-                registry.load_obj(&NexusInfoKey::from(nexus_id)).await?;
-            nexus_info.uuid = nexus_id.clone();
-            Some(nexus_info)
-        } else {
-            None
-        };
+        let nexus_info = registry
+            .get_nexus_info(spec.last_nexus_id.as_ref(), false)
+            .await?;
 
         Ok(Self {
             registry: registry.clone(),

--- a/control-plane/agents/core/src/core/scheduling/resources/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/resources/mod.rs
@@ -51,7 +51,7 @@ impl PoolItemLister {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ReplicaItem {
-    replica: ReplicaSpec,
+    replica_spec: ReplicaSpec,
     replica_state: Option<Replica>,
     child_uri: Option<ChildUri>,
     child_state: Option<Child>,
@@ -70,7 +70,7 @@ impl ReplicaItem {
         child_info: Option<ChildInfo>,
     ) -> Self {
         Self {
-            replica,
+            replica_spec: replica,
             replica_state: replica_state.cloned(),
             child_uri: child_uri.first().cloned(),
             // ANA not currently supported
@@ -81,7 +81,7 @@ impl ReplicaItem {
     }
     /// Get a reference to the replica spec
     pub(crate) fn spec(&self) -> &ReplicaSpec {
-        &self.replica
+        &self.replica_spec
     }
     /// Get a reference to the replica state
     pub(crate) fn state(&self) -> Option<&Replica> {

--- a/control-plane/agents/core/src/core/scheduling/resources/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/resources/mod.rs
@@ -52,30 +52,40 @@ impl PoolItemLister {
 #[derive(Debug, Clone)]
 pub(crate) struct ReplicaItem {
     replica: ReplicaSpec,
+    replica_state: Option<Replica>,
     child_uri: Option<ChildUri>,
     child_state: Option<Child>,
     child_spec: Option<NexusChild>,
+    child_info: Option<ChildInfo>,
 }
 
 impl ReplicaItem {
     /// Create new `Self` from the provided arguments
     pub(crate) fn new(
         replica: ReplicaSpec,
+        replica_state: Option<&Replica>,
         child_uri: Vec<ChildUri>,
         child_states: Vec<Child>,
         child_specs: Vec<NexusChild>,
+        child_info: Option<ChildInfo>,
     ) -> Self {
         Self {
             replica,
+            replica_state: replica_state.cloned(),
             child_uri: child_uri.first().cloned(),
             // ANA not currently supported
             child_state: child_states.first().cloned(),
             child_spec: child_specs.first().cloned(),
+            child_info,
         }
     }
     /// Get a reference to the replica spec
     pub(crate) fn spec(&self) -> &ReplicaSpec {
         &self.replica
+    }
+    /// Get a reference to the replica state
+    pub(crate) fn state(&self) -> Option<&Replica> {
+        self.replica_state.as_ref()
     }
     /// Get a reference to the child spec
     pub(crate) fn uri(&self) -> &Option<ChildUri> {
@@ -88,6 +98,10 @@ impl ReplicaItem {
     /// Get a reference to the child spec
     pub(crate) fn child_spec(&self) -> Option<&NexusChild> {
         self.child_spec.as_ref()
+    }
+    /// Get a reference to the child info
+    pub(crate) fn child_info(&self) -> Option<&ChildInfo> {
+        self.child_info.as_ref()
     }
 }
 
@@ -149,40 +163,5 @@ impl ChildItem {
     /// Get the pool wrapper
     pub(crate) fn pool(&self) -> &PoolWrapper {
         &self.pool_state
-    }
-}
-
-/// Nexus Child Items, used to filter nexus children for removal operations
-#[derive(Debug, Clone)]
-pub(crate) struct NexusChildItem {
-    replica: Option<ReplicaSpec>,
-    child_uri: ChildUri,
-    child_state: Option<Child>,
-}
-
-impl NexusChildItem {
-    /// Create new `Self` from the provided arguments
-    pub(crate) fn new(
-        replica: Option<ReplicaSpec>,
-        child_uri: ChildUri,
-        child_state: Option<&Child>,
-    ) -> Self {
-        Self {
-            replica,
-            child_uri,
-            child_state: child_state.cloned(),
-        }
-    }
-    /// Get a reference to the replica spec
-    pub(crate) fn replica(&self) -> Option<&ReplicaSpec> {
-        self.replica.as_ref()
-    }
-    /// Get a reference to the child state
-    pub(crate) fn child_state(&self) -> Option<&Child> {
-        self.child_state.as_ref()
-    }
-    /// Get a reference to the child URI
-    pub(crate) fn child_uri(&self) -> &ChildUri {
-        &self.child_uri
     }
 }

--- a/control-plane/agents/core/src/core/scheduling/volume.rs
+++ b/control-plane/agents/core/src/core/scheduling/volume.rs
@@ -1,24 +1,18 @@
 use crate::core::{
     registry::Registry,
     scheduling::{
-        resources::{PoolItem, PoolItemLister, ReplicaItem},
-        ChildSorters, NodeFilters, PoolFilters, PoolSorters, ResourceFilter,
+        resources::{ChildItem, PoolItem, PoolItemLister, ReplicaItem},
+        AddReplicaFilters, AddReplicaSorters, ChildSorters, NodeFilters, PoolFilters, PoolSorters,
+        ResourceFilter,
     },
 };
 
-use crate::core::scheduling::{
-    resources::{ChildItem, NexusChildItem},
-    AddReplicaFilters, AddReplicaSorters, NexusChildSorter,
-};
 use common::errors::SvcError;
 use common_lib::types::v0::{
     message_bus::{ChildUri, CreateVolume, VolumeState},
-    store::{
-        nexus::NexusSpec,
-        nexus_persistence::{NexusInfo, NexusInfoKey},
-        volume::VolumeSpec,
-    },
+    store::{nexus::NexusSpec, nexus_persistence::NexusInfo, volume::VolumeSpec},
 };
+
 use itertools::Itertools;
 use std::{collections::HashMap, ops::Deref};
 
@@ -174,15 +168,30 @@ impl GetChildForRemoval {
 
 /// Used to filter nexus children in order to choose the best candidates for removal
 /// when the volume's replica count is being reduced.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) struct GetChildForRemovalContext {
     registry: Registry,
     spec: VolumeSpec,
     state: VolumeState,
+    nexus_info: Option<NexusInfo>,
     unused_only: bool,
 }
 
 impl GetChildForRemovalContext {
+    async fn new(registry: &Registry, request: &GetChildForRemoval) -> Result<Self, SvcError> {
+        let nexus_info = registry
+            .get_nexus_info(request.spec.last_nexus_id.as_ref(), true)
+            .await?;
+
+        Ok(GetChildForRemovalContext {
+            registry: registry.clone(),
+            spec: request.spec.clone(),
+            state: request.state.clone(),
+            nexus_info,
+            unused_only: request.unused_only,
+        })
+    }
+
     async fn list(&self) -> Vec<ReplicaItem> {
         let replicas = self.registry.specs.get_volume_replicas(&self.spec.uuid);
         let nexuses = self.registry.specs.get_volume_nexuses(&self.spec.uuid);
@@ -193,6 +202,7 @@ impl GetChildForRemovalContext {
             .map(|replica_spec| {
                 ReplicaItem::new(
                     replica_spec.clone(),
+                    replica_states.iter().find(|r| r.uuid == replica_spec.uuid),
                     replica_states
                         .iter()
                         .find(|replica_state| replica_state.uuid == replica_spec.uuid)
@@ -241,6 +251,16 @@ impl GetChildForRemovalContext {
                                 .cloned()
                         })
                         .collect(),
+                    self.nexus_info
+                        .as_ref()
+                        .map(|nexus_info| {
+                            nexus_info
+                                .children
+                                .iter()
+                                .find(|child| child.uuid.as_str() == replica_spec.uuid.as_str())
+                                .cloned()
+                        })
+                        .flatten(),
                 )
             })
             .collect::<Vec<_>>()
@@ -248,28 +268,84 @@ impl GetChildForRemovalContext {
 }
 
 impl DecreaseVolumeReplica {
-    async fn builder(request: &GetChildForRemoval, registry: &Registry) -> Self {
-        let context = GetChildForRemovalContext {
-            registry: registry.clone(),
-            spec: request.spec.clone(),
-            state: request.state.clone(),
-            unused_only: request.unused_only,
-        };
-        Self {
+    async fn builder(request: &GetChildForRemoval, registry: &Registry) -> Result<Self, SvcError> {
+        let context = GetChildForRemovalContext::new(registry, request).await?;
+        Ok(Self {
             list: context.list().await,
             context,
-        }
+        })
     }
-    /// Create new `Self` from the given arguments with a default list of filters and sorting rules
+    /// Create new `Self` from the given arguments with a default list of sorting rules
     pub(crate) async fn builder_with_defaults(
         request: &GetChildForRemoval,
         registry: &Registry,
-    ) -> Self {
-        Self::builder(request, registry)
-            .await
-            // if requested filter for replicas which are not currently used for a nexus
-            .filter(|request, item| !(request.unused_only && item.child_spec().is_some()))
-            .sort(ChildSorters::sort)
+    ) -> Result<Self, SvcError> {
+        Ok(Self::builder(request, registry)
+            .await?
+            .sort(ChildSorters::sort))
+    }
+    /// Get the `ReplicaRemovalCandidates` for this request, which splits the candidates into
+    /// healthy and unhealthy candidates
+    pub(crate) fn candidates(self) -> ReplicaRemovalCandidates {
+        ReplicaRemovalCandidates::new(self.context, self.list)
+    }
+}
+
+/// Replica Removal Candidates with explicit partitioning between the healthy and unhealthy replicas
+/// This way we can make sure we do not unintentionally remove "too many" healthy candidates and
+/// risk making the volume degraded, or worst faulted
+#[derive(Debug)]
+pub(crate) struct ReplicaRemovalCandidates {
+    context: GetChildForRemovalContext,
+    healthy: Vec<ReplicaItem>,
+    unhealthy: Vec<ReplicaItem>,
+}
+
+impl ReplicaRemovalCandidates {
+    /// Get the next healthy replica removal candidate
+    fn next_healthy(&mut self) -> Option<ReplicaItem> {
+        let replica_count = self.context.spec.target_num_replicas();
+        let healthy_online = self.healthy.iter().filter(|replica| match replica.state() {
+            None => false,
+            Some(state) => state.online(),
+        });
+        // removing too many healthy_online replicas could compromise the volume's redundancy
+        if healthy_online.into_iter().count() > replica_count as usize {
+            match self.healthy.pop() {
+                Some(replica) if self.context.unused_only & replica.child_spec().is_none() => {
+                    Some(replica)
+                }
+                replica => replica,
+            }
+        } else {
+            None
+        }
+    }
+    /// Get the next unhealthy candidates (any is a good fit)
+    fn next_unhealthy(&mut self) -> Option<ReplicaItem> {
+        self.unhealthy.pop()
+    }
+    /// Get the next removal candidate.
+    /// Unhealthy replicas are removed before healthy replicas
+    pub fn next(&mut self) -> Option<ReplicaItem> {
+        self.next_unhealthy().or_else(|| self.next_healthy())
+    }
+
+    fn new(context: GetChildForRemovalContext, items: Vec<ReplicaItem>) -> Self {
+        let has_info = context.nexus_info.is_some();
+        let is_healthy = |item: &&ReplicaItem| -> bool {
+            match item.child_info() {
+                Some(info) => info.healthy,
+                None => !has_info,
+            }
+        };
+        let is_not_healthy = |item: &&ReplicaItem| -> bool { !is_healthy(item) };
+        Self {
+            context,
+            // reverse so we can pop them
+            healthy: items.iter().filter(is_healthy).rev().cloned().collect(),
+            unhealthy: items.iter().filter(is_not_healthy).rev().cloned().collect(),
+        }
     }
 }
 
@@ -277,101 +353,6 @@ impl DecreaseVolumeReplica {
 impl ResourceFilter for DecreaseVolumeReplica {
     type Request = GetChildForRemovalContext;
     type Item = ReplicaItem;
-
-    fn filter<P: FnMut(&Self::Request, &Self::Item) -> bool>(mut self, mut filter: P) -> Self {
-        let request = self.context.clone();
-        self.list = self
-            .list
-            .into_iter()
-            .filter(|v| filter(&request, v))
-            .collect();
-        self
-    }
-
-    fn sort<P: FnMut(&Self::Item, &Self::Item) -> std::cmp::Ordering>(mut self, sort: P) -> Self {
-        self.list = self.list.into_iter().sorted_by(sort).collect();
-        self
-    }
-
-    fn collect(self) -> Vec<Self::Item> {
-        self.list
-    }
-
-    fn group_by<K, V, F: Fn(&Self::Request, &Vec<Self::Item>) -> HashMap<K, V>>(
-        self,
-        group: F,
-    ) -> HashMap<K, V> {
-        group(&self.context, &self.list)
-    }
-}
-
-/// Used to determine the nexus child removal candidates when a nexus has "too many" replicas
-#[derive(Clone)]
-pub(crate) struct GetNexusChildForRemovalContext {
-    registry: Registry,
-    vol_spec: VolumeSpec,
-    nexus_spec: NexusSpec,
-}
-
-/// Decrease a nexus replica count when it has more than required by its volume
-#[derive(Clone)]
-pub(crate) struct DecreaseNexusReplica {
-    context: GetNexusChildForRemovalContext,
-    list: Vec<NexusChildItem>,
-}
-
-impl GetNexusChildForRemovalContext {
-    async fn list(&self) -> Vec<NexusChildItem> {
-        let nexus = self.registry.get_nexus(&self.nexus_spec.uuid).await.ok();
-        let replicas = self.registry.specs.get_volume_replicas(&self.vol_spec.uuid);
-        let mut replicas = replicas.iter().map(|r| r.lock().clone());
-
-        self.nexus_spec
-            .children
-            .iter()
-            .map(|child| {
-                let spec = child
-                    .as_replica()
-                    .map(|r| replicas.find(|s| &s.uuid == r.uuid()))
-                    .flatten();
-                let child_state = nexus
-                    .as_ref()
-                    .map(|n| n.children.iter().find(|c| c.uri == child.uri()));
-
-                NexusChildItem::new(spec, child.uri(), child_state.flatten())
-            })
-            .collect::<Vec<_>>()
-    }
-}
-
-impl DecreaseNexusReplica {
-    async fn builder(vol_spec: &VolumeSpec, nexus_spec: &NexusSpec, registry: &Registry) -> Self {
-        let context = GetNexusChildForRemovalContext {
-            registry: registry.clone(),
-            vol_spec: vol_spec.clone(),
-            nexus_spec: nexus_spec.clone(),
-        };
-        Self {
-            list: context.list().await,
-            context,
-        }
-    }
-    /// Create a new `Self` from the given arguments
-    pub(crate) async fn builder_with_defaults(
-        vol_spec: &VolumeSpec,
-        nexus_spec: &NexusSpec,
-        registry: &Registry,
-    ) -> Self {
-        Self::builder(vol_spec, nexus_spec, registry)
-            .await
-            .sort(NexusChildSorter::sort)
-    }
-}
-
-#[async_trait::async_trait(?Send)]
-impl ResourceFilter for DecreaseNexusReplica {
-    type Request = GetNexusChildForRemovalContext;
-    type Item = NexusChildItem;
 
     fn filter<P: FnMut(&Self::Request, &Self::Item) -> bool>(mut self, mut filter: P) -> Self {
         let request = self.context.clone();
@@ -437,17 +418,7 @@ impl VolumeReplicasForNexusCtx {
         vol_spec: &VolumeSpec,
         nx_spec: &NexusSpec,
     ) -> Result<Self, SvcError> {
-        let nexus_info = match registry
-            .load_obj::<NexusInfo>(&NexusInfoKey::from(&nx_spec.uuid))
-            .await
-        {
-            Ok(mut info) => {
-                info.uuid = nx_spec.uuid.clone();
-                Some(info)
-            }
-            Err(SvcError::StoreMissingEntry { .. }) => None,
-            Err(error) => return Err(error),
-        };
+        let nexus_info = registry.get_nexus_info(Some(&nx_spec.uuid), true).await?;
 
         Ok(Self {
             registry: registry.clone(),

--- a/control-plane/agents/core/src/core/scheduling/volume.rs
+++ b/control-plane/agents/core/src/core/scheduling/volume.rs
@@ -304,7 +304,7 @@ pub(crate) struct ReplicaRemovalCandidates {
 impl ReplicaRemovalCandidates {
     /// Get the next healthy replica removal candidate
     fn next_healthy(&mut self) -> Option<ReplicaItem> {
-        let replica_count = self.context.spec.target_num_replicas();
+        let replica_count = self.context.spec.desired_num_replicas();
         let healthy_online = self.healthy.iter().filter(|replica| match replica.state() {
             None => false,
             Some(state) => state.online(),
@@ -342,7 +342,9 @@ impl ReplicaRemovalCandidates {
         let is_not_healthy = |item: &&ReplicaItem| -> bool { !is_healthy(item) };
         Self {
             context,
-            // reverse so we can pop them
+            // replicas were sorted with the least preferred replica at the front
+            // since we're going to "pop" them here, we now need to move the least preferred to the
+            // back and that's why we need the "rev"
             healthy: items.iter().filter(is_healthy).rev().cloned().collect(),
             unhealthy: items.iter().filter(is_not_healthy).rev().cloned().collect(),
         }

--- a/control-plane/agents/core/src/core/task_poller.rs
+++ b/control-plane/agents/core/src/core/task_poller.rs
@@ -108,7 +108,7 @@ impl PollContext {
 #[async_trait::async_trait]
 pub(crate) trait TaskPoller: Send + Sync + std::fmt::Debug {
     /// Attempts to poll this poller, which will poll itself depending on the `PollEvent`
-    #[tracing::instrument(skip(context), err)]
+    #[tracing::instrument(skip(context), level = "trace", err)]
     async fn try_poll(&mut self, context: &PollContext) -> PollResult {
         tracing::trace!("Entering trace call");
         let result = if self.poll_ready(context).await {

--- a/control-plane/agents/core/src/nexus/registry.rs
+++ b/control-plane/agents/core/src/nexus/registry.rs
@@ -63,12 +63,12 @@ impl Registry {
 
     /// Fetch the `NexusInfo` from the persistent store
     /// Returns an error if we fail to query the persistent store
-    /// Returns Ok(None) if the entry does not exist
-    /// allow_missing determines whether not finding the key is an allow or not
+    /// Returns Ok(None) if the entry does not exist or if no nexus_uuid was provided
+    /// missing_key_is_error determines whether not finding the key is considered an error or not
     pub(crate) async fn get_nexus_info(
         &self,
         nexus_uuid: Option<&NexusId>,
-        allow_missing: bool,
+        missing_key_is_error: bool,
     ) -> Result<Option<NexusInfo>, SvcError> {
         match nexus_uuid {
             None => Ok(None),
@@ -81,7 +81,7 @@ impl Registry {
                         info.uuid = nexus_uuid.clone();
                         Ok(Some(info))
                     }
-                    Err(SvcError::StoreMissingEntry { .. }) if allow_missing => Ok(None),
+                    Err(SvcError::StoreMissingEntry { .. }) if missing_key_is_error => Ok(None),
                     Err(error) => Err(error),
                 }
             }

--- a/control-plane/agents/core/src/nexus/service.rs
+++ b/control-plane/agents/core/src/nexus/service.rs
@@ -22,7 +22,7 @@ impl Service {
     }
 
     /// Get nexuses according to the filter
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err)]
     pub(super) async fn get_nexuses(&self, request: &GetNexuses) -> Result<Nexuses, SvcError> {
         let filter = request.filter.clone();
         let nexuses = match filter {
@@ -42,7 +42,7 @@ impl Service {
     }
 
     /// Create nexus
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn create_nexus(&self, request: &CreateNexus) -> Result<Nexus, SvcError> {
         self.registry
             .specs
@@ -51,7 +51,7 @@ impl Service {
     }
 
     /// Destroy nexus
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn destroy_nexus(&self, request: &DestroyNexus) -> Result<(), SvcError> {
         self.registry
             .specs
@@ -60,7 +60,7 @@ impl Service {
     }
 
     /// Share nexus
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn share_nexus(&self, request: &ShareNexus) -> Result<String, SvcError> {
         self.registry
             .specs
@@ -69,7 +69,7 @@ impl Service {
     }
 
     /// Unshare nexus
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn unshare_nexus(&self, request: &UnshareNexus) -> Result<(), SvcError> {
         self.registry
             .specs
@@ -78,7 +78,7 @@ impl Service {
     }
 
     /// Add nexus child
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.nexus))]
     pub(super) async fn add_nexus_child(&self, request: &AddNexusChild) -> Result<Child, SvcError> {
         self.registry
             .specs
@@ -87,7 +87,7 @@ impl Service {
     }
 
     /// Remove nexus child
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.nexus))]
     pub(super) async fn remove_nexus_child(
         &self,
         request: &RemoveNexusChild,

--- a/control-plane/agents/core/src/nexus/specs.rs
+++ b/control-plane/agents/core/src/nexus/specs.rs
@@ -32,7 +32,7 @@ impl SpecOperations for NexusSpec {
     type State = Nexus;
     type UpdateOp = NexusOperation;
 
-    fn start_update_op(
+    async fn start_update_op(
         &mut self,
         _: &Registry,
         state: &Self::State,

--- a/control-plane/agents/core/src/pool/service.rs
+++ b/control-plane/agents/core/src/pool/service.rs
@@ -23,7 +23,7 @@ impl Service {
     }
 
     /// Get pools according to the filter
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err)]
     pub(super) async fn get_pools(&self, request: &GetPools) -> Result<Pools, SvcError> {
         let filter = request.filter.clone();
         match filter {
@@ -58,7 +58,7 @@ impl Service {
     }
 
     /// Get replicas according to the filter
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err)]
     pub(super) async fn get_replicas(&self, request: &GetReplicas) -> Result<Replicas, SvcError> {
         let filter = request.filter.clone();
         match filter {
@@ -127,7 +127,7 @@ impl Service {
     }
 
     /// Create pool
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(super) async fn create_pool(&self, request: &CreatePool) -> Result<Pool, SvcError> {
         self.registry
             .specs
@@ -136,7 +136,7 @@ impl Service {
     }
 
     /// Destroy pool
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err)]
     pub(super) async fn destroy_pool(&self, request: &DestroyPool) -> Result<(), SvcError> {
         self.registry
             .specs
@@ -145,7 +145,7 @@ impl Service {
     }
 
     /// Create replica
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err)]
     pub(super) async fn create_replica(
         &self,
         request: &CreateReplica,
@@ -157,7 +157,7 @@ impl Service {
     }
 
     /// Destroy replica
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err)]
     pub(super) async fn destroy_replica(&self, request: &DestroyReplica) -> Result<(), SvcError> {
         self.registry
             .specs
@@ -166,7 +166,7 @@ impl Service {
     }
 
     /// Share replica
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err)]
     pub(super) async fn share_replica(&self, request: &ShareReplica) -> Result<String, SvcError> {
         self.registry
             .specs
@@ -175,7 +175,7 @@ impl Service {
     }
 
     /// Unshare replica
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err)]
     pub(super) async fn unshare_replica(&self, request: &UnshareReplica) -> Result<(), SvcError> {
         self.registry
             .specs

--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -25,6 +25,7 @@ use common_lib::{
     },
 };
 
+#[async_trait::async_trait]
 impl SpecOperations for PoolSpec {
     type Create = CreatePool;
     type Owners = ();
@@ -76,6 +77,7 @@ impl SpecOperations for PoolSpec {
     }
 }
 
+#[async_trait::async_trait]
 impl SpecOperations for ReplicaSpec {
     type Create = CreateReplica;
     type Owners = ReplicaOwners;
@@ -83,7 +85,7 @@ impl SpecOperations for ReplicaSpec {
     type State = Replica;
     type UpdateOp = ReplicaOperation;
 
-    fn start_update_op(
+    async fn start_update_op(
         &mut self,
         _: &Registry,
         state: &Self::State,

--- a/control-plane/agents/core/src/volume/service.rs
+++ b/control-plane/agents/core/src/volume/service.rs
@@ -22,14 +22,17 @@ impl Service {
     }
 
     /// Get volumes
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid))]
     pub(super) async fn get_volumes(&self, request: &GetVolumes) -> Result<Volumes, SvcError> {
         let volumes = self.registry.get_volumes().await;
 
         // The filter criteria is matched against the volume state.
         let filtered_volumes = match &request.filter {
             Filter::None => volumes,
-            Filter::Volume(volume_id) => vec![self.registry.get_volume(volume_id).await?],
+            Filter::Volume(volume_id) => {
+                tracing::Span::current().record("volume.uuid", &volume_id.as_str());
+                vec![self.registry.get_volume(volume_id).await?]
+            }
             filter => {
                 return Err(SvcError::InvalidFilter {
                     filter: filter.clone(),
@@ -41,7 +44,7 @@ impl Service {
     }
 
     /// Create volume
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn create_volume(&self, request: &CreateVolume) -> Result<Volume, SvcError> {
         self.registry
             .specs
@@ -50,7 +53,7 @@ impl Service {
     }
 
     /// Destroy volume
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn destroy_volume(&self, request: &DestroyVolume) -> Result<(), SvcError> {
         self.registry
             .specs
@@ -59,7 +62,7 @@ impl Service {
     }
 
     /// Share volume
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn share_volume(&self, request: &ShareVolume) -> Result<String, SvcError> {
         self.registry
             .specs
@@ -68,7 +71,7 @@ impl Service {
     }
 
     /// Unshare volume
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn unshare_volume(&self, request: &UnshareVolume) -> Result<(), SvcError> {
         self.registry
             .specs
@@ -77,7 +80,7 @@ impl Service {
     }
 
     /// Publish volume
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn publish_volume(&self, request: &PublishVolume) -> Result<Volume, SvcError> {
         self.registry
             .specs
@@ -86,7 +89,7 @@ impl Service {
     }
 
     /// Unpublish volume
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn unpublish_volume(
         &self,
         request: &UnpublishVolume,
@@ -98,7 +101,7 @@ impl Service {
     }
 
     /// Set volume replica
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn set_volume_replica(
         &self,
         request: &SetVolumeReplica,

--- a/control-plane/agents/core/src/volume/tests.rs
+++ b/control-plane/agents/core/src/volume/tests.rs
@@ -322,7 +322,7 @@ async fn hotspare_replica_count(cluster: &Cluster) {
     destroy.disowners = ReplicaOwners::from_volume(volume.uuid());
     destroy.request().await.unwrap();
 
-    wait_till_volume(volume.uuid(), 1).await;
+    // check we have 2 replicas
     wait_till_volume(volume.uuid(), 2).await;
 
     // now add one extra replica (it should be removed)
@@ -340,7 +340,6 @@ async fn hotspare_replica_count(cluster: &Cluster) {
     .await
     .unwrap();
 
-    wait_till_volume(volume.uuid(), 3).await;
     wait_till_volume(volume.uuid(), 2).await;
 
     DestroyVolume::new(volume.uuid()).request().await.unwrap();
@@ -367,7 +366,7 @@ async fn hotspare_nexus_replica_count(cluster: &Cluster) {
 
     let timeout_opts = TimeoutOptions::default()
         .with_max_retries(10)
-        .with_timeout(Duration::from_millis(250))
+        .with_timeout(Duration::from_millis(500))
         .with_timeout_backoff(Duration::from_millis(50));
     let mut store = Etcd::new("0.0.0.0:2379")
         .await

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -20,7 +20,7 @@ rustls = "0.19.1"
 actix-web = { version = "4.0.0-beta.8", features = ["rustls"] }
 actix-service = "2.0.0"
 opentelemetry-jaeger = { version = "0.14", features = ["tokio"] }
-tracing-opentelemetry = "0.13.0"
+tracing-opentelemetry = "0.14.0"
 opentelemetry = "0.15.0"
 actix-web-opentelemetry = "0.11.0-beta.4"
 actix-http = "3.0.0-beta.8"

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -38,10 +38,11 @@ async fn test_setup(auth: &bool) -> ((String, String), ComposeTest) {
         true => vec!["--jwk", &jwk_file],
         false => vec!["--no-auth"],
     };
-    rest_args.append(&mut vec!["-j", "10.1.0.6:6831", "--dummy-certificates"]);
+    rest_args.append(&mut vec!["-j", "10.1.0.7:6831", "--dummy-certificates"]);
 
     let mayastor1 = "node-test-name-1";
     let mayastor2 = "node-test-name-2";
+    // todo: this is getting unwieldy... we should make use of the deployer
     let test = Builder::new()
         .name("rest")
         .add_container_spec(
@@ -52,7 +53,8 @@ async fn test_setup(auth: &bool) -> ((String, String), ComposeTest) {
             "core",
             Binary::from_dbg("core")
                 .with_nats("-n")
-                .with_args(vec!["--store", "http://etcd.rest:2379"]),
+                .with_args(vec!["--store", "http://etcd.rest:2379"])
+                .with_args(vec!["-j", "10.1.0.7:6831"]),
         )
         .add_container_spec(
             ContainerSpec::from_binary(

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -122,6 +122,10 @@ macro_rules! impl_ctrlp_agents {
                     if let Some(period) = &options.reconcile_idle_period {
                         binary = binary.with_args(vec!["--reconcile-idle-period", &period.to_string()]);
                     }
+                    if options.jaeger {
+                        let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
+                        binary = binary.with_args(vec!["--jaeger", &jaeger_config]);
+                    }
                 }
                 Ok(cfg.add_container_bin(&name, binary))
             }

--- a/tests-mayastor/Cargo.toml
+++ b/tests-mayastor/Cargo.toml
@@ -17,7 +17,7 @@ deployer = { path = "../deployer" }
 rest = { path = "../control-plane/rest" }
 actix-rt = "2.2.0"
 opentelemetry-jaeger = { version = "0.14", features = ["tokio"] }
-tracing-opentelemetry = "0.13.0"
+tracing-opentelemetry = "0.14.0"
 opentelemetry = "0.15.0"
 actix-web-opentelemetry = "0.11.0-beta.4"
 tracing = "0.1"


### PR DESCRIPTION
fix: don't remove too many replicas

When removing a replica from a volume or a child from a nexus we could
potentially "too many" and cause the volume to become degraded, or worst, faulted.
Now, when we remove a replica we always check that we're not falling into that case.

Note: we can still get things wrong because the state of nexuses and its children
is volatile so our decisions could be based on stale information.
To address this better we need cas -1018.

feat: improve tracing of volumes, nexus and operations

Don't add a span to the main poller fn otherwise we'll have an infinite span...
Tag every reconcile top level fn and every service function with the volume/nexus id.
Add a request.type = "service|reconcile" which is useful for tracing.

Add TraceStrLog trait which allows us to easily trace string messages for resources.
Add TraceSpan trait which allows us to easily add new spans and run code within
the entered span, useful for adding log messages with span information.