### PR TITLE
feat: delete spec when volume creation fails

### DIFF
--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -122,7 +122,7 @@ impl Registry {
         )
         .await
         {
-            Ok(_) => Ok(()),
+            Ok(result) => result.map_err(Into::into),
             Err(_) => Err(StoreError::Timeout {
                 operation: "Put".to_string(),
                 timeout: self.store_timeout,

--- a/tests/bdd/test_volume_create.py
+++ b/tests/bdd/test_volume_create.py
@@ -146,11 +146,10 @@ def volume_creation_should_fail_with_an_insufficient_storage_error(create_reques
     except Exception as e:
         exception_info = e.__dict__
         assert exception_info["status"] == requests.codes["insufficient_storage"]
-    # TODO: Uncomment the "finally" clause when CAS-1059 is completed.
-    # finally:
-    #     # Check that the volume wasn't created.
-    #     volumes = common.get_volumes_api().get_volumes()
-    #     assert len(volumes) == 0
+    finally:
+        # Check that the volume wasn't created.
+        volumes = common.get_volumes_api().get_volumes()
+        assert len(volumes) == 0
 
 
 @then("volume creation should succeed with a returned volume object")


### PR DESCRIPTION
Ensure that the volume spec is eventually deleted when volume creation
fails.

In the event that the persistent store cannot be reached, the
reconcile_dirty_volumes function will ensure that the spec will
eventually be removed from the store and registry.

Bug fix:
- Ensure that an error is returned when storing an object to the
persistent store fails.

Resolves: CAS-1059