### PR TITLE
chore: run bdd tests no longer run on separate agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
           when{
             expression { bdd_test == true }
           }
-          agent { label 'nixos-mayastor-pytest' }
+          agent { label 'nixos-mayastor' }
           steps {
             sh 'printenv'
             sh 'nix-shell --run "cargo build --bins"'

--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,7 @@ mkShell {
     git
     llvmPackages.libclang
     nats-server
+    nodejs-16_x
     nvme-cli
     openssl
     pkg-config


### PR DESCRIPTION
The current agent 'nixos-mayastor-pytest' is no longer available
as the node upon which it resides is being repurposed
as a "hypervisor" node