### PR TITLE
feat(CI): build and push control plane images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
   parameters {
-    booleanParam(defaultValue: false, name: 'build_images')
+    booleanParam(defaultValue: true, name: 'build_images')
   }
   triggers {
     cron(cron_schedule)
@@ -135,7 +135,7 @@ pipeline {
         }
       }// parallel stages block
     }// end of test stage
-    stage('build images') {
+    stage('build and push images') {
       agent { label 'nixos-mayastor' }
       when {
         beforeAgent true
@@ -149,7 +149,10 @@ pipeline {
         }
       }
       steps {
-        sh './scripts/release.sh --skip-publish'
+        withCredentials([usernamePassword(credentialsId: 'dockerhub', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
+            sh 'echo $PASSWORD | docker login -u $USERNAME --password-stdin'
+        }
+        sh './scripts/release.sh'
       }
       post {
         always {

--- a/deploy/core-agents-deployment.yaml
+++ b/deploy/core-agents-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: core-agents
+  namespace: mayastor
+  labels:
+    app: core-agents
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: core-agents
+  template:
+    metadata:
+      labels:
+        app: core-agents
+    spec:
+      containers:
+        - name: core
+          image: mayadata/mcp-core:develop
+          imagePullPolicy: Always
+          args:
+            - "-smayastor-etcd"
+            - "-nnats"

--- a/deploy/rest-deployment.yaml
+++ b/deploy/rest-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rest
+  namespace: mayastor
+  labels:
+    app: rest
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rest
+  template:
+    metadata:
+      labels:
+        app: rest
+    spec:
+      containers:
+        - name: rest
+          image: mayadata/mcp-rest:develop
+          imagePullPolicy: Always
+          args:
+            - "--dummy-certificates"
+            - "--no-auth"
+            - "-nnats"
+          ports:
+          - containerPort: 8080

--- a/deploy/rest-service.yaml
+++ b/deploy/rest-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rest
+  namespace: mayastor
+  labels:
+    app: rest
+spec:
+  type: NodePort
+  selector:
+    app: rest
+  ports:
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
+      nodePort: 30010

--- a/nix/pkgs/images/default.nix
+++ b/nix/pkgs/images/default.nix
@@ -13,7 +13,7 @@ let
   build-control-plane-image = { build, name, config ? { } }: dockerTools.buildImage {
     tag = control-plane.version;
     created = "now";
-    name = "mayadata/mayastor-${name}";
+    name = "mayadata/mcp-${name}";
     contents = [ tini busybox control-plane.${build}.${name} ];
     config = { Entrypoint = [ "tini" "--" control-plane.${build}.${name}.binary ]; } // config;
   };
@@ -25,14 +25,12 @@ let
     name = "rest";
     config = { ExposedPorts = { "8080/tcp" = { }; "8081/tcp" = { }; }; };
   };
-  agent-images = { build }: {
-    core = build-agent-image { inherit build; name = "core"; };
-    jsongrpc = build-agent-image { inherit build; name = "jsongrpc"; };
-  };
 in
 {
-  agents = agent-images { build = "release"; };
-  agents-dev = agent-images { build = "debug"; };
+  core = build-agent-image { build = "release"; name = "core"; };
+  core-dev = build-agent-image { build = "debug"; name = "core"; };
+  jsongrpc = build-agent-image { build = "release"; name = "jsongrpc"; };
+  jsongrpc-dev = build-agent-image { build = "debug"; name = "jsongrpc"; };
   rest = build-rest-image {
     build = "release";
   };

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -119,14 +119,14 @@ cd $SCRIPTDIR/..
 
 if [ -z "$IMAGES" ]; then
   if [ -z "$DEBUG" ]; then
-    IMAGES="agents rest"
+    IMAGES="core jsongrpc rest"
   else
-    IMAGES="agents-dev rest-dev"
+    IMAGES="core-dev jsongrpc-dev rest-dev"
   fi
 fi
 
 for name in $IMAGES; do
-  image_basename="mayadata/${name}"
+  image_basename="mayadata/mcp-${name}"
   image=$image_basename
   if [ -n "$REGISTRY" ]; then
     image="${REGISTRY}/${image}"


### PR DESCRIPTION
Enable CI to build and push control plane images for certain branches.

Build core and jsongrpc images separately to allow both to be loaded
from the resulting tar file. Attempting to build them both together was
resulting in only the core image being loaded from the tar file.

Provide deployment YAML files for the core agent and REST server. The
REST server is exposed through a NodePort service on port 30010.

Bug fix:

- Allow the etcd enpoint to be provided to the core agent without
the need for a port to be specified. Omitting the port results in the
default port being chosen (2379). This mimicks the behaviour of
Mayastor.

Resolves: CAS-636