### PR TITLE
feat(REST timeout): add command line argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,6 +2732,7 @@ dependencies = [
  "composer",
  "futures",
  "http",
+ "humantime",
  "jsonwebtoken",
  "opentelemetry",
  "opentelemetry-jaeger",

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -44,6 +44,7 @@ tinytemplate = "1.2.1"
 jsonwebtoken = "7.2.0"
 composer = { path = "../../composer" }
 common-lib = { path = "../../common" }
+humantime = "2.1.0"
 
 [dev-dependencies]
 rpc = { path = "../../rpc"}

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -50,13 +50,17 @@ pub(crate) struct CliArgs {
     /// Don't authenticate REST requests
     #[structopt(long, required_unless = "jwk")]
     no_auth: bool,
+
+    /// The timeout for every REST request
+    #[structopt(long, short, default_value = "6s")]
+    pub(crate) timeout: humantime::Duration,
 }
 
 /// default timeout options for every bus request
 fn bus_timeout_opts() -> TimeoutOptions {
     TimeoutOptions::default()
         .with_max_retries(0)
-        .with_timeout(Duration::from_secs(6))
+        .with_timeout(CliArgs::from_args().timeout.into())
 }
 
 use actix_web_opentelemetry::RequestTracing;
@@ -65,7 +69,6 @@ use opentelemetry::{
     global,
     sdk::{propagation::TraceContextPropagator, trace::Tracer},
 };
-use std::time::Duration;
 
 fn init_tracing() -> Option<Tracer> {
     if let Ok(filter) = tracing_subscriber::EnvFilter::try_from_default_env() {

--- a/deploy/rest-deployment.yaml
+++ b/deploy/rest-deployment.yaml
@@ -24,6 +24,7 @@ spec:
             - "--no-auth"
             - "-nnats"
             - "--http=0.0.0.0:8081"
+            - "--timeout=6s"
           ports:
           - containerPort: 8080
           - containerPort: 8081


### PR DESCRIPTION
Provide a command line argument which can be used to set the timeout
time for every REST request.