### PR TITLE
feat(kubectl plugin): control plane interaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1631,6 +1631,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "kubectl-mayastor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "once_cell",
+ "reqwest",
+ "serde_json",
+ "structopt",
+ "tokio",
+]
+
+[[package]]
 name = "language-tags"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "control-plane/agents",
     "control-plane/rest",
     "deployer",
+    "kubectl-plugin",
     "openapi",
     "rpc",
 # Test mayastor through the rest api

--- a/deploy/rest-deployment.yaml
+++ b/deploy/rest-deployment.yaml
@@ -23,5 +23,7 @@ spec:
             - "--dummy-certificates"
             - "--no-auth"
             - "-nnats"
+            - --http=0.0.0.0:8081
           ports:
           - containerPort: 8080
+          - containerPort: 8081

--- a/deploy/rest-service.yaml
+++ b/deploy/rest-service.yaml
@@ -11,6 +11,12 @@ spec:
     app: rest
   ports:
     - port: 8080
+      name: https
       targetPort: 8080
       protocol: TCP
       nodePort: 30010
+    - port: 8081
+      name: http
+      targetPort: 8081
+      protocol: TCP
+      nodePort: 30011

--- a/kubectl-plugin/Cargo.toml
+++ b/kubectl-plugin/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kubectl-mayastor"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.43"
+async-trait = "0.1.51"
+once_cell = "1.8.0"
+reqwest = "0.11.4"
+structopt = "0.3.22"
+tokio = { version = "1.10.0", features = [ "full" ] }
+serde_json = "1.0.66"

--- a/kubectl-plugin/README.md
+++ b/kubectl-plugin/README.md
@@ -1,0 +1,37 @@
+# Mayastor kubectl Plugin
+
+## Overview
+The Mayastor kubectl plugin has been created in accordance with the instructions outlined in the [official documentation](https://kubernetes.io/docs/tasks/extend-kubectl/kubectl-plugins/).
+
+
+The name of the plugin binary dictates how it is used. From the documentation:
+> For example, a plugin named `kubectl-foo` provides a command `kubectl foo`.
+
+In our case the name of the binary is specified in the Cargo.toml file as `kubectl-mayastor`, therefore the command is `kubectl mayastor`.
+
+## Usage
+**The plugin must be placed in your `PATH` in order for it to be used.**
+
+To make the plugin as intuitive as possible, every attempt has been made to make the usage as similar to that of the standard `kubectl` command line utility as possible.
+
+The general command structure is `kubectl mayastor --rest <rest_endpoint> <operation> <resource>` where the operation defines what should be performed (i.e. `list`, `get`) and the resource defines what the operation should be performed on (i.e. `volumes`, `pools`).
+
+### Examples
+
+#### Volumes
+Listing volumes:\
+`kubectl mayastor --rest http://192.168.122.142:30011 list volumes`
+
+Getting a volume:\
+`kubectl mayastor --rest http://192.168.122.142:30011 get volume ec4e66fd-3b33-4439-b504-d49aba53da26`
+
+Scaling a volume:\
+`kubectl mayastor --rest http://192.168.122.142:30011 scale volume ec4e66fd-3b33-4439-b504-d49aba53da26 2`
+
+#### Pools
+
+Listing pools:\
+`kubectl mayastor --rest http://192.168.122.142:30011 list pools`
+
+Getting a pool:\
+`kubectl mayastor --rest http://192.168.122.142:30011 get pool 574ba4c9-fec6-441c-a4d0-d5f3fafe7078`

--- a/kubectl-plugin/src/main.rs
+++ b/kubectl-plugin/src/main.rs
@@ -1,0 +1,61 @@
+#![feature(once_cell)]
+
+mod operations;
+mod resources;
+mod rest_client;
+
+use crate::resources::ResourceFactory;
+use anyhow::Result;
+use operations::Operations;
+use reqwest::{Response, Url};
+use rest_client::RestClient;
+use serde_json::Value;
+use structopt::StructOpt;
+
+#[derive(StructOpt, Debug)]
+struct CliArgs {
+    /// Rest endpoint.
+    #[structopt(long, short)]
+    rest: Url,
+    /// The operation to be performed.
+    #[structopt(subcommand)]
+    operations: Operations,
+}
+
+#[tokio::main]
+async fn main() {
+    let cli_args = &CliArgs::from_args();
+
+    // Initialise the REST client.
+    RestClient::init(&cli_args.rest);
+
+    // Perform the requested operation.
+    let response = match &cli_args.operations {
+        Operations::List(resource) => resource.instance().list().await,
+        Operations::Get(resource) => resource.instance().get().await,
+        Operations::Scale(resource) => resource.instance().scale().await,
+    };
+
+    // TODO: Tabulate output by default. Output as JSON if an output argument is supplied.
+    match response {
+        Ok(r) => {
+            if let Err(e) = pretty_print(r).await {
+                println!("Failed to pretty print response. Error {}", e);
+            }
+        }
+        Err(e) => {
+            println!("Operation failed with error {}", e);
+        }
+    };
+}
+
+/// Print the response as pretty JSON.
+/// Printing the response is the last thing we do, so if there is an error just output an
+/// appropriate message as there isn't anything else to do.
+async fn pretty_print(response: Response) -> Result<()> {
+    let response_text = response.text().await?;
+    let response_value: Value = serde_json::from_str(&response_text)?;
+    let pretty_string = serde_json::to_string_pretty(&response_value)?;
+    println!("{}", pretty_string);
+    Ok(())
+}

--- a/kubectl-plugin/src/operations.rs
+++ b/kubectl-plugin/src/operations.rs
@@ -1,0 +1,37 @@
+use crate::resources::{GetResources, ListResources, ScaleResources};
+use anyhow::Result;
+use async_trait::async_trait;
+use reqwest::Response;
+use structopt::StructOpt;
+
+/// The types of operations that are supported.
+#[derive(StructOpt, Debug)]
+pub(crate) enum Operations {
+    /// 'List' operation.
+    List(ListResources),
+    /// 'Get' operation.
+    Get(GetResources),
+    /// 'Scale' operation.
+    Scale(ScaleResources),
+}
+
+/// List trait.
+/// To be implemented by resources which support the 'list' operation.
+#[async_trait]
+pub trait List {
+    async fn list(&self) -> Result<Response>;
+}
+
+/// Get trait.
+/// To be implemented by resources which support the 'get' operation.
+#[async_trait]
+pub trait Get {
+    async fn get(&self) -> Result<Response>;
+}
+
+/// Scale trait.
+/// To be implemented by resources which support the 'scale' operation.
+#[async_trait]
+pub trait Scale {
+    async fn scale(&self) -> Result<Response>;
+}

--- a/kubectl-plugin/src/resources/mod.rs
+++ b/kubectl-plugin/src/resources/mod.rs
@@ -1,0 +1,72 @@
+mod pool;
+mod volume;
+
+use crate::operations::{Get, List, Scale};
+use structopt::StructOpt;
+
+/// Trait to create a concrete instance of a resource.
+pub trait ResourceFactory {
+    type R;
+    fn instance(&self) -> Self::R;
+}
+
+/// The types of resources that support the 'list' operation.
+#[derive(StructOpt, Debug)]
+pub(crate) enum ListResources {
+    Volumes,
+    Pools,
+}
+
+impl ResourceFactory for &ListResources {
+    type R = Box<dyn List>;
+
+    fn instance(&self) -> Self::R {
+        match self {
+            ListResources::Volumes => Box::new(volume::Volumes {}),
+            ListResources::Pools => Box::new(pool::Pools {}),
+        }
+    }
+}
+
+pub(crate) type VolumeId = String;
+pub(crate) type ReplicaCount = u8;
+pub(crate) type PoolId = String;
+
+/// The types of resources that support the 'get' operation.
+#[derive(StructOpt, Debug)]
+pub(crate) enum GetResources {
+    Volume { id: VolumeId },
+    Pool { id: PoolId },
+}
+
+impl ResourceFactory for &GetResources {
+    type R = Box<dyn Get>;
+
+    fn instance(&self) -> Self::R {
+        match self {
+            GetResources::Volume { id } => Box::new(volume::Volume::new(id, None)),
+            GetResources::Pool { id } => Box::new(pool::Pool::new(id)),
+        }
+    }
+}
+
+/// The types of resources that support the 'scale' operation.
+#[derive(StructOpt, Debug)]
+pub(crate) enum ScaleResources {
+    Volume {
+        id: VolumeId,
+        replica_count: ReplicaCount,
+    },
+}
+
+impl ResourceFactory for &ScaleResources {
+    type R = Box<dyn Scale>;
+
+    fn instance(&self) -> Self::R {
+        match self {
+            ScaleResources::Volume { id, replica_count } => {
+                Box::new(volume::Volume::new(id, Some(*replica_count)))
+            }
+        }
+    }
+}

--- a/kubectl-plugin/src/resources/pool.rs
+++ b/kubectl-plugin/src/resources/pool.rs
@@ -1,0 +1,49 @@
+use crate::{
+    operations::{Get, List},
+    resources::PoolId,
+    rest_client::RestClient,
+};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use reqwest::Response;
+use structopt::StructOpt;
+
+/// Pools resource.
+#[derive(StructOpt, Debug)]
+pub struct Pools {}
+
+#[async_trait]
+impl List for Pools {
+    /// Support listing pools.
+    async fn list(&self) -> Result<Response> {
+        let url = RestClient::http_base_url().join("pools")?;
+        RestClient::get_request(&url)
+            .await
+            .map_err(|e| anyhow!("Failed to list pools. Error {}", e))
+    }
+}
+
+/// Pool resource.
+#[derive(StructOpt, Debug)]
+pub(crate) struct Pool {
+    /// ID of the pool.
+    id: PoolId,
+}
+
+impl Pool {
+    /// Construct a new Pool instance.
+    pub fn new(id: &str) -> Self {
+        Self { id: id.into() }
+    }
+}
+
+#[async_trait]
+impl Get for Pool {
+    /// Support getting a pool using its ID.
+    async fn get(&self) -> Result<Response> {
+        let url = RestClient::http_base_url().join(&format!("pools/{}", self.id))?;
+        RestClient::get_request(&url)
+            .await
+            .map_err(|e| anyhow!("Failed to get pool {}. Error {}", self.id, e))
+    }
+}

--- a/kubectl-plugin/src/resources/volume.rs
+++ b/kubectl-plugin/src/resources/volume.rs
@@ -1,0 +1,75 @@
+use crate::{
+    operations::{Get, List, Scale},
+    resources::{ReplicaCount, VolumeId},
+    rest_client::RestClient,
+};
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use reqwest::{self, Response};
+use structopt::StructOpt;
+
+/// Volumes resource.
+#[derive(StructOpt, Debug)]
+pub(crate) struct Volumes {}
+
+#[async_trait]
+impl List for Volumes {
+    /// Support listing volumes.
+    async fn list(&self) -> Result<Response> {
+        let url = RestClient::http_base_url().join("volumes")?;
+        RestClient::get_request(&url)
+            .await
+            .map_err(|e| anyhow!("Failed to list volumes. Error {}", e))
+    }
+}
+
+/// Volume resource.
+#[derive(StructOpt, Debug)]
+pub(crate) struct Volume {
+    /// ID of the volume.
+    id: VolumeId,
+    /// Number of replicas.
+    replica_count: Option<ReplicaCount>,
+}
+
+impl Volume {
+    /// Construct a new Volume instance.
+    pub fn new(id: &str, replica_count: Option<ReplicaCount>) -> Self {
+        Self {
+            id: id.into(),
+            replica_count,
+        }
+    }
+}
+
+#[async_trait]
+impl Get for Volume {
+    /// Support getting a volume using its ID.
+    async fn get(&self) -> Result<Response> {
+        let url = RestClient::http_base_url().join(&format!("volumes/{}", self.id))?;
+        RestClient::get_request(&url)
+            .await
+            .map_err(|e| anyhow!("Failed to get volume {}. Error {}", self.id, e))
+    }
+}
+
+#[async_trait]
+impl Scale for Volume {
+    /// Support increasing/decreasing the replica count of a volume.
+    async fn scale(&self) -> Result<Response> {
+        assert!(self.replica_count.is_some());
+        let replica_count = self.replica_count.unwrap();
+        let url = RestClient::http_base_url().join(&format!(
+            "volumes/{}/replica_count/{}",
+            self.id, replica_count
+        ))?;
+        RestClient::put_request(&url).await.map_err(|e| {
+            anyhow!(
+                "Failed to scale volume {} to {} replica(s). Error {}",
+                self.id,
+                replica_count,
+                e
+            )
+        })
+    }
+}

--- a/kubectl-plugin/src/rest_client.rs
+++ b/kubectl-plugin/src/rest_client.rs
@@ -1,0 +1,66 @@
+use once_cell::sync::OnceCell;
+use reqwest::{Client, Error, Response, Url};
+
+static REST_CLIENT: OnceCell<RestClient> = OnceCell::new();
+
+/// REST client
+pub struct RestClient {
+    /// Address of the rest server. This acts as the base url for all requests.
+    base: Url,
+    /// Client used to make REST requests.
+    client: Client,
+}
+
+impl RestClient {
+    /// Initialise the REST client.
+    pub fn init(endpoint: &Url) {
+        if !Self::valid_endpoint(endpoint) {
+            return;
+        }
+
+        let base = endpoint.join("/v0/").expect("Failed to create base URL.");
+        let client = reqwest::Client::builder()
+            .danger_accept_invalid_certs(true)
+            .build()
+            .expect("Failed to build REST client");
+        REST_CLIENT.get_or_init(|| Self { base, client });
+    }
+
+    /// Returns the base url for all requests.
+    pub fn http_base_url() -> Url {
+        Self::rest_client().base.clone()
+    }
+
+    /// Issue the 'GET' REST request, returning the result of the operation.
+    pub async fn get_request(url: &Url) -> Result<Response, Error> {
+        Self::rest_client().client.get(url.clone()).send().await
+    }
+
+    /// Issue the 'PUT' REST request, returning the result of the operation.
+    pub async fn put_request(url: &Url) -> Result<Response, Error> {
+        Self::rest_client().client.put(url.clone()).send().await
+    }
+
+    /// Helper function to get the rest client.
+    fn rest_client() -> &'static RestClient {
+        REST_CLIENT
+            .get()
+            .expect("REST client should be initialised before use.")
+    }
+
+    /// Validate that the endpoint is in the correct form.
+    fn valid_endpoint(endpoint: &Url) -> bool {
+        // TODO: Add support for HTTPS.
+        if endpoint.scheme() != "http" {
+            println!(
+                "{} unsupported. Only HTTP is currently supported.",
+                endpoint.scheme()
+            );
+            return false;
+        } else if endpoint.port().is_none() {
+            println!("A port number must be supplied for the REST endpoint.");
+            return false;
+        }
+        true
+    }
+}


### PR DESCRIPTION
Create a kubectl plugin which can interact with the new control plane
through REST calls.

The REST calls are currently made using the reqwest crate rather than
using the in-tree ApiClient provided as part of the openapi
auto-generated code.

Currently the plugin only works over HTTP (not HTTPS) as the appropriate
certificates haven't been set up. Because of this, the REST deployment
and REST service have had their YAML files updated to expose the HTTP
port on NodePort 30011.

The plugin currently supports the following operations:
- Listing volumes
- Getting a specific volume by ID
- Scaling a specific volume (increasing/decreasing replica count)
- Listing pools
- Getting a specific pool by ID