### PR TITLE
fix: include kubectl-plugin in control plane build

### DIFF
--- a/kubectl-plugin/src/main.rs
+++ b/kubectl-plugin/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(once_cell)]
-
 #[macro_use]
 extern crate prettytable;
 #[macro_use]

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -39,6 +39,7 @@ let
       "composer"
       "control-plane"
       "deployer"
+      "kubectl-plugin"
       "openapi"
       "rpc"
       "tests"


### PR DESCRIPTION
When building the control plane ensure that the kubectl plugin is also
built.