### PR TITLE
chore: use the replica v2 operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "rest",
+ "structopt",
  "tracing",
  "tracing-opentelemetry",
 ]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -34,3 +34,10 @@ pub const DEFAULT_CONN_TIMEOUT: &str = "1s";
 
 /// Use a set of minimum timeouts for specific requests
 pub const ENABLE_MIN_TIMEOUTS: bool = true;
+
+/// Mayastor container image used for testing
+pub const MAYASTOR_IMAGE: &str = "mayadata/mayastor:655ffa91eb87";
+
+/// Mayastor environment variable that points to a mayastor binary
+/// This must be in sync with shell.nix
+pub const MAYASTOR_BINARY: &str = "MAYASTOR_BIN";

--- a/common/src/types/v0/store/replica.rs
+++ b/common/src/types/v0/store/replica.rs
@@ -3,7 +3,7 @@
 use crate::types::v0::{
     message_bus::{
         self, CreateReplica, NodeId, PoolId, Protocol, Replica as MbusReplica, ReplicaId,
-        ReplicaOwners, ReplicaShareProtocol,
+        ReplicaName, ReplicaOwners, ReplicaShareProtocol,
     },
     openapi::models,
     store::{
@@ -66,6 +66,8 @@ impl StorableObject for ReplicaState {
 /// User specification of a replica.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct ReplicaSpec {
+    /// name of the replica
+    pub name: ReplicaName,
     /// uuid of the replica
     pub uuid: ReplicaId,
     /// The size that the replica should be.
@@ -211,6 +213,7 @@ impl From<&ReplicaSpec> for message_bus::Replica {
     fn from(replica: &ReplicaSpec) -> Self {
         Self {
             node: NodeId::default(),
+            name: replica.name.clone(),
             uuid: replica.uuid.clone(),
             pool: replica.pool.clone(),
             thin: replica.thin,
@@ -228,6 +231,7 @@ pub type ReplicaSpecStatus = SpecStatus<message_bus::ReplicaStatus>;
 impl From<&CreateReplica> for ReplicaSpec {
     fn from(request: &CreateReplica) -> Self {
         Self {
+            name: ReplicaName::from_opt_uuid(request.name.as_ref(), &request.uuid),
             uuid: request.uuid.clone(),
             size: request.size,
             pool: request.pool.clone(),

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -1534,39 +1534,3 @@ impl ComposeTest {
         format!("{}.name", self.label_prefix)
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use rpc::mayastor::Null;
-
-    #[tokio::test]
-    async fn compose() {
-        let test = Builder::new()
-            .name("composer")
-            .network("10.1.0.0/16")
-            .expect("Network should be valid")
-            .add_container_spec(
-                ContainerSpec::from_binary(
-                    "nats",
-                    Binary::from_path("nats-server").with_arg("-DV"),
-                )
-                .with_portmap("4222", "4222"),
-            )
-            .add_container("mayastor")
-            .add_container_bin(
-                "mayastor2",
-                Binary::from_path("mayastor").with_args(vec!["-n", "nats.composer"]),
-            )
-            .with_clean(true)
-            .build()
-            .await
-            .unwrap();
-
-        let mut hdl = test.grpc_handle("mayastor").await.unwrap();
-        hdl.mayastor.list_nexus(Null {}).await.expect("list nexus");
-
-        // run with --nocapture to get the logs
-        test.logs_all().await.unwrap();
-    }
-}

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -1051,11 +1051,11 @@ impl ComposeTest {
 
         let mut binds = vec![
             format!("{}:{}", self.srcdir, self.srcdir),
-            "/nix:/nix:ro".into(),
             "/dev/hugepages:/dev/hugepages:rw".into(),
         ];
         binds.extend(spec.binds());
         if let Some(bin) = &spec.binary {
+            binds.push("/nix:/nix:ro".into());
             let path = std::path::PathBuf::from(&bin.path);
             if !path.starts_with("/nix") || !path.starts_with(&self.srcdir) {
                 binds.push(format!("{}:{}", bin.path, bin.path));

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -188,6 +188,8 @@ pub enum SvcError {
     NoOnlineReplicas { id: String },
     #[snafu(display("Entry with key '{}' not found in the persistent store.", key))]
     StoreMissingEntry { key: String },
+    #[snafu(display("The uuid '{}' for kind '{}' is not valid.", uuid, kind.to_string()))]
+    InvalidUuid { uuid: String, kind: ResourceKind },
 }
 
 impl From<StoreError> for SvcError {
@@ -515,6 +517,12 @@ impl From<SvcError> for ReplyError {
             SvcError::ReplicaCreateNumber { .. } => ReplyError {
                 kind: ReplyErrorKind::ReplicaCreateNumber,
                 resource: ResourceKind::Volume,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+            SvcError::InvalidUuid { ref kind, .. } => ReplyError {
+                kind: ReplyErrorKind::InvalidArgument,
+                resource: kind.clone(),
                 source: desc.to_string(),
                 extra: error.full_string(),
             },

--- a/control-plane/agents/common/src/lib.rs
+++ b/control-plane/agents/common/src/lib.rs
@@ -25,7 +25,10 @@ use common_lib::{
         BusClient, BusMessage, DynBus, Error, ErrorChain, Message, MessageId, ReceivedMessage,
         ReceivedRawMessage, TimeoutOptions,
     },
-    types::{v0::message_bus::Liveness, Channel},
+    types::{
+        v0::message_bus::{ChannelVs, Liveness},
+        Channel,
+    },
 };
 
 /// Agent level errors
@@ -341,7 +344,9 @@ impl Service {
             tokio::spawn(async move {
                 let context = Context::new(bus, state);
                 let args = Arguments::new(context, &message);
-                debug!("Processing message: {{ {} }}", args.request);
+                if args.request.channel() != Channel::v0(ChannelVs::Registry) {
+                    debug!("Processing message: {{ {} }}", args.request);
+                }
 
                 if let Err(error) = Self::process_message(args, &gated_subs).await {
                     error!("Error processing message: {}", error.full_string());

--- a/control-plane/agents/core/src/nexus/tests.rs
+++ b/control-plane/agents/core/src/nexus/tests.rs
@@ -49,7 +49,7 @@ async fn nexus() {
         node: mayastor.clone(),
         uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
         size: 5242880,
-        children: vec![replica.uri.into(), local],
+        children: vec![replica.uri.clone().into(), local],
         ..Default::default()
     }
     .request()
@@ -78,15 +78,7 @@ async fn nexus() {
     .await
     .unwrap();
 
-    DestroyReplica {
-        node: replica.node,
-        pool: replica.pool,
-        uuid: replica.uuid,
-        ..Default::default()
-    }
-    .request()
-    .await
-    .unwrap();
+    DestroyReplica::from(replica).request().await.unwrap();
 
     assert!(GetNexuses::default().request().await.unwrap().0.is_empty());
 }

--- a/control-plane/agents/core/src/pool/tests.rs
+++ b/control-plane/agents/core/src/pool/tests.rs
@@ -54,6 +54,7 @@ async fn pool() {
                          * create it like so */
         thin: true,
         share: Protocol::None,
+        name: None,
         ..Default::default()
     }
     .request()
@@ -68,6 +69,7 @@ async fn pool() {
         replica,
         Replica {
             node: mayastor.clone(),
+            name: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
             uuid: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
             pool: "pooloop".into(),
             thin: false,
@@ -83,6 +85,7 @@ async fn pool() {
         uuid: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
         pool: "pooloop".into(),
         protocol: ReplicaShareProtocol::Nvmf,
+        name: None,
     }
     .request()
     .await
@@ -117,6 +120,7 @@ async fn pool() {
         node: mayastor.clone(),
         uuid: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
         pool: "pooloop".into(),
+        name: None,
         ..Default::default()
     }
     .request()

--- a/control-plane/agents/core/src/volume/tests.rs
+++ b/control-plane/agents/core/src/volume/tests.rs
@@ -443,6 +443,7 @@ async fn hotspare_replica_count(cluster: &Cluster) {
     // now add one extra replica (it should be removed)
     CreateReplica {
         node: cluster.node(1),
+        name: Default::default(),
         uuid: ReplicaId::new(),
         pool: cluster.pool(1, 0),
         size: volume.spec().size / 1024 / 1024 + 5,

--- a/control-plane/rest/service/src/v0/replicas.rs
+++ b/control-plane/rest/service/src/v0/replicas.rs
@@ -41,6 +41,7 @@ async fn destroy_replica(filter: Filter) -> Result<(), RestError<RestJsonError>>
         Filter::NodePoolReplica(node_id, pool_id, replica_id) => DestroyReplica {
             node: node_id,
             pool: pool_id,
+            name: None,
             uuid: replica_id,
             ..Default::default()
         },
@@ -53,6 +54,7 @@ async fn destroy_replica(filter: Filter) -> Result<(), RestError<RestJsonError>>
             DestroyReplica {
                 node: node_id,
                 pool: pool_id,
+                name: None,
                 uuid: replica_id,
                 ..Default::default()
             }
@@ -79,6 +81,7 @@ async fn share_replica(
         Filter::NodePoolReplica(node_id, pool_id, replica_id) => ShareReplica {
             node: node_id,
             pool: pool_id,
+            name: None,
             uuid: replica_id,
             protocol,
         },
@@ -91,6 +94,7 @@ async fn share_replica(
             ShareReplica {
                 node: node_id,
                 pool: pool_id,
+                name: None,
                 uuid: replica_id,
                 protocol,
             }
@@ -114,6 +118,7 @@ async fn unshare_replica(filter: Filter) -> Result<(), RestError<RestJsonError>>
         Filter::NodePoolReplica(node_id, pool_id, replica_id) => UnshareReplica {
             node: node_id,
             pool: pool_id,
+            name: None,
             uuid: replica_id,
         },
         Filter::PoolReplica(pool_id, replica_id) => {
@@ -125,6 +130,7 @@ async fn unshare_replica(filter: Filter) -> Result<(), RestError<RestJsonError>>
             UnshareReplica {
                 node: node_id,
                 pool: pool_id,
+                name: None,
                 uuid: replica_id,
             }
         }

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -88,6 +88,7 @@ impl CreateReplicaBody {
     pub fn bus_request(&self, node_id: NodeId, pool_id: PoolId, uuid: ReplicaId) -> CreateReplica {
         CreateReplica {
             node: node_id,
+            name: None,
             uuid,
             pool: pool_id,
             size: self.size,

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -151,7 +151,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
             models::CreateReplicaBody::new_all(
                 models::ReplicaShareProtocol::Nvmf,
                 12582912u64,
-                true,
+                false,
             ),
         )
         .await

--- a/deployer/src/infra/mayastor.rs
+++ b/deployer/src/infra/mayastor.rs
@@ -7,28 +7,37 @@ impl ComponentAction for Mayastor {
         for i in 0 .. options.mayastors {
             let mayastor_socket =
                 format!("{}:10124", cfg.next_ip_for_name(&Self::name(i, options))?);
-            let mut bin = Binary::from_path("mayastor")
-                .with_nats("-n")
-                .with_args(vec!["-N", &Self::name(i, options)])
-                .with_args(vec!["-g", &mayastor_socket])
-                .with_bind("/tmp", "/host/tmp");
+            let name = Self::name(i, options);
+            let nats = format!("nats.{}:4222", options.cluster_label.name());
+            let bin = common_lib::MAYASTOR_BINARY;
+            let binary = options.mayastor_bin.clone().or_else(|| Self::binary(bin));
+
+            let mut spec = if let Some(binary) = binary {
+                ContainerSpec::from_binary(&name, Binary::from_path(&binary))
+            } else {
+                ContainerSpec::from_image(&name, &options.mayastor_image)
+            }
+            .with_args(vec!["-n", &nats])
+            .with_args(vec!["-N", &name])
+            .with_args(vec!["-g", &mayastor_socket])
+            .with_bind("/tmp", "/host/tmp");
 
             if !options.mayastor_devices.is_empty() {
-                bin = bin.with_privileged(Some(true));
+                spec = spec.with_privileged(Some(true));
                 for device in options.mayastor_devices.iter() {
-                    bin = bin.with_bind(device, device);
+                    spec = spec.with_bind(device, device);
                 }
             }
 
             if options.developer_delayed {
-                bin = bin.with_env("DEVELOPER_DELAYED", "1");
+                spec = spec.with_env("DEVELOPER_DELAYED", "1");
             }
 
             if !options.no_etcd {
                 let etcd = format!("etcd.{}:2379", options.cluster_label.name());
-                bin = bin.with_args(vec!["-p", &etcd]);
+                spec = spec.with_args(vec!["-p", &etcd]);
             }
-            cfg = cfg.add_container_bin(&Self::name(i, options), bin)
+            cfg = cfg.add_container_spec(spec)
         }
         Ok(cfg)
     }
@@ -53,5 +62,12 @@ impl ComponentAction for Mayastor {
 impl Mayastor {
     pub fn name(i: u32, _options: &StartOptions) -> String {
         format!("mayastor-{}", i + 1)
+    }
+    fn binary(path: &str) -> Option<String> {
+        match std::env::var_os(&path) {
+            None => None,
+            Some(val) if val.is_empty() => None,
+            Some(val) => Some(val.to_string_lossy().to_string()),
+        }
     }
 }

--- a/deployer/src/infra/mayastor.rs
+++ b/deployer/src/infra/mayastor.rs
@@ -15,6 +15,7 @@ impl ComponentAction for Mayastor {
             let mut spec = if let Some(binary) = binary {
                 ContainerSpec::from_binary(&name, Binary::from_path(&binary))
             } else {
+                println!("using: {}", options.mayastor_image);
                 ContainerSpec::from_image(&name, &options.mayastor_image)
             }
             .with_args(vec!["-n", &nats])

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -115,6 +115,14 @@ pub struct StartOptions {
     #[structopt(short, long, default_value = "1")]
     pub mayastors: u32,
 
+    /// Use the following docker image for the mayastor instances
+    #[structopt(long, default_value = common_lib::MAYASTOR_IMAGE)]
+    pub mayastor_image: String,
+
+    /// Use the following runnable binary for the mayastor instances
+    #[structopt(long, conflicts_with = "mayastor_image")]
+    pub mayastor_bin: Option<String>,
+
     /// Add host block devices to the mayastor containers as a docker bind mount
     /// A raw block device: --mayastor-devices /dev/sda /dev/sdb
     /// An lvm volume group: --mayastor-devices /dev/sdavg

--- a/kubectl-plugin/Cargo.toml
+++ b/kubectl-plugin/Cargo.toml
@@ -13,7 +13,7 @@ awc = "3.0.0-beta.7"
 once_cell = "1.8.0"
 openapi = { path = "../openapi" }
 reqwest = "0.11.4"
-structopt = "0.3.22"
+structopt = "0.3.23"
 yaml-rust = "0.4.5"
 prettytable-rs = "0.8.0"
 lazy_static = "1.4.0"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,14 +1,5 @@
 self: super: {
   images = super.callPackage ./pkgs/images { };
-  mayastor-src = super.fetchFromGitHub rec {
-    rev = "ebe0c03e5f472e94c74889d0a1797949f7e28166";
-    name = "mayastor-${rev}-source";
-    owner = "openebs";
-    repo = "Mayastor";
-    # Use rev from the RPC patch in the workspace's Cargo.toml
-    sha256 = "uLdGaHuHRV3QEcnBgMmzYtXLXur+BgAdzVbGLe6vX4M=";
-
-  };
   control-plane = super.callPackage ./pkgs/control-plane { };
   openapi-generator = super.callPackage ./pkgs/openapi-generator { };
 }

--- a/tests/tests-mayastor/Cargo.toml
+++ b/tests/tests-mayastor/Cargo.toml
@@ -23,3 +23,5 @@ actix-web-opentelemetry = "0.11.0-beta.5"
 tracing = "0.1.26"
 anyhow = "1.0.43"
 common-lib = { path = "../../common" }
+structopt = "0.3.23"
+

--- a/tests/tests-mayastor/tests/nexus.rs
+++ b/tests/tests-mayastor/tests/nexus.rs
@@ -155,6 +155,7 @@ async fn create_nexus_replicas() {
         node: cluster.node(1),
         pool: cluster.pool(1, 0),
         uuid: Cluster::replica(1, 0, 0),
+        name: None,
         protocol: v0::ReplicaShareProtocol::Nvmf,
     }
     .request()

--- a/tests/tests-mayastor/tests/replicas.rs
+++ b/tests/tests-mayastor/tests/replicas.rs
@@ -101,15 +101,10 @@ async fn create_replica_sizes() {
             .request()
             .await;
             if let Ok(replica) = &result {
-                v0::DestroyReplica {
-                    node: replica.node.clone(),
-                    pool: replica.pool.clone(),
-                    uuid: replica.uuid.clone(),
-                    ..Default::default()
-                }
-                .request()
-                .await
-                .unwrap();
+                v0::DestroyReplica::from(replica.clone())
+                    .request()
+                    .await
+                    .unwrap();
             }
             result
         })


### PR DESCRIPTION
chore: use the latest mayastor

------
chore: use the replica v2 operations

Use the replica v2 operations. Replicas now carry a name and a uuid.

Set the name to "mayastor-cp-$replicaId-$volumeId". This could even let us
determine whether a replica is created by us or not and get some more info.

The Share/Unshare/Destroy were noted not to have been updated to V2:
Raised cas-1107 to address this. Meanwhile simply set None for every
request and it gets "hardcoded" to be the same as the uuid.