### PR TITLE
fix(kubectl-mayastor): handle cases with empty state for volume and pools, add managed field

### DIFF
--- a/kubectl-plugin/README.md
+++ b/kubectl-plugin/README.md
@@ -39,16 +39,16 @@ The plugin needs to be able to connect to the REST server in order to make the a
 3. Get Pools
 ```
 ❯ kubectl mayastor get pools
- ID               TOTAL CAPACITY  USED CAPACITY  DISKS                                                     NODE      STATUS
- mayastor-pool-1  5360320512      1111490560     aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  kworker1  Online
- mayastor-pool-2  5360320512      2172649472     aio:///dev/vdc?uuid=bb12ec7d-8fc3-4644-82cd-dee5b63fc8c5  kworker1  Online
- mayastor-pool-3  5360320512      3258974208     aio:///dev/vdb?uuid=f324edb7-1aca-41ec-954a-9614527f77e1  kworker2  Online
+ ID               TOTAL CAPACITY  USED CAPACITY  DISKS                                                     NODE      STATUS  MANAGED
+ mayastor-pool-1  5360320512      1111490560     aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  kworker1  Online  true
+ mayastor-pool-2  5360320512      2172649472     aio:///dev/vdc?uuid=bb12ec7d-8fc3-4644-82cd-dee5b63fc8c5  kworker1  Online  true
+ mayastor-pool-3  5360320512      3258974208     aio:///dev/vdb?uuid=f324edb7-1aca-41ec-954a-9614527f77e1  kworker2  Online  false
 ```
 4. Get Pool by ID
 ```
 ❯ kubectl mayastor get pool mayastor-pool-1
- ID               TOTAL CAPACITY  USED CAPACITY  DISKS                                                     NODE      STATUS
- mayastor-pool-1  5360320512      1111490560     aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  kworker1  Online
+ ID               TOTAL CAPACITY  USED CAPACITY  DISKS                                                     NODE      STATUS  MANAGED
+ mayastor-pool-1  5360320512      1111490560     aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  kworker1  Online  true
 ```
 5. Scale Volume by ID
 ```

--- a/kubectl-plugin/src/resources/pool.rs
+++ b/kubectl-plugin/src/resources/pool.rs
@@ -28,8 +28,8 @@ impl CreateRows for Vec<openapi::models::Pool> {
             // The spec would be empty if it was not created using
             // control plane.
             let spec = pool.spec.clone().unwrap_or_default();
-            // In case the state is not coming as filled, either due to pool, node lost, fill in spec
-            // data and mark the status as Unknown.
+            // In case the state is not coming as filled, either due to pool, node lost, fill in
+            // spec data and mark the status as Unknown.
             let state = pool.state.clone().unwrap_or(openapi::models::PoolState {
                 capacity: 0,
                 disks: spec.disks,

--- a/kubectl-plugin/src/resources/pool.rs
+++ b/kubectl-plugin/src/resources/pool.rs
@@ -28,7 +28,7 @@ impl CreateRows for Vec<openapi::models::Pool> {
             // The spec would be empty if it was not created using
             // control plane.
             let spec = pool.spec.clone().unwrap_or_default();
-            // Incase the state is not coming as filled, either due to pool, node lost, fill in spec
+            // In case the state is not coming as filled, either due to pool, node lost, fill in spec
             // data and mark the status as Unknown.
             let state = pool.state.clone().unwrap_or(openapi::models::PoolState {
                 capacity: 0,

--- a/kubectl-plugin/src/resources/utils.rs
+++ b/kubectl-plugin/src/resources/utils.rs
@@ -14,7 +14,8 @@ lazy_static! {
         "USED CAPACITY",
         "DISKS",
         "NODE",
-        "STATUS"
+        "STATUS",
+        "MANAGED"
     ];
 }
 

--- a/kubectl-plugin/src/resources/volume.rs
+++ b/kubectl-plugin/src/resources/volume.rs
@@ -19,7 +19,17 @@ impl CreateRows for Vec<openapi::models::Volume> {
     fn create_rows(&self) -> Vec<Row> {
         let mut rows: Vec<Row> = Vec::new();
         for volume in self {
-            let state = volume.state.as_ref().unwrap();
+            let state = volume
+                .state
+                .clone()
+                // If the state comes as empty fill in the spec data and mark the status as Unknown.
+                .unwrap_or(openapi::models::VolumeState {
+                    child: None,
+                    protocol: volume.spec.protocol,
+                    size: volume.spec.size,
+                    status: openapi::models::VolumeStatus::Unknown,
+                    uuid: volume.spec.uuid,
+                });
             rows.push(row![
                 state.uuid,
                 volume.spec.num_replicas,


### PR DESCRIPTION
### What does this PR do?
- This PR handles the cases when a pool is likely having its state as empty.
- This PR adds a field `MANAGED` to denote whether a pool is created by Control plane or not.