### PR TITLE
fix: use correct key when deleting from store

### DIFF
--- a/common/src/mbus_api/mod.rs
+++ b/common/src/mbus_api/mod.rs
@@ -342,6 +342,7 @@ pub enum ReplyErrorKind {
     ReplicaCountAchieved,
     ReplicaChangeCount,
     ReplicaIncrease,
+    ReplicaCreateNumber,
     VolumeNoReplicas,
     InUse,
 }

--- a/common/src/types/mod.rs
+++ b/common/src/types/mod.rs
@@ -175,6 +175,10 @@ impl From<ReplyError> for RestError<RestJsonError> {
                 let error = RestJsonError::new(details, Kind::InUse);
                 (StatusCode::CONFLICT, error)
             }
+            ReplyErrorKind::ReplicaCreateNumber => {
+                let error = RestJsonError::new(details, Kind::FailedPrecondition);
+                (StatusCode::PRECONDITION_FAILED, error)
+            }
         };
 
         RestError::new(status, error)

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -182,6 +182,8 @@ pub enum SvcError {
     },
     #[snafu(display("No suitable replica removal candidates found for Volume '{}'", id))]
     ReplicaRemovalNoCandidates { id: String },
+    #[snafu(display("Failed to create the desired number of replicas for Volume '{}'", id))]
+    ReplicaCreateNumber { id: String },
     #[snafu(display("No online replicas are available for Volume '{}'", id))]
     NoOnlineReplicas { id: String },
     #[snafu(display("Entry with key '{}' not found in the persistent store.", key))]
@@ -506,6 +508,12 @@ impl From<SvcError> for ReplyError {
             },
             SvcError::NoOnlineReplicas { .. } => ReplyError {
                 kind: ReplyErrorKind::VolumeNoReplicas,
+                resource: ResourceKind::Volume,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+            SvcError::ReplicaCreateNumber { .. } => ReplyError {
+                kind: ReplyErrorKind::ReplicaCreateNumber,
                 resource: ResourceKind::Volume,
                 source: desc.to_string(),
                 extra: error.full_string(),

--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -194,7 +194,10 @@ impl Registry {
             Ok(result) => match result {
                 Ok(_) => Ok(()),
                 // already deleted, no problem
-                Err(StoreError::MissingEntry { .. }) => Ok(()),
+                Err(StoreError::MissingEntry { .. }) => {
+                    tracing::warn!("Entry with key {} missing from store.", key.to_string());
+                    Ok(())
+                }
                 Err(error) => Err(SvcError::from(error)),
             },
             Err(_) => Err(SvcError::from(StoreError::Timeout {

--- a/control-plane/agents/core/src/core/specs.rs
+++ b/control-plane/agents/core/src/core/specs.rs
@@ -187,7 +187,7 @@ pub trait SpecOperations: Clone + Debug + Sized + StorableObject + OperationSequ
         let spec_clone = locked_spec.lock().clone();
 
         // Attempt to delete the spec from the persistent store.
-        match registry.delete_kv(&spec_clone.uuid()).await {
+        match registry.delete_kv(&spec_clone.key().key()).await {
             Ok(_) => {
                 // Delete the spec from the registry.
                 Self::remove_spec(locked_spec, registry);

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -385,10 +385,9 @@ impl ResourceSpecsLocked {
                     ));
                 }
             }
-            Err(SvcError::from(NotEnough::OfReplicas {
-                have: replicas.len() as u64,
-                need: request.replicas,
-            }))
+            Err(SvcError::ReplicaCreateNumber {
+                id: request.uuid.to_string(),
+            })
         } else {
             Ok(())
         };

--- a/tests/bdd/common.py
+++ b/tests/bdd/common.py
@@ -3,6 +3,7 @@ import subprocess
 
 from openapi.openapi_client.api.volumes_api import VolumesApi
 from openapi.openapi_client.api.pools_api import PoolsApi
+from openapi.openapi_client.api.specs_api import SpecsApi
 from openapi.openapi_client import api_client
 from openapi.openapi_client import configuration
 import docker
@@ -29,6 +30,12 @@ def get_volumes_api():
 def get_pools_api():
     api = api_client.ApiClient(get_cfg())
     return PoolsApi(api)
+
+
+# Return a SpecsApi object which can be used for performing spec related REST calls.
+def get_specs_api():
+    api = api_client.ApiClient(get_cfg())
+    return SpecsApi(api)
 
 
 # Start containers

--- a/tests/bdd/features/volume/create.feature
+++ b/tests/bdd/features/volume/create.feature
@@ -16,4 +16,10 @@ Feature: Volume creation
   Scenario: provisioning failure due to missing Mayastor
     Given a request for a volume
     When there are no available Mayastor instances
-    Then volume creation should fail with an insufficient storage error
+    Then volume creation should fail with a precondition failed error
+
+  Scenario: provisioning failure due to gRPC timeout
+    Given a request for a volume
+    When a create operation takes longer than the gRPC timeout
+    Then volume creation should fail with a precondition failed error
+    And there should not be any specs relating to the volume


### PR DESCRIPTION
Ensure the correct key is used when attempting to delete an entry from
the persistent store.

Add a BDD test to check that when a gRPC timeout occurs, associated
specs are correctly deleted from the persistent store.

Resolves: CAS-1103