### PR TITLE
feat: add pool reconciler to recreate pools

### DIFF
--- a/common/src/types/v0/message_bus/node.rs
+++ b/common/src/types/v0/message_bus/node.rs
@@ -126,6 +126,18 @@ impl NodeState {
             status,
         }
     }
+    /// Get the node identification
+    pub fn id(&self) -> &NodeId {
+        &self.id
+    }
+    /// Get the node's gRPC endpoint
+    pub fn grpc(&self) -> &str {
+        &self.grpc_endpoint
+    }
+    /// Get the node status
+    pub fn status(&self) -> &NodeStatus {
+        &self.status
+    }
 }
 
 impl From<models::NodeState> for NodeState {

--- a/common/src/types/v0/message_bus/pool.rs
+++ b/common/src/types/v0/message_bus/pool.rs
@@ -278,6 +278,17 @@ pub struct CreatePool {
     pub disks: Vec<PoolDeviceUri>,
 }
 
+impl CreatePool {
+    /// Create new `Self` from the given parameters
+    pub fn new(node: &NodeId, id: &PoolId, disks: &[PoolDeviceUri]) -> Self {
+        Self {
+            node: node.clone(),
+            id: id.clone(),
+            disks: disks.to_vec(),
+        }
+    }
+}
+
 /// Destroy Pool Request
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -156,7 +156,7 @@ impl<T: OperationSequencer> Drop for OperationGuard<T> {
 
 /// Exclusive operations must be performed one at a time.
 /// A reconcile compound operation can be comprised of multiple steps
-/// A reconcile compound operation must first be issued, followed by 1-N Single Step Operations
+/// A reconcile start operation must first be issued, followed by 1-N Single Step Operations
 #[derive(Debug, Copy, Clone)]
 pub enum OperationMode {
     /// Start Exclusive operation

--- a/common/src/types/v0/store/pool.rs
+++ b/common/src/types/v0/store/pool.rs
@@ -101,6 +101,21 @@ pub struct PoolSpec {
     pub operation: Option<PoolOperationState>,
 }
 
+macro_rules! pool_span {
+    ($Self:tt, $Level:expr, $func:expr) => {
+        match tracing::Span::current().field("pool.uuid") {
+            None => {
+                let _span = tracing::span!($Level, "log_event", pool.uuid = %$Self.id).entered();
+                $func();
+            }
+            Some(_) => {
+                $func();
+            }
+        }
+    };
+}
+crate::impl_trace_span!(pool_span, PoolSpec);
+
 impl OperationSequencer for PoolSpec {
     fn as_ref(&self) -> &OperationSequence {
         &self.sequencer

--- a/control-plane/agents/core/src/core/reconciler/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/mod.rs
@@ -1,6 +1,7 @@
 mod nexus;
 mod persistent_store;
 pub mod poller;
+mod pool;
 mod volume;
 
 use crate::core::task_poller::{PollContext, PollEvent, TaskPoller};

--- a/control-plane/agents/core/src/core/reconciler/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/mod.rs
@@ -4,6 +4,7 @@ pub mod poller;
 mod pool;
 mod volume;
 
+pub(crate) use crate::core::task_poller::PollTriggerEvent;
 use crate::core::task_poller::{PollContext, PollEvent, TaskPoller};
 use poller::ReconcilerWorker;
 
@@ -43,5 +44,10 @@ impl ReconcilerControl {
     #[allow(dead_code)]
     pub(crate) async fn shutdown(&self) {
         self.shutdown_channel.send(()).await.ok();
+    }
+
+    /// Send an event signal to the poller's main loop
+    pub(crate) async fn notify(&self, event: PollEvent) {
+        self.event_channel.send(event).await.ok();
     }
 }

--- a/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
@@ -23,8 +23,7 @@ pub(super) async fn faulted_children_remover(
         nexus_spec_clone
             .warn_span(|| tracing::warn!("Attempting to remove faulted child '{}'", child.uri));
         if let Err(error) = context
-            .registry()
-            .specs
+            .specs()
             .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, true, mode)
             .await
         {
@@ -62,8 +61,7 @@ pub(super) async fn unknown_children_remover(
         nexus_spec_clone
             .warn_span(|| tracing::warn!("Attempting to remove unknown child '{}'", child.uri));
         if let Err(error) = context
-            .registry()
-            .specs
+            .specs()
             .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, false, mode)
             .await
         {
@@ -107,8 +105,7 @@ pub(super) async fn missing_children_remover(
         ));
 
         if let Err(error) = context
-            .registry()
-            .specs
+            .specs()
             .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri(), true, mode)
             .await
         {

--- a/control-plane/agents/core/src/core/reconciler/persistent_store.rs
+++ b/control-plane/agents/core/src/core/reconciler/persistent_store.rs
@@ -16,7 +16,7 @@ impl PersistentStoreReconciler {
 #[async_trait::async_trait]
 impl TaskPoller for PersistentStoreReconciler {
     async fn poll(&mut self, context: &PollContext) -> PollResult {
-        let specs = &context.registry().specs;
+        let specs = context.specs();
         let dirty_replicas = specs.reconcile_dirty_replicas(context.registry()).await;
         let dirty_nexuses = specs.reconcile_dirty_nexuses(context.registry()).await;
         let dirty_volumes = specs.reconcile_dirty_volumes(context.registry()).await;

--- a/control-plane/agents/core/src/core/reconciler/poller.rs
+++ b/control-plane/agents/core/src/core/reconciler/poller.rs
@@ -1,5 +1,5 @@
 use crate::core::{
-    reconciler::{persistent_store::PersistentStoreReconciler, volume},
+    reconciler::{persistent_store::PersistentStoreReconciler, pool, volume},
     registry::Registry,
     task_poller::{squash_results, PollContext, PollEvent, PollResult, PollerState, TaskPoller},
 };
@@ -25,6 +25,7 @@ impl ReconcilerWorker {
     pub(super) fn new() -> Self {
         let poll_targets: Vec<Box<dyn TaskPoller>> = vec![
             Box::new(volume::VolumeReconciler::new()),
+            Box::new(pool::PoolReconciler::new()),
             Box::new(PersistentStoreReconciler::new()),
         ];
 
@@ -87,7 +88,7 @@ impl ReconcilerWorker {
         }
     }
 
-    #[tracing::instrument(skip(context), level = "trace", err)]
+    #[tracing::instrument(skip(context), level = "trace")]
     async fn poller_work(&mut self, context: PollContext) -> PollResult {
         tracing::trace!("Entering the reconcile loop...");
         let mut results = vec![];

--- a/control-plane/agents/core/src/core/reconciler/poller.rs
+++ b/control-plane/agents/core/src/core/reconciler/poller.rs
@@ -78,9 +78,9 @@ impl ReconcilerWorker {
                     event.unwrap_or(PollEvent::Shutdown)
                 },
                 _timed = tokio::time::sleep(if result.unwrap_or(PollerState::Busy) == PollerState::Busy {
-                    registry.reconcile_period
+                    registry.reconcile_period()
                 } else {
-                    registry.reconcile_idle_period
+                    registry.reconcile_idle_period()
                 }) => {
                     PollEvent::TimedRun
                 }

--- a/control-plane/agents/core/src/core/reconciler/pool/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/pool/mod.rs
@@ -84,11 +84,11 @@ async fn missing_pool_state_reconciler(
             Ok(node) if !node.lock().await.is_online() => {
                 let node_status = node.lock().await.status().clone();
                 warn_missing(&pool_spec, node_status);
-                return PollResult::Ok(PollerState::Busy);
+                return PollResult::Ok(PollerState::Idle);
             }
             Err(_) => {
                 warn_missing(&pool_spec, NodeStatus::Unknown);
-                return PollResult::Ok(PollerState::Busy);
+                return PollResult::Ok(PollerState::Idle);
             }
             Ok(node) => node,
         };

--- a/control-plane/agents/core/src/core/reconciler/pool/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/pool/mod.rs
@@ -1,0 +1,112 @@
+use crate::core::{
+    specs::{OperationSequenceGuard, SpecOperations},
+    task_poller::{PollContext, PollPeriods, PollResult, PollTimer, PollerState, TaskPoller},
+    wrapper::ClientOps,
+};
+use common_lib::types::v0::{
+    message_bus::{CreatePool, NodeStatus},
+    store::{pool::PoolSpec, OperationMode, TraceSpan},
+};
+use parking_lot::Mutex;
+use std::sync::Arc;
+
+/// Pool Reconciler loop which:
+/// 1. recreates pools which are not present following a mayastor restart
+#[derive(Debug)]
+pub struct PoolReconciler {
+    counter: PollTimer,
+}
+impl PoolReconciler {
+    /// Return new `Self` with the provided period
+    pub fn from(period: PollPeriods) -> Self {
+        PoolReconciler {
+            counter: PollTimer::from(period),
+        }
+    }
+    /// Return new `Self` with the default period
+    pub fn new() -> Self {
+        Self::from(1)
+    }
+}
+
+#[async_trait::async_trait]
+impl TaskPoller for PoolReconciler {
+    async fn poll(&mut self, context: &PollContext) -> PollResult {
+        let mut results = vec![];
+        for pool in context.registry().specs().get_locked_pools() {
+            if pool.lock().status().created() {
+                results.push(missing_pool_state_reconciler(pool, context).await)
+            }
+        }
+        Self::squash_results(results)
+    }
+
+    async fn poll_timer(&mut self, _context: &PollContext) -> bool {
+        self.counter.poll()
+    }
+}
+
+/// If a pool has a spec but not state, it means that the mayastor instance where the pool should
+/// exist does not have the pool open.
+/// This can happen if the pool is destroyed under the control plane, or if mayastor
+/// crashed/restarted.
+/// In such a case, we issue a new create pool request against the mayastor instance where the pool
+/// should exist.
+#[tracing::instrument(skip(pool_spec, context), fields(pool.uuid = %pool_spec.lock().id))]
+async fn missing_pool_state_reconciler(
+    pool_spec: Arc<Mutex<PoolSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    if !pool_spec.lock().status().created() {
+        // nothing to do here
+        return PollResult::Ok(PollerState::Idle);
+    }
+    let pool_id = pool_spec.lock().id.clone();
+
+    if context.registry().get_pool_state(&pool_id).await.is_err() {
+        let _guard = match pool_spec.operation_guard(OperationMode::ReconcileStart) {
+            Ok(guard) => guard,
+            Err(_) => return PollResult::Ok(PollerState::Busy),
+        };
+        let pool = pool_spec.lock().clone();
+
+        let warn_missing = |pool_spec: &Arc<Mutex<PoolSpec>>, node_status: NodeStatus| {
+            let node_id = pool_spec.lock().node.clone();
+            pool.debug_span(|| {
+                tracing::debug!(
+                    node.uuid = %node_id,
+                    node.status = %node_status.to_string(),
+                    "Attempted to recreate missing pool state, but the node is not online"
+                )
+            });
+        };
+        let node = match context.registry().get_node_wrapper(&pool.node).await {
+            Ok(node) if !node.lock().await.is_online() => {
+                let node_status = node.lock().await.status().clone();
+                warn_missing(&pool_spec, node_status);
+                return PollResult::Ok(PollerState::Busy);
+            }
+            Err(_) => {
+                warn_missing(&pool_spec, NodeStatus::Unknown);
+                return PollResult::Ok(PollerState::Busy);
+            }
+            Ok(node) => node,
+        };
+
+        pool.warn_span(|| tracing::warn!("Attempting to recreate missing pool"));
+
+        let request = CreatePool::new(&pool.node, &pool.id, &pool.disks);
+        match node.create_pool(&request).await {
+            Ok(_) => {
+                pool.info_span(|| tracing::info!("Pool successfully recreated"));
+                PollResult::Ok(PollerState::Idle)
+            }
+            Err(error) => {
+                pool.error_span(|| tracing::error!(error=%error, "Failed to recreate the pool"));
+                Err(error)
+            }
+        }
+    } else {
+        PollResult::Ok(PollerState::Idle)
+    }
+}

--- a/control-plane/agents/core/src/core/reconciler/pool/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/pool/mod.rs
@@ -33,7 +33,7 @@ impl PoolReconciler {
 impl TaskPoller for PoolReconciler {
     async fn poll(&mut self, context: &PollContext) -> PollResult {
         let mut results = vec![];
-        for pool in context.registry().specs().get_locked_pools() {
+        for pool in context.specs().get_locked_pools() {
             if pool.lock().status().created() {
                 results.push(missing_pool_state_reconciler(pool, context).await)
             }

--- a/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
@@ -25,7 +25,7 @@ impl GarbageCollector {
 #[async_trait::async_trait]
 impl TaskPoller for GarbageCollector {
     async fn poll(&mut self, context: &PollContext) -> PollResult {
-        let volumes = context.registry().specs.get_locked_volumes();
+        let volumes = context.specs().get_locked_volumes();
         for volume in volumes {
             let _ = garbage_collector_reconcile(volume, context).await;
         }

--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -14,7 +14,11 @@
 //! Each instance also contains the known nexus, pools and replicas that live in
 //! said instance.
 use super::{specs::*, wrapper::NodeWrapper};
-use crate::core::{reconciler::ReconcilerControl, wrapper::InternalOps};
+use crate::core::{
+    reconciler::ReconcilerControl,
+    task_poller::{PollEvent, PollTriggerEvent},
+    wrapper::InternalOps,
+};
 use common::errors::SvcError;
 use common_lib::{
     store::etcd::Etcd,
@@ -206,6 +210,11 @@ impl Registry {
     async fn init(&self) {
         let mut store = self.store.lock().await;
         self.specs.init(store.deref_mut()).await;
+    }
+
+    /// Send a triggered event signal to the reconciler module
+    pub(crate) async fn notify(&self, event: PollTriggerEvent) {
+        self.reconciler.notify(PollEvent::Triggered(event)).await
     }
 
     /// Poll each node for resource updates

--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -43,6 +43,9 @@ pub struct Registry {
     inner: Arc<RegistryInner<Etcd>>,
 }
 
+/// Map that stores the actual state of the nodes
+pub(crate) type NodesMapLocked = Arc<RwLock<HashMap<NodeId, Arc<Mutex<NodeWrapper>>>>>;
+
 impl Deref for Registry {
     type Target = Arc<RegistryInner<Etcd>>;
 
@@ -54,19 +57,19 @@ impl Deref for Registry {
 /// Generic Registry Inner with a Store trait
 #[derive(Debug)]
 pub struct RegistryInner<S: Store> {
-    /// the actual state of the node
-    pub(crate) nodes: Arc<RwLock<HashMap<NodeId, Arc<Mutex<NodeWrapper>>>>>,
+    /// the actual state of the nodes
+    nodes: NodesMapLocked,
     /// spec (aka desired state) of the various resources
-    pub(crate) specs: ResourceSpecsLocked,
+    specs: ResourceSpecsLocked,
     /// period to refresh the cache
     cache_period: std::time::Duration,
-    pub(crate) store: Arc<Mutex<S>>,
+    store: Arc<Mutex<S>>,
     /// store gRPC operation timeout
     store_timeout: std::time::Duration,
     /// reconciliation period when no work is being done
-    pub(crate) reconcile_idle_period: std::time::Duration,
+    reconcile_idle_period: std::time::Duration,
     /// reconciliation period when work is pending
-    pub(crate) reconcile_period: std::time::Duration,
+    reconcile_period: std::time::Duration,
     reconciler: ReconcilerControl,
     config: CoreRegistryConfig,
 }
@@ -128,6 +131,24 @@ impl Registry {
         &self.config
     }
 
+    /// reconciliation period when no work is being done
+    pub(crate) fn reconcile_idle_period(&self) -> std::time::Duration {
+        self.reconcile_idle_period
+    }
+    /// reconciliation period when work is pending
+    pub(crate) fn reconcile_period(&self) -> std::time::Duration {
+        self.reconcile_period
+    }
+
+    /// Get a reference to the actual state of the nodes
+    pub(crate) fn nodes(&self) -> &NodesMapLocked {
+        &self.nodes
+    }
+    /// Get a reference to the locked resource specs object
+    pub(crate) fn specs(&self) -> &ResourceSpecsLocked {
+        &self.specs
+    }
+
     /// Serialized write to the persistent store
     pub async fn store_obj<O: StorableObject>(&self, object: &O) -> Result<(), SvcError> {
         let mut store = self.store.lock().await;
@@ -183,9 +204,9 @@ impl Registry {
         }
     }
 
-    /// Get the locked resource specs object
-    pub(crate) fn specs(&self) -> &ResourceSpecsLocked {
-        &self.specs
+    /// Get a reference to the persistent store
+    pub(crate) fn store(&self) -> &Arc<Mutex<Etcd>> {
+        &self.store
     }
 
     /// Check if the persistent store is currently online
@@ -220,7 +241,7 @@ impl Registry {
     /// Poll each node for resource updates
     async fn poller(&self) {
         loop {
-            let nodes = self.nodes.read().await.clone();
+            let nodes = self.nodes().read().await.clone();
             for (_, node) in nodes.iter() {
                 let lock = node.grpc_lock().await;
                 let _guard = lock.lock().await;

--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -179,6 +179,11 @@ impl Registry {
         }
     }
 
+    /// Get the locked resource specs object
+    pub(crate) fn specs(&self) -> &ResourceSpecsLocked {
+        &self.specs
+    }
+
     /// Check if the persistent store is currently online
     pub async fn store_online(&self) -> bool {
         let mut store = self.store.lock().await;

--- a/control-plane/agents/core/src/core/scheduling/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/mod.rs
@@ -56,7 +56,7 @@ impl NodeFilters {
     /// Should only attempt to use nodes not currently used by the volume
     pub(crate) fn unused(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
         let registry = request.registry();
-        let used_nodes = registry.specs.get_volume_data_nodes(&request.uuid);
+        let used_nodes = registry.specs().get_volume_data_nodes(&request.uuid);
         !used_nodes.contains(&item.pool.node)
     }
 }

--- a/control-plane/agents/core/src/core/scheduling/nexus.rs
+++ b/control-plane/agents/core/src/core/scheduling/nexus.rs
@@ -74,7 +74,7 @@ impl GetPersistedNexusChildrenCtx {
         // find all replica status
         let state_replicas = self.registry.get_replicas().await;
         // find all replica specs for this volume
-        let spec_replicas = self.registry.specs.get_volume_replicas(&self.spec.uuid);
+        let spec_replicas = self.registry.specs().get_volume_replicas(&self.spec.uuid);
         // all pools
         let pool_wrappers = self.registry.get_pool_wrappers().await;
 

--- a/control-plane/agents/core/src/core/scheduling/volume.rs
+++ b/control-plane/agents/core/src/core/scheduling/volume.rs
@@ -193,8 +193,8 @@ impl GetChildForRemovalContext {
     }
 
     async fn list(&self) -> Vec<ReplicaItem> {
-        let replicas = self.registry.specs.get_volume_replicas(&self.spec.uuid);
-        let nexuses = self.registry.specs.get_volume_nexuses(&self.spec.uuid);
+        let replicas = self.registry.specs().get_volume_replicas(&self.spec.uuid);
+        let nexuses = self.registry.specs().get_volume_nexuses(&self.spec.uuid);
         let replicas = replicas.iter().map(|r| r.lock().clone());
 
         let replica_states = self.registry.get_replicas().await;
@@ -435,7 +435,7 @@ impl VolumeReplicasForNexusCtx {
         // find all replica specs which are not yet part of the nexus
         let spec_replicas = self
             .registry
-            .specs
+            .specs()
             .get_volume_replicas(&self.vol_spec.uuid)
             .into_iter()
             .filter(|r| !self.nexus_spec.contains_replica(&r.lock().uuid));

--- a/control-plane/agents/core/src/core/task_poller.rs
+++ b/control-plane/agents/core/src/core/task_poller.rs
@@ -1,4 +1,4 @@
-use crate::core::registry::Registry;
+use crate::core::{registry::Registry, specs::ResourceSpecsLocked};
 use common::errors::SvcError;
 
 /// Poll Event that identifies why a poll is running
@@ -93,6 +93,10 @@ impl PollContext {
     /// Get a reference to the core registry
     pub(crate) fn registry(&self) -> &Registry {
         &self.registry
+    }
+    /// Get a reference to the locked resource specs object
+    pub(crate) fn specs(&self) -> &ResourceSpecsLocked {
+        self.registry.specs()
     }
 
     #[allow(dead_code)]

--- a/control-plane/agents/core/src/core/task_poller.rs
+++ b/control-plane/agents/core/src/core/task_poller.rs
@@ -9,18 +9,16 @@ pub(crate) enum PollEvent {
     /// Request Triggered by another component
     /// example: A node has come back online so it could be a good idea to run the
     /// reconciliation loop's as soon as possible
-    #[allow(dead_code)]
     Triggered(PollTriggerEvent),
     /// Shutdown the pollers
     Shutdown,
 }
 
 /// Poll Trigger source
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) enum PollTriggerEvent {
-    /// A node state has changed
-    NodeStateChange,
+    /// A node state has changed to Online
+    NodeStateChangeOnline,
 }
 
 /// State of a poller

--- a/control-plane/agents/core/src/core/wrapper.rs
+++ b/control-plane/agents/core/src/core/wrapper.rs
@@ -490,6 +490,7 @@ impl ClientOps for Arc<tokio::sync::Mutex<NodeWrapper>> {
                 })?;
         let pool = rpc_pool_to_bus(&rpc_pool.into_inner(), &request.node);
         self.lock().await.update_pool_states().await?;
+        self.lock().await.update_replica_states().await?;
         Ok(pool)
     }
     /// Destroy a pool on the node via gRPC
@@ -521,6 +522,7 @@ impl ClientOps for Arc<tokio::sync::Mutex<NodeWrapper>> {
 
         let replica = rpc_replica_to_bus(&rpc_replica.into_inner(), &request.node);
         self.lock().await.update_replica_states().await?;
+        self.lock().await.update_pool_states().await?;
         Ok(replica)
     }
 
@@ -570,6 +572,7 @@ impl ClientOps for Arc<tokio::sync::Mutex<NodeWrapper>> {
                 request: "destroy_replica",
             })?;
         self.lock().await.update_replica_states().await?;
+        self.lock().await.update_pool_states().await?;
         Ok(())
     }
 

--- a/control-plane/agents/core/src/nexus/service.rs
+++ b/control-plane/agents/core/src/nexus/service.rs
@@ -1,4 +1,4 @@
-use crate::core::registry::Registry;
+use crate::core::{registry::Registry, specs::ResourceSpecsLocked};
 use common::errors::SvcError;
 use common_lib::{
     mbus_api::message_bus::v0::Nexuses,
@@ -19,6 +19,9 @@ pub(super) struct Service {
 impl Service {
     pub(super) fn new(registry: Registry) -> Self {
         Self { registry }
+    }
+    fn specs(&self) -> &ResourceSpecsLocked {
+        self.registry.specs()
     }
 
     /// Get nexuses according to the filter
@@ -44,8 +47,7 @@ impl Service {
     /// Create nexus
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn create_nexus(&self, request: &CreateNexus) -> Result<Nexus, SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .create_nexus(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -53,8 +55,7 @@ impl Service {
     /// Destroy nexus
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn destroy_nexus(&self, request: &DestroyNexus) -> Result<(), SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .destroy_nexus(&self.registry, request, true, OperationMode::Exclusive)
             .await
     }
@@ -62,8 +63,7 @@ impl Service {
     /// Share nexus
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn share_nexus(&self, request: &ShareNexus) -> Result<String, SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .share_nexus(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -71,8 +71,7 @@ impl Service {
     /// Unshare nexus
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.uuid))]
     pub(super) async fn unshare_nexus(&self, request: &UnshareNexus) -> Result<(), SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .unshare_nexus(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -80,8 +79,7 @@ impl Service {
     /// Add nexus child
     #[tracing::instrument(level = "info", skip(self), err, fields(nexus.uuid = %request.nexus))]
     pub(super) async fn add_nexus_child(&self, request: &AddNexusChild) -> Result<Child, SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .add_nexus_child(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -92,8 +90,7 @@ impl Service {
         &self,
         request: &RemoveNexusChild,
     ) -> Result<(), SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .remove_nexus_child(&self.registry, request, OperationMode::Exclusive)
             .await
     }

--- a/control-plane/agents/core/src/nexus/specs.rs
+++ b/control-plane/agents/core/src/nexus/specs.rs
@@ -79,7 +79,7 @@ impl SpecOperations for NexusSpec {
     }
     fn remove_spec(locked_spec: &Arc<Mutex<Self>>, registry: &Registry) {
         let uuid = locked_spec.lock().uuid.clone();
-        registry.specs.remove_nexus(&uuid);
+        registry.specs().remove_nexus(&uuid);
     }
 
     fn dirty(&self) -> bool {

--- a/control-plane/agents/core/src/node/mod.rs
+++ b/control-plane/agents/core/src/node/mod.rs
@@ -123,7 +123,7 @@ mod tests {
             &new_node(maya_name.clone(), grpc.clone(), NodeStatus::Online)
         );
 
-        cluster.composer().stop("mayastor").await.unwrap();
+        cluster.composer().stop(maya_name.as_str()).await.unwrap();
         cluster.composer().restart("core").await.unwrap();
         Liveness {}
             .request_on_ext(ChannelVs::Node, bus_timeout)

--- a/control-plane/agents/core/src/node/mod.rs
+++ b/control-plane/agents/core/src/node/mod.rs
@@ -41,7 +41,7 @@ async fn create_node_service(builder: &Service) -> service::Service {
     let service = service::Service::new(registry.clone(), deadline, request, connect);
 
     // attempt to reload the node state based on the specification
-    for node in registry.specs.get_nodes() {
+    for node in registry.specs().get_nodes() {
         service
             .register_state(&Register {
                 id: node.id().clone(),

--- a/control-plane/agents/core/src/node/registry.rs
+++ b/control-plane/agents/core/src/node/registry.rs
@@ -8,13 +8,13 @@ use tokio::sync::Mutex;
 impl Registry {
     /// Get all node wrappers
     pub(crate) async fn get_node_wrappers(&self) -> Vec<Arc<Mutex<NodeWrapper>>> {
-        let nodes = self.nodes.read().await;
+        let nodes = self.nodes().read().await;
         nodes.values().cloned().collect()
     }
 
     /// Get all node states
     pub(crate) async fn get_node_states(&self) -> Vec<NodeState> {
-        let nodes = self.nodes.read().await;
+        let nodes = self.nodes().read().await;
         let mut nodes_vec = vec![];
         for node in nodes.values() {
             nodes_vec.push(node.lock().await.node_state().clone());
@@ -27,9 +27,9 @@ impl Registry {
         &self,
         node_id: &NodeId,
     ) -> Result<Arc<Mutex<NodeWrapper>>, SvcError> {
-        match self.nodes.read().await.get(node_id).cloned() {
+        match self.nodes().read().await.get(node_id).cloned() {
             None => {
-                if self.specs.get_node(node_id).is_ok() {
+                if self.specs().get_node(node_id).is_ok() {
                     Err(SvcError::NodeNotOnline {
                         node: node_id.to_owned(),
                     })
@@ -45,9 +45,9 @@ impl Registry {
 
     /// Get node state by its `NodeId`
     pub(crate) async fn get_node_state(&self, node_id: &NodeId) -> Result<NodeState, SvcError> {
-        match self.nodes.read().await.get(node_id).cloned() {
+        match self.nodes().read().await.get(node_id).cloned() {
             None => {
-                if self.specs.get_node(node_id).is_ok() {
+                if self.specs().get_node(node_id).is_ok() {
                     Err(SvcError::NodeNotOnline {
                         node: node_id.to_owned(),
                     })
@@ -64,7 +64,7 @@ impl Registry {
     /// Register new NodeSpec for the given `Register` Request
     pub(super) async fn register_node_spec(&self, request: &Register) {
         if self.config().node_registration().automatic() {
-            self.specs.register_node(self, request).await.ok();
+            self.specs().register_node(self, request).await.ok();
         }
     }
 }

--- a/control-plane/agents/core/src/node/service.rs
+++ b/control-plane/agents/core/src/node/service.rs
@@ -1,7 +1,8 @@
 use super::*;
-use crate::core::{registry::Registry, wrapper::NodeWrapper};
-
-use crate::core::reconciler::PollTriggerEvent;
+use crate::core::{
+    reconciler::PollTriggerEvent, registry::Registry, specs::ResourceSpecsLocked,
+    wrapper::NodeWrapper,
+};
 use common::{
     errors::{GrpcRequestError, SvcError},
     v0::msg_translation::RpcToMessageBus,
@@ -9,6 +10,7 @@ use common::{
 use common_lib::types::v0::message_bus::{
     Filter, GetSpecs, Node, NodeId, NodeState, NodeStatus, Specs, States,
 };
+
 use rpc::mayastor::ListBlockDevicesRequest;
 use snafu::ResultExt;
 use std::{collections::HashMap, sync::Arc};
@@ -63,11 +65,14 @@ impl Service {
             comms_timeouts: NodeCommsTimeout::new(connect, request),
         }
     }
+    fn specs(&self) -> &ResourceSpecsLocked {
+        self.registry.specs()
+    }
 
     /// Callback to be called when a node's watchdog times out
     pub(super) async fn on_timeout(service: &Service, id: &NodeId) {
         let registry = service.registry.clone();
-        let state = registry.nodes.read().await;
+        let state = registry.nodes().read().await;
         if let Some(node) = state.get(id) {
             let mut node = node.lock().await;
             if node.is_online() {
@@ -96,7 +101,7 @@ impl Service {
         };
 
         let mut send_event = true;
-        let mut nodes = self.registry.nodes.write().await;
+        let mut nodes = self.registry.nodes().write().await;
         match nodes.get_mut(&node.id) {
             None => {
                 let mut node = NodeWrapper::new(&node, self.deadline, self.comms_timeouts.clone());
@@ -122,7 +127,7 @@ impl Service {
 
     /// Deregister a node through the deregister information
     pub(super) async fn deregister(&self, node: &Deregister) {
-        let nodes = self.registry.nodes.read().await;
+        let nodes = self.registry.nodes().read().await;
         match nodes.get(&node.id) {
             None => {}
             // ideally we want this node to disappear completely when it's not
@@ -140,7 +145,7 @@ impl Service {
         match request.filter() {
             Filter::None => {
                 let node_states = self.registry.get_node_states().await;
-                let node_specs = self.registry.specs.get_nodes();
+                let node_specs = self.specs().get_nodes();
                 let mut nodes = HashMap::new();
 
                 node_states.into_iter().for_each(|state| {
@@ -163,7 +168,7 @@ impl Service {
             }
             Filter::Node(node_id) => {
                 let node_state = self.registry.get_node_state(node_id).await.ok();
-                let node_spec = self.registry.specs.get_node(node_id).ok();
+                let node_spec = self.specs().get_node(node_id).ok();
                 if node_state.is_none() && node_spec.is_none() {
                     Err(SvcError::NodeNotFound {
                         node_id: node_id.to_owned(),
@@ -214,7 +219,7 @@ impl Service {
 
     /// Get specs from the registry
     pub(crate) async fn get_specs(&self, _request: &GetSpecs) -> Result<Specs, SvcError> {
-        let specs = self.registry.specs.write();
+        let specs = self.specs().write();
         Ok(Specs {
             volumes: specs.get_volumes(),
             nexuses: specs.get_nexuses(),
@@ -230,7 +235,7 @@ impl Service {
         let mut replicas = vec![];
 
         // Aggregate the state information from each node.
-        let nodes = self.registry.nodes.read().await;
+        let nodes = self.registry.nodes().read().await;
         for (_node_id, locked_node_wrapper) in nodes.iter() {
             let node_wrapper = locked_node_wrapper.lock().await;
             nexuses.extend(node_wrapper.nexus_states());

--- a/control-plane/agents/core/src/pool/registry.rs
+++ b/control-plane/agents/core/src/pool/registry.rs
@@ -18,14 +18,14 @@ impl Registry {
                         .await?
                         .into_iter()
                         .map(|state| {
-                            let spec = self.specs.get_pool(&state.id).ok();
+                            let spec = self.specs().get_pool(&state.id).ok();
                             Pool::from_state(state, spec)
                         });
 
                 pools.extend(pools_from_state);
 
                 let pools_from_spec = self
-                    .specs
+                    .specs()
                     .get_pools()
                     .into_iter()
                     .filter(|p| !pools.iter().any(|i| i.id() == &p.id))
@@ -42,14 +42,14 @@ impl Registry {
                         .await?
                         .into_iter()
                         .map(|state| {
-                            let spec = self.specs.get_pool(&state.id).ok();
+                            let spec = self.specs().get_pool(&state.id).ok();
                             Pool::from_state(state, spec)
                         });
 
                 pools.extend(pools_from_state);
 
                 let pools_from_spec = self
-                    .specs
+                    .specs()
                     .get_pools()
                     .into_iter()
                     .filter(|p| p.node == node_id)
@@ -120,7 +120,7 @@ impl Registry {
     /// Get the pool object corresponding to the id.
     pub(crate) async fn get_pool(&self, id: &PoolId) -> Result<Pool, SvcError> {
         Pool::try_new(
-            self.specs.get_pool(id).ok(),
+            self.specs().get_pool(id).ok(),
             self.get_pool_state(id).await.ok(),
         )
         .ok_or(PoolNotFound {

--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -379,7 +379,7 @@ impl ResourceSpecsLocked {
             })
     }
     /// Get a vector of protected PoolSpec's
-    fn get_locked_pools(&self) -> Vec<Arc<Mutex<PoolSpec>>> {
+    pub(crate) fn get_locked_pools(&self) -> Vec<Arc<Mutex<PoolSpec>>> {
         let specs = self.read();
         specs.pools.to_vec()
     }

--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -38,7 +38,7 @@ impl SpecOperations for PoolSpec {
         registry: &Registry,
     ) -> Result<(), SvcError> {
         let id = locked_spec.lock().id.clone();
-        let pool_in_use = registry.specs.pool_has_replicas(&id);
+        let pool_in_use = registry.specs().pool_has_replicas(&id);
         if pool_in_use {
             Err(SvcError::InUse {
                 kind: ResourceKind::Pool,
@@ -56,7 +56,7 @@ impl SpecOperations for PoolSpec {
     }
     fn remove_spec(locked_spec: &Arc<Mutex<Self>>, registry: &Registry) {
         let id = locked_spec.lock().id.clone();
-        registry.specs.remove_pool(&id);
+        registry.specs().remove_pool(&id);
     }
     fn dirty(&self) -> bool {
         // pools are not updatable currently, so the spec is never dirty (not written to etcd)
@@ -120,7 +120,7 @@ impl SpecOperations for ReplicaSpec {
     }
     fn remove_spec(locked_spec: &Arc<Mutex<Self>>, registry: &Registry) {
         let uuid = locked_spec.lock().uuid.clone();
-        registry.specs.remove_replica(&uuid);
+        registry.specs().remove_replica(&uuid);
     }
     fn dirty(&self) -> bool {
         self.pending_op()

--- a/control-plane/agents/core/src/pool/tests.rs
+++ b/control-plane/agents/core/src/pool/tests.rs
@@ -11,8 +11,15 @@ use common_lib::{
         store::replica::ReplicaSpec,
     },
 };
+use itertools::Itertools;
 use std::time::Duration;
-use testlib::{Cluster, ClusterBuilder};
+use testlib::{
+    v0::{
+        models::{CreateVolumeBody, Pool, PoolState, Topology, VolumeHealPolicy},
+        VolumeId,
+    },
+    Cluster, ClusterBuilder,
+};
 
 #[actix_rt::test]
 async fn pool() {
@@ -329,4 +336,115 @@ async fn replica_transaction_store() {
         (UnshareReplica::from(&replica), Protocol::None),
     )
     .await;
+}
+
+const RECONCILE_TIMEOUT_SECS: u64 = 7;
+const POOL_FILE_NAME: &str = "disk1.img";
+const POOL_SIZE_BYTES: u64 = 128 * 1024 * 1024;
+
+#[actix_rt::test]
+async fn reconciler() {
+    let disk = testlib::TmpDiskFile::new(POOL_FILE_NAME, POOL_SIZE_BYTES);
+
+    let cluster = ClusterBuilder::builder()
+        .with_rest(true)
+        .with_agents(vec!["core"])
+        .with_mayastors(1)
+        .with_pool(disk.uri())
+        .with_cache_period("1s")
+        .with_reconcile_period(Duration::from_secs(1), Duration::from_secs(1))
+        .build()
+        .await
+        .unwrap();
+
+    let nodes = GetNodes::default().request().await.unwrap();
+    tracing::info!("Nodes: {:?}", nodes);
+
+    missing_pool_state(&cluster).await;
+}
+
+/// Creates a pool on a mayastor instance, which will have both spec and state.
+/// Stops/Kills the mayastor container. At some point we will have no pool state, because the node
+/// is gone. We then restart the node and the pool reconciler will then recreate the pool! At this
+/// point, we'll have a state again.
+async fn missing_pool_state(cluster: &Cluster) {
+    let client = cluster.rest_v00();
+    let pools_api = client.pools_api();
+    let volumes_api = client.volumes_api();
+
+    // create volume to fill up some of the pool space
+    for _ in 0 .. 10 {
+        let body =
+            CreateVolumeBody::new(VolumeHealPolicy::default(), 1, 8388608u64, Topology::new());
+        let volume = VolumeId::new();
+        volumes_api.put_volume(volume.as_str(), body).await.unwrap();
+    }
+    let replicas = client.replicas_api().get_replicas().await.unwrap();
+
+    let pool = pools_api
+        .get_pool(cluster.pool(0, 0).as_str())
+        .await
+        .unwrap();
+    tracing::info!("Pool: {:#?}", pool);
+
+    assert!(pool.spec.is_some());
+    assert!(pool.state.is_some());
+
+    let maya = cluster.node(0);
+    async fn pool_checker(cluster: &Cluster, state: Option<&PoolState>) {
+        let maya = cluster.node(0);
+
+        let pool = wait_till_pool_state(cluster, (0, 0), false).await;
+        assert!(pool.state.is_none());
+
+        cluster.composer().start(maya.as_str()).await.unwrap();
+        let pool = wait_till_pool_state(cluster, (0, 0), true).await;
+        // the state should be the same as it was before
+        assert_eq!(pool.state.as_ref(), state);
+    }
+
+    // let's stop the mayastor container, gracefully
+    cluster.composer().stop(maya.as_str()).await.unwrap();
+    pool_checker(cluster, pool.state.as_ref()).await;
+
+    // now kill it, so there's no deregistration message
+    cluster.composer().kill(maya.as_str()).await.unwrap();
+    pool_checker(cluster, pool.state.as_ref()).await;
+
+    // we should have also "imported" the same replicas, perhaps in a different order...
+    let current_replicas = client.replicas_api().get_replicas().await.unwrap();
+    assert_eq!(
+        replicas
+            .iter()
+            .sorted_by(|a, b| a.uuid.cmp(&b.uuid))
+            .collect::<Vec<_>>(),
+        current_replicas
+            .iter()
+            .sorted_by(|a, b| a.uuid.cmp(&b.uuid))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Wait until the specified pool state option presence matches the `has_state` flag
+async fn wait_till_pool_state(cluster: &Cluster, pool: (u32, u32), has_state: bool) -> Pool {
+    let pool_id = cluster.pool(pool.0, pool.1);
+    let timeout = Duration::from_secs(RECONCILE_TIMEOUT_SECS);
+    let client = cluster.rest_v00();
+    let pools_api = client.pools_api();
+    let start = std::time::Instant::now();
+    loop {
+        let pool = pools_api.get_pool(pool_id.as_str()).await.unwrap();
+
+        if pool.state.is_some() == has_state {
+            return pool;
+        }
+
+        if std::time::Instant::now() > (start + timeout) {
+            panic!(
+                "Timeout waiting for the pool to have 'has_state': '{}'. Pool: '{:#?}'",
+                has_state, pool
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
 }

--- a/control-plane/agents/core/src/volume/registry.rs
+++ b/control-plane/agents/core/src/volume/registry.rs
@@ -12,15 +12,15 @@ impl Registry {
         volume_uuid: &VolumeId,
     ) -> Result<VolumeState, SvcError> {
         let nexuses = self.get_node_opt_nexuses(None).await?;
-        let nexus_specs = self.specs.get_volume_nexuses(volume_uuid);
+        let nexus_specs = self.specs().get_volume_nexuses(volume_uuid);
         let nexus_states = nexus_specs
             .iter()
             .map(|n| nexuses.iter().find(|nexus| nexus.uuid == n.lock().uuid))
             .flatten()
             .collect::<Vec<_>>();
-        let replica_specs = self.specs.get_volume_replicas(volume_uuid);
+        let replica_specs = self.specs().get_volume_replicas(volume_uuid);
         let volume_spec = self
-            .specs
+            .specs()
             .get_locked_volume(volume_uuid)
             .context(VolumeNotFound {
                 vol_id: volume_uuid.to_string(),
@@ -66,7 +66,7 @@ impl Registry {
     /// Get all volumes
     pub(super) async fn get_volumes(&self) -> Vec<Volume> {
         let mut volumes = vec![];
-        let volume_specs = self.specs.get_volumes();
+        let volume_specs = self.specs().get_volumes();
         for spec in &volume_specs {
             volumes.push(Volume::new(
                 spec,
@@ -79,7 +79,7 @@ impl Registry {
     /// Return a volume object corresponding to the ID.
     pub(crate) async fn get_volume(&self, id: &VolumeId) -> Result<Volume, SvcError> {
         Ok(Volume::new(
-            &self.specs.get_volume(id)?,
+            &self.specs().get_volume(id)?,
             &self.get_volume_state(id).await.ok(),
         ))
     }

--- a/control-plane/agents/core/src/volume/service.rs
+++ b/control-plane/agents/core/src/volume/service.rs
@@ -1,4 +1,4 @@
-use crate::core::registry::Registry;
+use crate::core::{registry::Registry, specs::ResourceSpecsLocked};
 use common::errors::SvcError;
 use common_lib::{
     mbus_api::message_bus::v0::Volumes,
@@ -19,6 +19,9 @@ pub(super) struct Service {
 impl Service {
     pub(super) fn new(registry: Registry) -> Self {
         Self { registry }
+    }
+    fn specs(&self) -> &ResourceSpecsLocked {
+        self.registry.specs()
     }
 
     /// Get volumes
@@ -46,8 +49,7 @@ impl Service {
     /// Create volume
     #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn create_volume(&self, request: &CreateVolume) -> Result<Volume, SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .create_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -55,8 +57,7 @@ impl Service {
     /// Destroy volume
     #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn destroy_volume(&self, request: &DestroyVolume) -> Result<(), SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .destroy_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -64,8 +65,7 @@ impl Service {
     /// Share volume
     #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn share_volume(&self, request: &ShareVolume) -> Result<String, SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .share_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -73,8 +73,7 @@ impl Service {
     /// Unshare volume
     #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn unshare_volume(&self, request: &UnshareVolume) -> Result<(), SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .unshare_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -82,8 +81,7 @@ impl Service {
     /// Publish volume
     #[tracing::instrument(level = "info", skip(self), err, fields(volume.uuid = %request.uuid))]
     pub(super) async fn publish_volume(&self, request: &PublishVolume) -> Result<Volume, SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .publish_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -94,8 +92,7 @@ impl Service {
         &self,
         request: &UnpublishVolume,
     ) -> Result<Volume, SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .unpublish_volume(&self.registry, request, OperationMode::Exclusive)
             .await
     }
@@ -106,8 +103,7 @@ impl Service {
         &self,
         request: &SetVolumeReplica,
     ) -> Result<Volume, SvcError> {
-        self.registry
-            .specs
+        self.specs()
             .set_volume_replica(&self.registry, request, OperationMode::Exclusive)
             .await
     }

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -1093,7 +1093,7 @@ impl ResourceSpecsLocked {
                 .iter()
                 .fold(0usize, |mut c, child| {
                     if let Some(replica) = child.as_replica() {
-                        if registry.specs.get_replica(replica.uuid()).is_some() {
+                        if registry.specs().get_replica(replica.uuid()).is_some() {
                             c += 1;
                         }
                     }
@@ -1434,11 +1434,11 @@ impl SpecOperations for VolumeSpec {
 
             VolumeOperation::RemoveUnusedReplica(uuid) => {
                 let last_replica = !registry
-                    .specs
+                    .specs()
                     .get_volume_replicas(&self.uuid)
                     .iter()
                     .any(|r| &r.lock().uuid != uuid);
-                let nexuses = registry.specs.get_volume_nexuses(&self.uuid);
+                let nexuses = registry.specs().get_volume_nexuses(&self.uuid);
                 let used = nexuses.iter().any(|n| n.lock().contains_replica(uuid));
                 if last_replica {
                     Err(SvcError::LastReplica {
@@ -1496,7 +1496,7 @@ impl SpecOperations for VolumeSpec {
     }
     fn remove_spec(locked_spec: &Arc<Mutex<Self>>, registry: &Registry) {
         let uuid = locked_spec.lock().uuid.clone();
-        registry.specs.remove_volume(&uuid);
+        registry.specs().remove_volume(&uuid);
     }
     fn dirty(&self) -> bool {
         self.pending_op()

--- a/control-plane/agents/core/src/watcher/watch.rs
+++ b/control-plane/agents/core/src/watcher/watch.rs
@@ -447,7 +447,7 @@ impl StoreWatcher {
         };
 
         let mut watch_cfg = watch_cfg.lock().await;
-        watch_cfg.add(&watch, self.registry.store.clone()).await?;
+        watch_cfg.add(&watch, self.registry.store().clone()).await?;
         Ok(())
     }
 

--- a/deployer/src/infra/mayastor.rs
+++ b/deployer/src/infra/mayastor.rs
@@ -10,7 +10,8 @@ impl ComponentAction for Mayastor {
             let mut bin = Binary::from_path("mayastor")
                 .with_nats("-n")
                 .with_args(vec!["-N", &Self::name(i, options)])
-                .with_args(vec!["-g", &mayastor_socket]);
+                .with_args(vec!["-g", &mayastor_socket])
+                .with_bind("/tmp", "/host/tmp");
 
             if options.developer_delayed {
                 bin = bin.with_env("DEVELOPER_DELAYED", "1");

--- a/deployer/src/infra/mayastor.rs
+++ b/deployer/src/infra/mayastor.rs
@@ -43,11 +43,7 @@ impl ComponentAction for Mayastor {
 }
 
 impl Mayastor {
-    pub fn name(i: u32, options: &StartOptions) -> String {
-        if options.mayastors == 1 {
-            "mayastor".into()
-        } else {
-            format!("mayastor-{}", i + 1)
-        }
+    pub fn name(i: u32, _options: &StartOptions) -> String {
+        format!("mayastor-{}", i + 1)
     }
 }

--- a/tests/bdd/common.py
+++ b/tests/bdd/common.py
@@ -9,7 +9,7 @@ import docker
 
 REST_SERVER = "http://localhost:8081/v0"
 POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
-NODE_NAME = "mayastor"
+NODE_NAME = "mayastor-1"
 
 
 # Return a configuration which can be used for API calls.

--- a/tests/bdd/test_volume_create.py
+++ b/tests/bdd/test_volume_create.py
@@ -28,7 +28,7 @@ NUM_VOLUME_REPLICAS = 1
 REST_SERVER = "http://localhost:8081/v0"
 CREATE_REQUEST_KEY = "create_request"
 POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
-NODE_NAME = "mayastor"
+NODE_NAME = "mayastor-1"
 
 
 # This fixture will be automatically used by all tests.
@@ -133,7 +133,7 @@ def there_are_no_available_mayastor_instances():
     """there are no available Mayastor instances."""
     # Kill mayastor instance
     docker_client = docker.from_env()
-    container = docker_client.containers.get("mayastor")
+    container = docker_client.containers.get("mayastor-1")
     container.kill()
 
 

--- a/tests/bdd/test_volume_delete.py
+++ b/tests/bdd/test_volume_delete.py
@@ -17,7 +17,7 @@ from openapi.openapi_client.model.protocol import Protocol
 
 POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
 VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
-NODE_NAME = "mayastor"
+NODE_NAME = "mayastor-1"
 VOLUME_CTX_KEY = "volume"
 
 

--- a/tests/bdd/test_volume_observability.py
+++ b/tests/bdd/test_volume_observability.py
@@ -20,7 +20,7 @@ from openapi.openapi_client.model.spec_status import SpecStatus
 
 POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
 VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
-NODE_NAME = "mayastor"
+NODE_NAME = "mayastor-1"
 VOLUME_CTX_KEY = "volume"
 VOLUME_SIZE = 10485761
 

--- a/tests/bdd/test_volume_publish.py
+++ b/tests/bdd/test_volume_publish.py
@@ -17,7 +17,7 @@ from openapi.openapi_client.model.protocol import Protocol
 
 POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
 VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
-NODE_NAME = "mayastor"
+NODE_NAME = "mayastor-1"
 VOLUME_CTX_KEY = "volume"
 VOLUME_SIZE = 10485761
 

--- a/tests/bdd/test_volume_unpublish.py
+++ b/tests/bdd/test_volume_unpublish.py
@@ -17,7 +17,7 @@ from openapi.openapi_client.model.protocol import Protocol
 
 POOL_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
 VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
-NODE_NAME = "mayastor"
+NODE_NAME = "mayastor-1"
 VOLUME_CTX_KEY = "volume"
 VOLUME_SIZE = 10485761
 

--- a/tests/tests-mayastor/tests/pools.rs
+++ b/tests/tests-mayastor/tests/pools.rs
@@ -7,8 +7,8 @@ async fn create_pool_malloc() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -22,8 +22,8 @@ async fn create_pool_with_missing_disk() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["/dev/c/3po".into()],
         })
         .await
@@ -37,8 +37,8 @@ async fn create_pool_with_existing_disk() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -47,8 +47,8 @@ async fn create_pool_with_existing_disk() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop-new".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -57,8 +57,8 @@ async fn create_pool_with_existing_disk() {
     cluster
         .rest_v0()
         .destroy_pool(v0::DestroyPool {
-            node: "mayastor".into(),
-            id: "pooloop".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
         })
         .await
         .unwrap();
@@ -66,8 +66,8 @@ async fn create_pool_with_existing_disk() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop-new".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -81,8 +81,8 @@ async fn create_pool_idempotent() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -91,8 +91,8 @@ async fn create_pool_idempotent() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -112,8 +112,8 @@ async fn create_pool_idempotent_same_disk_different_query() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["malloc:///disk?size_mb=100&blk_size=512".into()],
         })
         .await
@@ -122,8 +122,8 @@ async fn create_pool_idempotent_same_disk_different_query() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor".into(),
-            id: "pooloop".into(),
+            node: cluster.node(0),
+            id: cluster.pool(0, 0),
             disks: vec!["malloc:///disk?size_mb=200&blk_size=4096".into()],
         })
         .await
@@ -141,8 +141,8 @@ async fn create_pool_idempotent_different_nvmf_host() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor-1".into(),
-            id: "pooloop-1".into(),
+            node: cluster.node(1),
+            id: cluster.pool(1, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -151,8 +151,8 @@ async fn create_pool_idempotent_different_nvmf_host() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor-2".into(),
-            id: "pooloop-2".into(),
+            node: cluster.node(2),
+            id: cluster.pool(2, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -161,8 +161,8 @@ async fn create_pool_idempotent_different_nvmf_host() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor-2".into(),
-            id: "pooloop-2".into(),
+            node: cluster.node(2),
+            id: cluster.pool(2, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await
@@ -171,8 +171,8 @@ async fn create_pool_idempotent_different_nvmf_host() {
     cluster
         .rest_v0()
         .create_pool(v0::CreatePool {
-            node: "mayastor-2".into(),
-            id: "pooloop-x".into(),
+            node: cluster.node(2),
+            id: cluster.pool(2, 0),
             disks: vec!["malloc:///disk?size_mb=100".into()],
         })
         .await


### PR DESCRIPTION
chore(tests): always use "mayastor-{}" format

feat: add pool reconciler to recreate pools

feat: kick the reconcile loop when a node changes to online

test(pools): basic pool reconciler tests
Stops/Kills mayastor and on restart it makes sure the pools get recreated again.
It also checks that the existing replicas have been reimported.
