### PR TITLE
chore: add missing npx to the shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,7 @@ mkShell {
     git
     llvmPackages.libclang
     nats-server
+    nodejs-16_x
     nvme-cli
     openssl
     pkg-config


### PR DESCRIPTION
add missing npx to the shell