### PR TITLE
chore: remove ana bits from existing non-ana volumes

### DIFF
--- a/common/src/types/v0/message_bus/volume.rs
+++ b/common/src/types/v0/message_bus/volume.rs
@@ -106,8 +106,6 @@ impl VolumeState {
     }
 }
 
-/// ANA not supported at the moment, so derive volume state from the
-/// single Nexus instance
 impl From<(&VolumeId, &Nexus)> for VolumeState {
     fn from(src: (&VolumeId, &Nexus)) -> Self {
         let uuid = src.0.clone();

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -33,8 +33,16 @@ pub enum SvcError {
         endpoint: String,
         timeout: std::time::Duration,
     },
-    #[snafu(display("Failed to connect to node via gRPC"))]
-    GrpcConnect { source: tonic::transport::Error },
+    #[snafu(display(
+        "Failed to connect to node '{}' via gRPC endpoint '{}'",
+        node_id,
+        endpoint
+    ))]
+    GrpcConnect {
+        node_id: String,
+        endpoint: String,
+        source: tonic::transport::Error,
+    },
     #[snafu(display("Node '{}' has invalid gRPC URI '{}'", node_id, uri))]
     GrpcConnectUri {
         node_id: String,
@@ -322,11 +330,11 @@ impl From<SvcError> for ReplyError {
                 extra: error.full_string(),
             },
 
-            SvcError::GrpcConnect { source } => ReplyError {
+            SvcError::GrpcConnect { .. } => ReplyError {
                 kind: ReplyErrorKind::Internal,
                 resource: ResourceKind::Unknown,
                 source: desc.to_string(),
-                extra: source.to_string(),
+                extra: error_str,
             },
 
             SvcError::NotEnoughResources { ref source } => ReplyError {

--- a/control-plane/agents/core/src/core/scheduling/resources/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/resources/mod.rs
@@ -64,18 +64,17 @@ impl ReplicaItem {
     pub(crate) fn new(
         replica: ReplicaSpec,
         replica_state: Option<&Replica>,
-        child_uri: Vec<ChildUri>,
-        child_states: Vec<Child>,
-        child_specs: Vec<NexusChild>,
+        child_uri: Option<ChildUri>,
+        child_state: Option<Child>,
+        child_spec: Option<NexusChild>,
         child_info: Option<ChildInfo>,
     ) -> Self {
         Self {
             replica_spec: replica,
             replica_state: replica_state.cloned(),
-            child_uri: child_uri.first().cloned(),
-            // ANA not currently supported
-            child_state: child_states.first().cloned(),
-            child_spec: child_specs.first().cloned(),
+            child_uri,
+            child_state,
+            child_spec,
             child_info,
         }
     }

--- a/control-plane/agents/core/src/server.rs
+++ b/control-plane/agents/core/src/server.rs
@@ -23,7 +23,7 @@ pub(crate) struct CliArgs {
 
     /// The period at which the registry updates its cache of all
     /// resources from all nodes
-    #[structopt(long, short, default_value = "20s")]
+    #[structopt(long, short, default_value = "30s")]
     pub(crate) cache_period: humantime::Duration,
 
     /// The period at which the reconcile loop checks for new work
@@ -31,7 +31,7 @@ pub(crate) struct CliArgs {
     pub(crate) reconcile_idle_period: humantime::Duration,
 
     /// The period at which the reconcile loop attempts to do work
-    #[structopt(long, default_value = "3s")]
+    #[structopt(long, default_value = "10s")]
     pub(crate) reconcile_period: humantime::Duration,
 
     /// Deadline for the mayastor instance keep alive registration
@@ -54,7 +54,7 @@ pub(crate) struct CliArgs {
     pub(crate) connect: humantime::Duration,
 
     /// The timeout for every node request operation (gRPC)
-    #[structopt(long, short, default_value = "6s")]
+    #[structopt(long, short, default_value = "5s")]
     pub(crate) request: humantime::Duration,
 
     /// Trace rest requests to the Jaeger endpoint agent

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1933,7 +1933,7 @@ components:
     CreateVolumeBody:
       example:
         policy:
-          self_heal: false
+          self_heal: true
           topology: null
         replicas: 1
         size: 10485761
@@ -2475,7 +2475,6 @@ components:
     VolumeSpec:
       example:
         labels: null
-        num_paths: 1
         num_replicas: 2
         operation: null
         protocol: none
@@ -2491,12 +2490,6 @@ components:
           type: array
           items:
             type: string
-        num_paths:
-          description: Number of front-end paths.
-          type: integer
-          format: uint8
-          minimum: 0
-          maximum: 255
         num_replicas:
           description: Number of children the volume should have.
           type: integer
@@ -2518,8 +2511,8 @@ components:
                 - Destroy
                 - Share
                 - Unshare
-                - AddReplica
-                - RemoveReplica
+                - SetReplica
+                - RemoveUnusedReplica
                 - Publish
                 - Unpublish
             result:
@@ -2604,18 +2597,18 @@ components:
             - uri
     VolumeState:
       example:
-        children:
-          - children:
-              - rebuildProgress: null
-                state: Online
-                uri: 'nvmf://10.1.0.5:8420/nqn.2019-05.io.openebs:nexus-a76adcd6-9df0-47a1-90a5-2d5bf4151572'
-            deviceUri: ''
-            node: mayastor-1
-            rebuilds: 0
-            share: none
-            size: 80241024
-            state: Online
-            uuid: 61d6afc8-15c6-4127-b0aa-15a570198880
+        child:
+          children:
+            - rebuildProgress: null
+              state: Online
+              uri: 'nvmf://10.1.0.5:8420/nqn.2019-05.io.openebs:nexus-a76adcd6-9df0-47a1-90a5-2d5bf4151572'
+          deviceUri: ''
+          node: mayastor-1
+          rebuilds: 0
+          share: none
+          size: 80241024
+          state: Online
+          uuid: 61d6afc8-15c6-4127-b0aa-15a570198880
         protocol: none
         size: 80241024
         status: Online
@@ -2623,11 +2616,10 @@ components:
       description: Runtime state of the volume
       type: object
       properties:
-        children:
-          description: array of children nexuses
-          type: array
-          items:
-            $ref: '#/components/schemas/Nexus'
+        child:
+          description: nexus child that exposes the target
+          allOf:
+            - $ref: '#/components/schemas/Nexus'
         protocol:
           $ref: '#/components/schemas/Protocol'
         size:

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -397,7 +397,7 @@ async fn client_test(mayastor1: &NodeId, mayastor2: &NodeId, test: &ComposeTest,
         .await
         .unwrap();
     let volume_state = volume.state.expect("Volume state not found.");
-    let nexus = volume_state.children.first().unwrap();
+    let nexus = volume_state.child.unwrap();
     tracing::info!("Published on '{}'", nexus.node);
 
     let volume = client
@@ -407,7 +407,7 @@ async fn client_test(mayastor1: &NodeId, mayastor2: &NodeId, test: &ComposeTest,
         .expect("We have 2 nodes with a pool each");
     tracing::info!("Volume: {:#?}", volume);
     let volume_state = volume.state.expect("No volume state");
-    let nexus = volume_state.children.first().unwrap();
+    let nexus = volume_state.child.unwrap();
     assert_eq!(nexus.children.len(), 2);
 
     let volume = client
@@ -417,7 +417,7 @@ async fn client_test(mayastor1: &NodeId, mayastor2: &NodeId, test: &ComposeTest,
         .expect("Should be able to reduce back to 1");
     tracing::info!("Volume: {:#?}", volume);
     let volume_state = volume.state.expect("No volume state");
-    let nexus = volume_state.children.first().unwrap();
+    let nexus = volume_state.child.unwrap();
     assert_eq!(nexus.children.len(), 1);
 
     let volume = client
@@ -427,7 +427,7 @@ async fn client_test(mayastor1: &NodeId, mayastor2: &NodeId, test: &ComposeTest,
         .unwrap();
     tracing::info!("Volume: {:#?}", volume);
     let volume_state = volume.state.expect("No volume state");
-    assert!(volume_state.children.is_empty());
+    assert!(volume_state.child.is_none());
 
     let volume_uuid = volume_state.uuid.to_string();
 

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -11,7 +11,7 @@ The `deployer` tool facilitates this by creating a composable docker `"cluster"`
 
 **Using the help**
 ```textmate
-[nix-shell:~/git/Mayastor]$ cargo run --bin deployer -- --help
+[nix-shell:~/git/mayastor-control-plane]$ cargo run --bin deployer -- --help
   deployer --help
   agents 0.1.0
   Deployment actions
@@ -34,29 +34,33 @@ The help can also be used on each subcommand.
 **Deploying the cluster with default components**
 
 ```textmate
-[nix-shell:~/git/Mayastor]$ cargo run --bin deployer -- start -m 2
-    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
-     Running `sh /home/tiago/git/myconfigs/maya/test_as_sudo.sh target/debug/deployer start`
-Using options: CliArgs { action: Start(StartOptions { agents: [Node(Node), Pool(Pool), Volume(Volume)], base_image: None, jaeger: false, no_rest: false, mayastors: 2, jaeger_image: None, build: false, dns: false, show_info: false, cluster_name: "cluster" }) }
+[nix-shell:~/git/mayastor-control-plane]$ cargo run --bin deployer -- start -m 2 -s
+    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
+     Running `sh /home/tiago/git/myconfigs/maya/test_as_sudo.sh target/debug/deployer start -m 2 -s`
+Sep 10 09:45:32.422  INFO deployer: Using options: CliArgs { action: Start(StartOptions { agents: [Core(Core)], kube_config: None, base_image: None, jaeger: false, elastic: false, kibana: false, no_rest: false, mayastors: 2, build: false, build_all: false, dns: false, show_info: true, cluster_label: 'io.mayastor.test'.'cluster', no_etcd: false, no_nats: false, cache_period: None, node_deadline: None, node_req_timeout: None, node_conn_timeout: None, store_timeout: None, reconcile_period: None, reconcile_idle_period: None, wait_timeout: None, reuse_cluster: false, developer_delayed: false }) }
+[/mayastor-2] [10.1.0.7] /nix/store/3vxnxa72zdj6nnal3hgx0nnska26s8f4-mayastor/bin/mayastor -N mayastor-2 -g 10.1.0.7:10124 -p etcd.cluster:2379 -n nats.cluster:4222
+[/mayastor-1] [10.1.0.6] /nix/store/3vxnxa72zdj6nnal3hgx0nnska26s8f4-mayastor/bin/mayastor -N mayastor-1 -g 10.1.0.6:10124 -p etcd.cluster:2379 -n nats.cluster:4222
+[/rest] [10.1.0.5] /home/tiago/git/mayastor-control-plane/target/debug/rest --dummy-certificates --no-auth --https rest:8080 --http rest:8081 -n nats.cluster:4222
+[/core] [10.1.0.4] /home/tiago/git/mayastor-control-plane/target/debug/core --store etcd.cluster:2379 -n nats.cluster:4222
+[/etcd] [10.1.0.3] /nix/store/r2av08h9shmgqkzs87j7dhhaxxbpnqkd-etcd-3.3.25/bin/etcd --data-dir /tmp/etcd-data --advertise-client-urls http://0.0.0.0:2379 --listen-client-urls http://0.0.0.0:2379
+[/nats] [10.1.0.2] /nix/store/ffwvclpayymciz4pdabqk7i3prhlz6ik-nats-server-2.2.1/bin/nats-server -DV
 ```
 
 Notice the options which are printed out. They can be overridden - more on this later.
 
 We could also use the `deploy` tool to inspect the components:
 ```textmate
-[nix-shell:~/git/Mayastor]$ cargo run --bin deployer -- list
-   Compiling agents v0.1.0 (/home/tiago/git/Mayastor/agents)
-    Finished dev [unoptimized + debuginfo] target(s) in 5.50s
+[nix-shell:~/git/mayastor-control-plane]$ cargo run --bin deployer -- list
+    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
      Running `sh /home/tiago/git/myconfigs/maya/test_as_sudo.sh target/debug/deployer list`
-Using options: CliArgs { action: List(ListOptions { no_docker: false, format: None }) }
-CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                              NAMES
-e775b6272009        <no image>          "/home/tiago/git/May…"   56 minutes ago      Up 56 minutes       0.0.0.0:8080-8081->8080-8081/tcp   rest
-888da76b62ed        <no image>          "/home/tiago/git/May…"   56 minutes ago      Up 56 minutes                                          volume
-95e8e0c45755        <no image>          "/home/tiago/git/May…"   56 minutes ago      Up 56 minutes                                          pool
-bd1504c962fe        <no image>          "/home/tiago/git/May…"   56 minutes ago      Up 56 minutes                                          node
-e8927a7a1cec        <no image>          "/home/tiago/git/May…"   56 minutes ago      Up 56 minutes                                          mayastor-2
-9788961605c1        <no image>          "/home/tiago/git/May…"   56 minutes ago      Up 56 minutes                                          mayastor-1
-ff94b234f2b9        <no image>          "/nix/store/pbd1hbhx…"   56 minutes ago      Up 56 minutes       0.0.0.0:4222->4222/tcp             nats
+Sep 10 09:44:45.299  INFO deployer: Using options: CliArgs { action: List(ListOptions { no_docker: false, format: None, cluster_label: 'io.mayastor.test'.'cluster' }) }
+CONTAINER ID   IMAGE        COMMAND                  CREATED         STATUS         PORTS                              NAMES
+89614520a612   <no image>   "/nix/store/3vxnxa72…"   2 minutes ago   Up 2 minutes                                      mayastor-2
+82202a62dff9   <no image>   "/nix/store/3vxnxa72…"   2 minutes ago   Up 2 minutes                                      mayastor-1
+9ef521180d3e   <no image>   "/home/tiago/git/chi…"   2 minutes ago   Up 2 minutes   0.0.0.0:8080-8081->8080-8081/tcp   rest
+68aef7fae90c   <no image>   "/home/tiago/git/chi…"   2 minutes ago   Up 2 minutes                                      core
+09a9530aac4f   <no image>   "/nix/store/r2av08h9…"   2 minutes ago   Up 2 minutes   0.0.0.0:2379-2380->2379-2380/tcp   etcd
+60bfe758d371   <no image>   "/nix/store/ffwvclpa…"   2 minutes ago   Up 2 minutes   0.0.0.0:4222->4222/tcp             nats
 ```
 
 As the previous logs shows, the `rest` server ports are mapped to your host on 8080/8081.
@@ -79,10 +83,10 @@ So, we for example list existing `nodes` (aka `mayastor` instances) as such:
 
 To tear-down the cluster, just run the stop command:
 ```textmate
-[nix-shell:~/git/Mayastor]$ cargo run --bin deployer -- stop
-    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
+[nix-shell:~/git/mayastor-control-plane]$ cargo run --bin deployer -- stop
+    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
      Running `sh /home/tiago/git/myconfigs/maya/test_as_sudo.sh target/debug/deployer stop`
-Using options: CliArgs { action: Stop(StopOptions { cluster_name: "cluster" }) }
+Sep 10 09:47:37.497  INFO deployer: Using options: CliArgs { action: Stop(StopOptions { cluster_label: 'io.mayastor.test'.'cluster' }) }
 ```
 
 For more information, please refer to the help argument on every command/subcommand.
@@ -91,29 +95,27 @@ For more information, please refer to the help argument on every command/subcomm
 
 For example, to debug the rest server, we'd create a `cluster` without the rest server:
 ```textmate
-[nix-shell:~/git/Mayastor]$ cargo run --bin deployer -- start --no-rest --show-info
-   Compiling agents v0.1.0 (/home/tiago/git/Mayastor/agents)
-    Finished dev [unoptimized + debuginfo] target(s) in 5.86s
+[nix-shell:~/git/mayastor-control-plane]$ cargo run --bin deployer -- start --no-rest --show-info
+    Finished dev [unoptimized + debuginfo] target(s) in 0.11s
      Running `sh /home/tiago/git/myconfigs/maya/test_as_sudo.sh target/debug/deployer start --no-rest --show-info`
-Using options: CliArgs { action: Start(StartOptions { agents: [Node(Node), Pool(Pool), Volume(Volume)], base_image: None, jaeger: false, no_rest: true, mayastors: 1, jaeger_image: None, build: false, dns: false, show_info: true, cluster_name: "cluster" }) }
-[20994b0098d6] [/volume] /home/tiago/git/Mayastor/target/debug/volume -n nats.cluster:4222
-[f4884e343756] [/pool] /home/tiago/git/Mayastor/target/debug/pool -n nats.cluster:4222
-[fb6e78a0b6ef] [/node] /home/tiago/git/Mayastor/target/debug/node -n nats.cluster:4222
-[992df686ec8a] [/mayastor] /home/tiago/git/Mayastor/target/debug/mayastor -N mayastor -g 10.1.0.3:10124 -n nats.cluster:4222
-[0a5016d6c81f] [/nats] /nix/store/pbd1hbhxm17xy29mg1gibdbvbmr7gnz2-nats-server-2.1.9/bin/nats-server -DV
+Sep 10 09:48:06.445  INFO deployer: Using options: CliArgs { action: Start(StartOptions { agents: [Core(Core)], kube_config: None, base_image: None, jaeger: false, elastic: false, kibana: false, no_rest: true, mayastors: 1, build: false, build_all: false, dns: false, show_info: true, cluster_label: 'io.mayastor.test'.'cluster', no_etcd: false, no_nats: false, cache_period: None, node_deadline: None, node_req_timeout: None, node_conn_timeout: None, store_timeout: None, reconcile_period: None, reconcile_idle_period: None, wait_timeout: None, reuse_cluster: false, developer_delayed: false }) }
+[/mayastor-1] [10.1.0.5] /nix/store/3vxnxa72zdj6nnal3hgx0nnska26s8f4-mayastor/bin/mayastor -N mayastor-1 -g 10.1.0.5:10124 -p etcd.cluster:2379 -n nats.cluster:4222
+[/core] [10.1.0.4] /home/tiago/git/mayastor-control-plane/target/debug/core --store etcd.cluster:2379 -n nats.cluster:4222
+[/etcd] [10.1.0.3] /nix/store/r2av08h9shmgqkzs87j7dhhaxxbpnqkd-etcd-3.3.25/bin/etcd --data-dir /tmp/etcd-data --advertise-client-urls http://0.0.0.0:2379 --listen-client-urls http://0.0.0.0:2379
+[/nats] [10.1.0.2] /nix/store/ffwvclpayymciz4pdabqk7i3prhlz6ik-nats-server-2.2.1/bin/nats-server -DV
 ```
 
 As you can see, there is no `rest` server started - go ahead and start your own!
 This way you can make changes to this specific server and test them without destroying the state of the cluster.
 
 ```textmate
-[nix-shell:~/git/Mayastor]$ cargo run --bin rest
-    Finished dev [unoptimized + debuginfo] target(s) in 0.13s
-     Running `sh /home/tiago/git/myconfigs/maya/test_as_sudo.sh target/debug/rest`
-Jan 27 12:23:44.993  INFO mbus_api::mbus_nats: Connecting to the nats server nats://0.0.0.0:4222...
-Jan 27 12:23:45.007  INFO mbus_api::mbus_nats: Successfully connected to the nats server nats://0.0.0.0:4222
-Jan 27 12:23:45.008  INFO actix_server::builder: Starting 16 workers
-Jan 27 12:23:45.008  INFO actix_server::builder: Starting "actix-web-service-0.0.0.0:8080" service on 0.0.0.0:8080
+[nix-shell:~/git/mayastor-control-plane]$ cargo run --bin rest -- --dummy-certificates --no-auth
+    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
+     Running `sh /home/tiago/git/myconfigs/maya/test_as_sudo.sh target/debug/rest --dummy-certificates --no-auth`
+Sep 10 09:49:16.635  INFO common_lib::mbus_api::mbus_nats: Connecting to the nats server nats://0.0.0.0:4222...
+Sep 10 09:49:17.065  INFO common_lib::mbus_api::mbus_nats: Successfully connected to the nats server nats://0.0.0.0:4222
+Sep 10 09:49:17.067  INFO actix_server::builder: Starting 16 workers
+Sep 10 09:49:17.069  INFO actix_server::builder: Starting "actix-web-service-0.0.0.0:8080" service on 0.0.0.0:8080
 ....
 [nix-shell:~/git/Mayastor]$ curl -k https://localhost:8080/v0/nodes | jq
 [

--- a/deployer/src/infra/mayastor.rs
+++ b/deployer/src/infra/mayastor.rs
@@ -13,6 +13,13 @@ impl ComponentAction for Mayastor {
                 .with_args(vec!["-g", &mayastor_socket])
                 .with_bind("/tmp", "/host/tmp");
 
+            if !options.mayastor_devices.is_empty() {
+                bin = bin.with_privileged(Some(true));
+                for device in options.mayastor_devices.iter() {
+                    bin = bin.with_bind(device, device);
+                }
+            }
+
             if options.developer_delayed {
                 bin = bin.with_env("DEVELOPER_DELAYED", "1");
             }

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -103,8 +103,17 @@ pub struct StartOptions {
     pub no_rest: bool,
 
     /// Use `N` mayastor instances
+    /// Note: the mayastor containers have the host's /tmp directory mapped into the container
+    /// as /host/tmp. This is useful to create pool's from file images.
     #[structopt(short, long, default_value = "1")]
     pub mayastors: u32,
+
+    /// Add host block devices to the mayastor containers as a docker bind mount
+    /// A raw block device: --mayastor-devices /dev/sda /dev/sdb
+    /// An lvm volume group: --mayastor-devices /dev/sdavg
+    /// Note: the mayastor containers will run as `privileged`!
+    #[structopt(long)]
+    pub mayastor_devices: Vec<String>,
 
     /// Cargo Build each component before deploying
     #[structopt(short, long)]

--- a/openapi/docs/models/VolumeSpec.md
+++ b/openapi/docs/models/VolumeSpec.md
@@ -5,7 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **labels** | **Vec<String>** | Volume labels. | 
-**num_paths** | **u8** | Number of front-end paths. | 
 **num_replicas** | **u8** | Number of children the volume should have. | 
 **operation** | Option<[**crate::models::VolumeSpecOperation**](VolumeSpec_operation.md)> |  | [optional]
 **protocol** | [**crate::models::Protocol**](Protocol.md) |  | 

--- a/openapi/docs/models/VolumeState.md
+++ b/openapi/docs/models/VolumeState.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**children** | [**Vec<crate::models::Nexus>**](Nexus.md) | array of children nexuses | 
+**child** | Option<[**crate::models::Nexus**](Nexus.md)> | nexus child that exposes the target | [optional]
 **protocol** | [**crate::models::Protocol**](Protocol.md) |  | 
 **size** | **u64** | size of the volume in bytes | 
 **status** | [**crate::models::VolumeStatus**](VolumeStatus.md) |  | 

--- a/openapi/src/models/volume_spec.rs
+++ b/openapi/src/models/volume_spec.rs
@@ -22,9 +22,6 @@ pub struct VolumeSpec {
     /// Volume labels.
     #[serde(rename = "labels")]
     pub labels: Vec<String>,
-    /// Number of front-end paths.
-    #[serde(rename = "num_paths")]
-    pub num_paths: u8,
     /// Number of children the volume should have.
     #[serde(rename = "num_replicas")]
     pub num_replicas: u8,
@@ -49,7 +46,6 @@ impl VolumeSpec {
     /// VolumeSpec using only the required fields
     pub fn new(
         labels: impl IntoVec<String>,
-        num_paths: impl Into<u8>,
         num_replicas: impl Into<u8>,
         protocol: impl Into<crate::models::Protocol>,
         size: impl Into<u64>,
@@ -58,7 +54,6 @@ impl VolumeSpec {
     ) -> VolumeSpec {
         VolumeSpec {
             labels: labels.into_vec(),
-            num_paths: num_paths.into(),
             num_replicas: num_replicas.into(),
             operation: None,
             protocol: protocol.into(),
@@ -71,7 +66,6 @@ impl VolumeSpec {
     /// VolumeSpec using all fields
     pub fn new_all(
         labels: impl IntoVec<String>,
-        num_paths: impl Into<u8>,
         num_replicas: impl Into<u8>,
         operation: impl Into<Option<crate::models::VolumeSpecOperation>>,
         protocol: impl Into<crate::models::Protocol>,
@@ -82,7 +76,6 @@ impl VolumeSpec {
     ) -> VolumeSpec {
         VolumeSpec {
             labels: labels.into_vec(),
-            num_paths: num_paths.into(),
             num_replicas: num_replicas.into(),
             operation: operation.into(),
             protocol: protocol.into(),

--- a/openapi/src/models/volume_spec_operation.rs
+++ b/openapi/src/models/volume_spec_operation.rs
@@ -58,10 +58,10 @@ pub enum Operation {
     Share,
     #[serde(rename = "Unshare")]
     Unshare,
-    #[serde(rename = "AddReplica")]
-    AddReplica,
-    #[serde(rename = "RemoveReplica")]
-    RemoveReplica,
+    #[serde(rename = "SetReplica")]
+    SetReplica,
+    #[serde(rename = "RemoveUnusedReplica")]
+    RemoveUnusedReplica,
     #[serde(rename = "Publish")]
     Publish,
     #[serde(rename = "Unpublish")]

--- a/openapi/src/models/volume_state.rs
+++ b/openapi/src/models/volume_state.rs
@@ -19,9 +19,9 @@ use crate::apis::IntoVec;
 /// Runtime state of the volume
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct VolumeState {
-    /// array of children nexuses
-    #[serde(rename = "children")]
-    pub children: Vec<crate::models::Nexus>,
+    /// nexus child that exposes the target
+    #[serde(rename = "child", skip_serializing_if = "Option::is_none")]
+    pub child: Option<crate::models::Nexus>,
     #[serde(rename = "protocol")]
     pub protocol: crate::models::Protocol,
     /// size of the volume in bytes
@@ -37,14 +37,13 @@ pub struct VolumeState {
 impl VolumeState {
     /// VolumeState using only the required fields
     pub fn new(
-        children: impl IntoVec<crate::models::Nexus>,
         protocol: impl Into<crate::models::Protocol>,
         size: impl Into<u64>,
         status: impl Into<crate::models::VolumeStatus>,
         uuid: impl Into<uuid::Uuid>,
     ) -> VolumeState {
         VolumeState {
-            children: children.into_vec(),
+            child: None,
             protocol: protocol.into(),
             size: size.into(),
             status: status.into(),
@@ -53,14 +52,14 @@ impl VolumeState {
     }
     /// VolumeState using all fields
     pub fn new_all(
-        children: impl IntoVec<crate::models::Nexus>,
+        child: impl Into<Option<crate::models::Nexus>>,
         protocol: impl Into<crate::models::Protocol>,
         size: impl Into<u64>,
         status: impl Into<crate::models::VolumeStatus>,
         uuid: impl Into<uuid::Uuid>,
     ) -> VolumeState {
         VolumeState {
-            children: children.into_vec(),
+            child: child.into(),
             protocol: protocol.into(),
             size: size.into(),
             status: status.into(),

--- a/shell.nix
+++ b/shell.nix
@@ -37,6 +37,7 @@ mkShell {
     python3
     utillinux
     which
+    tini
   ] ++ pkgs.lib.optional (!norust) channel.nightly
   ++ pkgs.lib.optional (!nomayastor) mayastor.units.debug.mayastor;
 

--- a/tests/bdd/test_volume_create.py
+++ b/tests/bdd/test_volume_create.py
@@ -159,7 +159,6 @@ def volume_creation_should_succeed_with_a_returned_volume_object(create_request)
     expected_spec = VolumeSpec(
         [],
         1,
-        1,
         Protocol("none"),
         VOLUME_SIZE,
         SpecStatus("Created"),
@@ -167,7 +166,6 @@ def volume_creation_should_succeed_with_a_returned_volume_object(create_request)
         _configuration=cfg,
     )
     expected_state = VolumeState(
-        [],
         Protocol("none"),
         VOLUME_SIZE,
         VolumeStatus("Online"),

--- a/tests/bdd/test_volume_observability.py
+++ b/tests/bdd/test_volume_observability.py
@@ -74,7 +74,6 @@ def a_volume_object_representing_the_volume_should_be_returned(volume_ctx):
     expected_spec = VolumeSpec(
         [],
         1,
-        1,
         Protocol("none"),
         VOLUME_SIZE,
         SpecStatus("Created"),
@@ -82,7 +81,6 @@ def a_volume_object_representing_the_volume_should_be_returned(volume_ctx):
         _configuration=cfg,
     )
     expected_state = VolumeState(
-        [],
         Protocol("none"),
         VOLUME_SIZE,
         VolumeStatus("Online"),

--- a/tests/bdd/test_volume_publish.py
+++ b/tests/bdd/test_volume_publish.py
@@ -98,5 +98,6 @@ def publishing_the_volume_should_succeed_with_a_returned_volume_object_containin
         VOLUME_UUID, NODE_NAME, Protocol("nvmf")
     )
     assert str(volume.spec.protocol) == str(Protocol("nvmf"))
-    assert len(volume.state.children) > 0
-    assert "nvmf://" in volume.state.children[0].device_uri
+    assert hasattr(volume.spec, "target_node")
+    assert hasattr(volume.state, "child")
+    assert "nvmf://" in volume.state.child["deviceUri"]

--- a/tests/bdd/test_volume_replicas.py
+++ b/tests/bdd/test_volume_replicas.py
@@ -120,18 +120,19 @@ def a_user_attempts_to_increase_the_number_of_volume_replicas(replica_ctx):
 def a_replica_should_be_removed_from_the_volume(replica_ctx):
     """a replica should be removed from the volume."""
     volume = common.get_volumes_api().get_volume(VOLUME_UUID)
-    assert len(volume.state.children) > 0
-    nexus = volume.state.children[0]
-    assert replica_ctx[REPLICA_CONTEXT_KEY] == len(nexus.children)
+    assert hasattr(volume.state, "child")
+    nexus = volume.state.child
+    assert replica_ctx[REPLICA_CONTEXT_KEY] == len(nexus["children"])
 
 
 @then("an additional replica should be added to the volume")
 def an_additional_replica_should_be_added_to_the_volume(replica_ctx):
     """an additional replica should be added to the volume."""
     volume = common.get_volumes_api().get_volume(VOLUME_UUID)
-    assert len(volume.state.children) > 0
-    nexus = volume.state.children[0]
-    assert replica_ctx[REPLICA_CONTEXT_KEY] == len(nexus.children)
+    print(volume.state)
+    assert hasattr(volume.state, "child")
+    nexus = volume.state.child
+    assert replica_ctx[REPLICA_CONTEXT_KEY] == len(nexus["children"])
 
 
 @then("setting the number of replicas to zero should fail with a suitable error")
@@ -139,7 +140,7 @@ def setting_the_number_of_replicas_to_zero_should_fail_with_a_suitable_error():
     """the replica removal should fail with a suitable error."""
     volumes_api = common.get_volumes_api()
     volume = volumes_api.get_volume(VOLUME_UUID)
-    assert len(volume.state.children) > 0
+    assert hasattr(volume.state, "child")
     try:
         volumes_api.put_volume_replica_count(VOLUME_UUID, 0)
     except Exception as e:

--- a/tests/bdd/test_volume_unpublish.py
+++ b/tests/bdd/test_volume_unpublish.py
@@ -91,4 +91,4 @@ def unpublishing_the_volume_should_succeed():
     """unpublishing the volume should succeed."""
     volume = common.get_volumes_api().del_volume_target(VOLUME_UUID)
     assert str(volume.spec.protocol) == str(Protocol("none"))
-    assert len(volume.state.children) == 0
+    assert not hasattr(volume.state, "child")


### PR DESCRIPTION
chore: remove "ANA bits" from the current volume

A non-ANA volume is only meant to have one active nexus target at a time.
ANA adds a lot more complexity than than just a vector of nexuses, so it's better
to completely ignore multi volume nexuses for now and add it back later as a new
type of volume.
This way we can also make sure that we don't break non-ANA volumes when we start
adding ANA volumes..

--

chore: update the deployer docs and add block devices

Updates the readme.md to match the latest.
Add new option to add a host block device to the mayastor containers.