### PR TITLE
fix: finally use uuid as a Uuid

### DIFF
--- a/common/src/types/v0/message_bus/mod.rs
+++ b/common/src/types/v0/message_bus/mod.rs
@@ -33,7 +33,7 @@ use strum_macros::{EnumString, ToString};
 use crate::mbus_api::{BusClient, DynBus, MessageIdTimeout, TimeoutOptions};
 pub use crate::{
     bus_impl_string_id, bus_impl_string_id_inner, bus_impl_string_id_percent_decoding,
-    bus_impl_string_uuid,
+    bus_impl_string_uuid, bus_impl_string_uuid_inner,
 };
 use std::time::Duration;
 

--- a/common/src/types/v0/message_bus/nexus.rs
+++ b/common/src/types/v0/message_bus/nexus.rs
@@ -53,7 +53,7 @@ impl From<Nexus> for models::Nexus {
             src.share,
             src.size,
             src.status,
-            apis::Uuid::try_from(src.uuid).unwrap(),
+            src.uuid,
         )
     }
 }

--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use crate::types::v0::store::nexus::ReplicaUri;
+use crate::{types::v0::store::nexus::ReplicaUri, IntoOption};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, fmt::Debug, ops::Deref};
 use strum_macros::{EnumString, ToString};
@@ -49,14 +49,7 @@ impl Replica {
     pub fn online(&self) -> bool {
         self.status.online()
     }
-    /// check if it was created by the control plane
-    pub fn ours(&self) -> bool {
-        let base_name = ReplicaName::new(&self.uuid, None);
-        self.name.0.starts_with(base_name.as_str())
-    }
 }
-
-bus_impl_string_uuid!(ReplicaId, "UUID of a mayastor pool replica");
 
 /// Name of a Replica
 #[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
@@ -122,6 +115,8 @@ impl From<Replica> for models::Replica {
         )
     }
 }
+
+bus_impl_string_uuid!(ReplicaId, "UUID of a mayastor pool replica");
 
 impl From<Replica> for DestroyReplica {
     fn from(replica: Replica) -> Self {
@@ -226,7 +221,7 @@ impl From<ReplicaOwners> for models::ReplicaSpecOwners {
                 .iter()
                 .map(|n| apis::Uuid::try_from(n).unwrap())
                 .collect(),
-            volume: src.volume.map(|n| apis::Uuid::try_from(n).unwrap()),
+            volume: src.volume.into_opt(),
         }
     }
 }

--- a/common/src/types/v0/message_bus/volume.rs
+++ b/common/src/types/v0/message_bus/volume.rs
@@ -2,7 +2,7 @@ use super::*;
 
 use crate::{types::v0::store::volume::VolumeSpec, IntoOption};
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt::Debug};
+use std::fmt::Debug;
 
 bus_impl_string_uuid!(VolumeId, "UUID of a mayastor volume");
 
@@ -72,7 +72,7 @@ impl From<VolumeState> for models::VolumeState {
             protocol: volume.protocol.into(),
             size: volume.size,
             status: volume.status.into(),
-            uuid: apis::Uuid::try_from(volume.uuid).unwrap(),
+            uuid: volume.uuid.into(),
         }
     }
 }

--- a/common/src/types/v0/store/mod.rs
+++ b/common/src/types/v0/store/mod.rs
@@ -72,9 +72,10 @@ pub trait SpecTransaction<Operation> {
     fn set_op_result(&mut self, result: bool);
 }
 
-/// Trait which allows a UUID to be returned as a string.
-pub trait UuidString {
-    fn uuid_as_string(&self) -> String;
+/// Trait which allows a UUID to be returned as the associated type Id.
+pub trait ResourceUuid {
+    type Id;
+    fn uuid(&self) -> Self::Id;
 }
 
 /// Sequence operations for a resource without locking it

--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -9,7 +9,7 @@ use crate::types::v0::{
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
         nexus_child::NexusChild,
-        SpecStatus, SpecTransaction, UuidString,
+        ResourceUuid, SpecStatus, SpecTransaction,
     },
 };
 
@@ -39,9 +39,10 @@ impl From<MbusNexus> for NexusState {
     }
 }
 
-impl UuidString for NexusState {
-    fn uuid_as_string(&self) -> String {
-        self.nexus.uuid.clone().into()
+impl ResourceUuid for NexusState {
+    type Id = NexusId;
+    fn uuid(&self) -> Self::Id {
+        self.nexus.uuid.clone()
     }
 }
 
@@ -177,9 +178,10 @@ impl OperationSequencer for NexusSpec {
     }
 }
 
-impl UuidString for NexusSpec {
-    fn uuid_as_string(&self) -> String {
-        self.uuid.clone().into()
+impl ResourceUuid for NexusSpec {
+    type Id = NexusId;
+    fn uuid(&self) -> Self::Id {
+        self.uuid.clone()
     }
 }
 

--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -5,7 +5,7 @@ use crate::types::v0::{
     openapi::models,
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
-        UuidString,
+        ResourceUuid,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -64,9 +64,10 @@ impl From<NodeSpec> for models::NodeSpec {
     }
 }
 
-impl UuidString for NodeSpec {
-    fn uuid_as_string(&self) -> String {
-        self.id.clone().into()
+impl ResourceUuid for NodeSpec {
+    type Id = NodeId;
+    fn uuid(&self) -> Self::Id {
+        self.id.clone()
     }
 }
 

--- a/common/src/types/v0/store/pool.rs
+++ b/common/src/types/v0/store/pool.rs
@@ -5,7 +5,7 @@ use crate::types::v0::{
     openapi::models,
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
-        OperationSequence, OperationSequencer, SpecStatus, SpecTransaction, UuidString,
+        OperationSequence, OperationSequencer, ResourceUuid, SpecStatus, SpecTransaction,
     },
 };
 
@@ -37,9 +37,10 @@ impl From<message_bus::PoolState> for PoolState {
     }
 }
 
-impl UuidString for PoolState {
-    fn uuid_as_string(&self) -> String {
-        self.pool.id.clone().into()
+impl ResourceUuid for PoolState {
+    type Id = PoolId;
+    fn uuid(&self) -> Self::Id {
+        self.pool.id.clone()
     }
 }
 
@@ -113,9 +114,10 @@ impl OperationSequencer for PoolSpec {
     }
 }
 
-impl UuidString for PoolSpec {
-    fn uuid_as_string(&self) -> String {
-        self.id.clone().into()
+impl ResourceUuid for PoolSpec {
+    type Id = PoolId;
+    fn uuid(&self) -> Self::Id {
+        self.id.clone()
     }
 }
 

--- a/common/src/types/v0/store/replica.rs
+++ b/common/src/types/v0/store/replica.rs
@@ -8,7 +8,7 @@ use crate::types::v0::{
     openapi::models,
     store::{
         definitions::{ObjectKey, StorableObject, StorableObjectType},
-        OperationSequence, OperationSequencer, SpecStatus, SpecTransaction, UuidString,
+        OperationSequence, OperationSequencer, ResourceUuid, SpecStatus, SpecTransaction,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -36,9 +36,10 @@ impl From<MbusReplica> for ReplicaState {
     }
 }
 
-impl UuidString for ReplicaState {
-    fn uuid_as_string(&self) -> String {
-        self.replica.uuid.clone().into()
+impl ResourceUuid for ReplicaState {
+    type Id = ReplicaId;
+    fn uuid(&self) -> Self::Id {
+        self.replica.uuid.clone()
     }
 }
 
@@ -101,9 +102,10 @@ impl OperationSequencer for ReplicaSpec {
     }
 }
 
-impl UuidString for ReplicaSpec {
-    fn uuid_as_string(&self) -> String {
-        self.uuid.clone().into()
+impl ResourceUuid for ReplicaSpec {
+    type Id = ReplicaId;
+    fn uuid(&self) -> Self::Id {
+        self.uuid.clone()
     }
 }
 

--- a/common/src/types/v0/store/volume.rs
+++ b/common/src/types/v0/store/volume.rs
@@ -12,12 +12,11 @@ use crate::{
     types::v0::{
         message_bus::{ReplicaId, Topology, VolumeHealPolicy, VolumeStatus},
         openapi::models,
-        store::{OperationSequence, OperationSequencer, UuidString},
+        store::{OperationSequence, OperationSequencer, ResourceUuid},
     },
     IntoOption,
 };
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 
 type VolumeLabel = String;
 
@@ -194,9 +193,10 @@ impl VolumeSpec {
     }
 }
 
-impl UuidString for VolumeSpec {
-    fn uuid_as_string(&self) -> String {
-        self.uuid.clone().into()
+impl ResourceUuid for VolumeSpec {
+    type Id = VolumeId;
+    fn uuid(&self) -> Self::Id {
+        self.uuid.clone()
     }
 }
 
@@ -389,7 +389,7 @@ impl From<VolumeSpec> for models::VolumeSpec {
             src.size,
             src.status,
             src.target.map(|t| t.node).into_opt(),
-            openapi::apis::Uuid::try_from(src.uuid).unwrap(),
+            src.uuid,
         )
     }
 }

--- a/control-plane/agents/core/src/core/resource_map.rs
+++ b/control-plane/agents/core/src/core/resource_map.rs
@@ -1,4 +1,4 @@
-use common_lib::{types::v0::store::UuidString, IntoVec};
+use common_lib::{types::v0::store::ResourceUuid, IntoVec};
 use parking_lot::Mutex;
 use std::{
     collections::{hash_map::Values, HashMap},
@@ -13,8 +13,8 @@ pub struct ResourceMap<I, S> {
 
 impl<I, S> ResourceMap<I, S>
 where
-    I: Eq + Hash + From<String>,
-    S: Clone + UuidString,
+    I: Eq + Hash,
+    S: Clone + ResourceUuid<Id = I>,
 {
     /// Get the resource with the given key.
     pub fn get(&self, key: &I) -> Option<&Arc<Mutex<S>>> {
@@ -28,7 +28,7 @@ where
 
     /// Insert an element or update an existing entry in the map.
     pub fn insert(&mut self, value: S) -> Arc<Mutex<S>> {
-        let key = value.uuid_as_string().into();
+        let key = value.uuid();
         match self.map.get(&key) {
             Some(entry) => {
                 let mut e = entry.lock();
@@ -54,8 +54,7 @@ where
     pub fn populate(&mut self, values: impl IntoVec<S>) {
         assert!(self.map.is_empty());
         for value in values.into_vec() {
-            self.map
-                .insert(value.uuid_as_string().into(), Arc::new(Mutex::new(value)));
+            self.map.insert(value.uuid(), Arc::new(Mutex::new(value)));
         }
     }
 

--- a/control-plane/agents/core/src/core/scheduling/resources/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/resources/mod.rs
@@ -40,6 +40,7 @@ impl PoolItemLister {
             .map(|n| {
                 n.pool_wrappers()
                     .iter()
+                    .filter(|p| registry.specs().get_pool(&p.id).is_ok())
                     .map(|p| PoolItem::new(n.clone(), p.clone()))
                     .collect::<Vec<_>>()
             })

--- a/control-plane/agents/core/src/core/tests.rs
+++ b/control-plane/agents/core/src/core/tests.rs
@@ -23,14 +23,14 @@ async fn bootstrap_registry() {
 
     let replica = client
         .replicas_api()
-        .get_replica(Cluster::replica(0, 0, 0).as_str())
+        .get_replica(&Cluster::replica(0, 0, 0))
         .await
         .unwrap();
     client
         .nexuses_api()
         .put_node_nexus(
             cluster.node(0).as_str(),
-            message_bus::NexusId::new().as_str(),
+            &message_bus::NexusId::new(),
             models::CreateNexusBody::new(vec![replica.uri], size),
         )
         .await

--- a/control-plane/agents/core/src/nexus/tests.rs
+++ b/control-plane/agents/core/src/nexus/tests.rs
@@ -5,13 +5,13 @@ use common_lib::{
     types::v0::{
         message_bus::{
             AddNexusChild, CreateNexus, CreateReplica, DestroyNexus, DestroyReplica, GetNexuses,
-            GetNodes, GetSpecs, Nexus, NexusShareProtocol, Protocol, RemoveNexusChild, ReplicaId,
-            ShareNexus, UnshareNexus,
+            GetNodes, GetSpecs, Nexus, NexusId, NexusShareProtocol, Protocol, RemoveNexusChild,
+            ReplicaId, ShareNexus, UnshareNexus,
         },
         store::nexus::NexusSpec,
     },
 };
-use std::time::Duration;
+use std::{convert::TryFrom, time::Duration};
 use testlib::{Cluster, ClusterBuilder};
 
 #[actix_rt::test]
@@ -47,7 +47,7 @@ async fn nexus() {
 
     let nexus = CreateNexus {
         node: mayastor.clone(),
-        uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
+        uuid: NexusId::try_from("f086f12c-1728-449e-be32-9415051090d6").unwrap(),
         size: 5242880,
         children: vec![replica.uri.clone().into(), local],
         ..Default::default()
@@ -62,7 +62,7 @@ async fn nexus() {
 
     ShareNexus {
         node: mayastor.clone(),
-        uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
+        uuid: NexusId::try_from("f086f12c-1728-449e-be32-9415051090d6").unwrap(),
         key: None,
         protocol: NexusShareProtocol::Nvmf,
     }
@@ -72,7 +72,7 @@ async fn nexus() {
 
     DestroyNexus {
         node: mayastor.clone(),
-        uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
+        uuid: NexusId::try_from("f086f12c-1728-449e-be32-9415051090d6").unwrap(),
     }
     .request()
     .await
@@ -121,7 +121,7 @@ async fn nexus_share_transaction() {
     let local = "malloc:///local?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into();
     let nexus = CreateNexus {
         node: mayastor.clone(),
-        uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
+        uuid: NexusId::try_from("f086f12c-1728-449e-be32-9415051090d6").unwrap(),
         size: 5242880,
         children: vec![local],
         ..Default::default()
@@ -252,7 +252,7 @@ async fn nexus_share_transaction_store() {
     let local = "malloc:///local?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into();
     let nexus = CreateNexus {
         node: mayastor.clone(),
-        uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
+        uuid: NexusId::try_from("f086f12c-1728-449e-be32-9415051090d6").unwrap(),
         size: 5242880,
         children: vec![local],
         ..Default::default()
@@ -303,7 +303,7 @@ async fn nexus_child_transaction() {
     let child2 = "malloc:///ch2?size_mb=12&uuid=4a7b0566-8ec6-49e0-a8b2-1d9a292cf59b";
     let nexus = CreateNexus {
         node: mayastor.clone(),
-        uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
+        uuid: NexusId::try_from("f086f12c-1728-449e-be32-9415051090d6").unwrap(),
         size: 5242880,
         children: vec!["malloc:///ch1?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into()],
         ..Default::default()
@@ -386,7 +386,7 @@ async fn nexus_child_transaction_store() {
 
     let nexus = CreateNexus {
         node: mayastor.clone(),
-        uuid: "f086f12c-1728-449e-be32-9415051090d6".into(),
+        uuid: NexusId::try_from("f086f12c-1728-449e-be32-9415051090d6").unwrap(),
         size: 5242880,
         children: vec!["malloc:///ch1?size_mb=12&uuid=281b87d3-0401-459c-a594-60f76d0ce0da".into()],
         ..Default::default()

--- a/control-plane/agents/core/src/pool/tests.rs
+++ b/control-plane/agents/core/src/pool/tests.rs
@@ -6,13 +6,14 @@ use common_lib::{
     mbus_api::{ReplyError, ReplyErrorKind, ResourceKind, TimeoutOptions},
     types::v0::{
         message_bus::{
-            GetNodes, GetSpecs, Protocol, Replica, ReplicaId, ReplicaShareProtocol, ReplicaStatus,
+            GetNodes, GetSpecs, Protocol, Replica, ReplicaId, ReplicaName, ReplicaShareProtocol,
+            ReplicaStatus,
         },
         store::replica::ReplicaSpec,
     },
 };
 use itertools::Itertools;
-use std::time::Duration;
+use std::{convert::TryFrom, time::Duration};
 use testlib::{
     v0::{
         models::{CreateVolumeBody, Pool, PoolState, Topology, VolumeHealPolicy},
@@ -48,7 +49,7 @@ async fn pool() {
 
     let replica = CreateReplica {
         node: mayastor.clone(),
-        uuid: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
+        uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
         pool: "pooloop".into(),
         size: 12582912, /* actual size will be a multiple of 4MB so just
                          * create it like so */
@@ -69,8 +70,8 @@ async fn pool() {
         replica,
         Replica {
             node: mayastor.clone(),
-            name: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
-            uuid: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
+            name: ReplicaName::from("cf36a440-74c6-4042-b16c-4f7eddfc24da"),
+            uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
             pool: "pooloop".into(),
             thin: false,
             size: 12582912,
@@ -82,7 +83,7 @@ async fn pool() {
 
     let uri = ShareReplica {
         node: mayastor.clone(),
-        uuid: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
+        uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
         pool: "pooloop".into(),
         protocol: ReplicaShareProtocol::Nvmf,
         name: None,
@@ -118,7 +119,7 @@ async fn pool() {
 
     DestroyReplica {
         node: mayastor.clone(),
-        uuid: "cf36a440-74c6-4042-b16c-4f7eddfc24da".into(),
+        uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
         pool: "pooloop".into(),
         name: None,
         ..Default::default()
@@ -381,7 +382,7 @@ async fn missing_pool_state(cluster: &Cluster) {
         let body =
             CreateVolumeBody::new(VolumeHealPolicy::default(), 1, 8388608u64, Topology::new());
         let volume = VolumeId::new();
-        volumes_api.put_volume(volume.as_str(), body).await.unwrap();
+        volumes_api.put_volume(&volume, body).await.unwrap();
     }
     let replicas = client.replicas_api().get_replicas().await.unwrap();
 

--- a/control-plane/agents/core/src/watcher/mod.rs
+++ b/control-plane/agents/core/src/watcher/mod.rs
@@ -99,10 +99,7 @@ mod tests {
         let watch_volume = WatchResourceId::Volume(volume.spec().uuid);
         let callback = url::Url::parse("http://10.1.0.1:8082/test").unwrap();
 
-        let watchers = client
-            .get_watch_volume(volume.spec().uuid.as_str())
-            .await
-            .unwrap();
+        let watchers = client.get_watch_volume(&volume.spec().uuid).await.unwrap();
         assert!(watchers.is_empty());
 
         let mut store = Etcd::new("0.0.0.0:2379")
@@ -110,7 +107,7 @@ mod tests {
             .expect("Failed to connect to etcd.");
 
         client
-            .put_watch_volume(volume.spec().uuid.as_str(), callback.as_str())
+            .put_watch_volume(&volume.spec().uuid, callback.as_str())
             .await
             .expect_err("volume does not exist in the store");
 
@@ -120,14 +117,11 @@ mod tests {
             .unwrap();
 
         client
-            .put_watch_volume(volume.spec().uuid.as_str(), callback.as_str())
+            .put_watch_volume(&volume.spec().uuid, callback.as_str())
             .await
             .unwrap();
 
-        let watchers = client
-            .get_watch_volume(volume.spec().uuid.as_str())
-            .await
-            .unwrap();
+        let watchers = client.get_watch_volume(&volume.spec().uuid).await.unwrap();
         assert_eq!(
             watchers.first(),
             Some(&v0::models::RestWatch {
@@ -147,7 +141,7 @@ mod tests {
             .unwrap();
 
         client
-            .del_watch_volume(volume.spec().uuid.as_str(), callback.as_str())
+            .del_watch_volume(&volume.spec().uuid, callback.as_str())
             .await
             .unwrap();
 
@@ -160,10 +154,7 @@ mod tests {
             .await
             .expect_err("should have been deleted so no callback");
 
-        let watchers = client
-            .get_watch_volume(volume.spec().uuid.as_str())
-            .await
-            .unwrap();
+        let watchers = client.get_watch_volume(&volume.spec().uuid).await.unwrap();
         assert!(watchers.is_empty());
     }
 }

--- a/control-plane/agents/core/src/watcher/service.rs
+++ b/control-plane/agents/core/src/watcher/service.rs
@@ -28,7 +28,7 @@ impl Service {
     }
 
     /// Create new resource watch
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "debug", skip(self), err)]
     pub(super) async fn create_watch(&self, request: &CreateWatch) -> Result<(), SvcError> {
         self.watcher
             .lock()
@@ -43,7 +43,7 @@ impl Service {
     }
 
     /// Get resource watch
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "debug", skip(self), err)]
     pub(super) async fn get_watchers(&self, request: &GetWatchers) -> Result<Watches, SvcError> {
         self.watcher
             .lock()
@@ -53,7 +53,7 @@ impl Service {
     }
 
     /// Delete resource watch
-    #[tracing::instrument(level = "debug", err)]
+    #[tracing::instrument(level = "debug", skip(self), err)]
     pub(super) async fn delete_watch(&self, request: &DeleteWatch) -> Result<(), SvcError> {
         self.watcher
             .lock()

--- a/control-plane/rest/service/src/v0/children.rs
+++ b/control-plane/rest/service/src/v0/children.rs
@@ -1,6 +1,7 @@
 use super::*;
-use common_lib::types::v0::message_bus::{
-    AddNexusChild, Child, ChildUri, Filter, Nexus, RemoveNexusChild,
+use common_lib::types::v0::{
+    message_bus::{AddNexusChild, Child, ChildUri, Filter, Nexus, RemoveNexusChild},
+    openapi::apis::Uuid,
 };
 use mbus_api::{
     message_bus::v0::{BusError, MessageBus, MessageBusTrait},
@@ -104,14 +105,14 @@ fn build_child_uri(child_id: ChildUri, query: &str) -> ChildUri {
 impl apis::Children for RestApi {
     async fn del_nexus_child(
         query: &str,
-        Path((nexus_id, child_id)): Path<(String, String)>,
+        Path((nexus_id, child_id)): Path<(Uuid, String)>,
     ) -> Result<(), RestError<RestJsonError>> {
         delete_child_filtered(child_id.into(), query, Filter::Nexus(nexus_id.into())).await
     }
 
     async fn del_node_nexus_child(
         query: &str,
-        Path((node_id, nexus_id, child_id)): Path<(String, String, String)>,
+        Path((node_id, nexus_id, child_id)): Path<(String, Uuid, String)>,
     ) -> Result<(), RestError<RestJsonError>> {
         delete_child_filtered(
             child_id.into(),
@@ -123,20 +124,20 @@ impl apis::Children for RestApi {
 
     async fn get_nexus_child(
         query: &str,
-        Path((nexus_id, child_id)): Path<(String, String)>,
+        Path((nexus_id, child_id)): Path<(Uuid, String)>,
     ) -> Result<models::Child, RestError<RestJsonError>> {
         get_child_response(child_id.into(), query, Filter::Nexus(nexus_id.into())).await
     }
 
     async fn get_nexus_children(
-        Path(nexus_id): Path<String>,
+        Path(nexus_id): Path<Uuid>,
     ) -> Result<Vec<models::Child>, RestError<RestJsonError>> {
         get_children_response(Filter::Nexus(nexus_id.into())).await
     }
 
     async fn get_node_nexus_child(
         query: &str,
-        Path((node_id, nexus_id, child_id)): Path<(String, String, String)>,
+        Path((node_id, nexus_id, child_id)): Path<(String, Uuid, String)>,
     ) -> Result<models::Child, RestError<RestJsonError>> {
         get_child_response(
             child_id.into(),
@@ -147,21 +148,21 @@ impl apis::Children for RestApi {
     }
 
     async fn get_node_nexus_children(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, Uuid)>,
     ) -> Result<Vec<models::Child>, RestError<RestJsonError>> {
         get_children_response(Filter::NodeNexus(node_id.into(), nexus_id.into())).await
     }
 
     async fn put_nexus_child(
         query: &str,
-        Path((nexus_id, child_id)): Path<(String, String)>,
+        Path((nexus_id, child_id)): Path<(Uuid, String)>,
     ) -> Result<models::Child, RestError<RestJsonError>> {
         add_child_filtered(child_id.into(), query, Filter::Nexus(nexus_id.into())).await
     }
 
     async fn put_node_nexus_child(
         query: &str,
-        Path((node_id, nexus_id, child_id)): Path<(String, String, String)>,
+        Path((node_id, nexus_id, child_id)): Path<(String, Uuid, String)>,
     ) -> Result<models::Child, RestError<RestJsonError>> {
         add_child_filtered(
             child_id.into(),

--- a/control-plane/rest/service/src/v0/nexuses.rs
+++ b/control-plane/rest/service/src/v0/nexuses.rs
@@ -1,5 +1,8 @@
 use super::*;
-use common_lib::types::v0::message_bus::{DestroyNexus, Filter, ShareNexus, UnshareNexus};
+use common_lib::types::v0::{
+    message_bus::{DestroyNexus, Filter, ShareNexus, UnshareNexus},
+    openapi::apis::Uuid,
+};
 use mbus_api::{
     message_bus::v0::{BusError, MessageBus, MessageBusTrait},
     ReplyErrorKind, ResourceKind,
@@ -37,18 +40,18 @@ async fn destroy_nexus(filter: Filter) -> Result<(), RestError<RestJsonError>> {
 
 #[async_trait::async_trait]
 impl apis::Nexuses for RestApi {
-    async fn del_nexus(Path(nexus_id): Path<String>) -> Result<(), RestError<RestJsonError>> {
+    async fn del_nexus(Path(nexus_id): Path<Uuid>) -> Result<(), RestError<RestJsonError>> {
         destroy_nexus(Filter::Nexus(nexus_id.into())).await
     }
 
     async fn del_node_nexus(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, Uuid)>,
     ) -> Result<(), RestError<RestJsonError>> {
         destroy_nexus(Filter::NodeNexus(node_id.into(), nexus_id.into())).await
     }
 
     async fn del_node_nexus_share(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, Uuid)>,
     ) -> Result<(), RestError<RestJsonError>> {
         MessageBus::unshare_nexus(UnshareNexus {
             node: node_id.into(),
@@ -59,7 +62,7 @@ impl apis::Nexuses for RestApi {
     }
 
     async fn get_nexus(
-        Path(nexus_id): Path<String>,
+        Path(nexus_id): Path<Uuid>,
     ) -> Result<models::Nexus, RestError<RestJsonError>> {
         let nexus = MessageBus::get_nexus(Filter::Nexus(nexus_id.into())).await?;
         Ok(nexus.into())
@@ -71,7 +74,7 @@ impl apis::Nexuses for RestApi {
     }
 
     async fn get_node_nexus(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, Uuid)>,
     ) -> Result<models::Nexus, RestError<RestJsonError>> {
         let nexus =
             MessageBus::get_nexus(Filter::NodeNexus(node_id.into(), nexus_id.into())).await?;
@@ -86,7 +89,7 @@ impl apis::Nexuses for RestApi {
     }
 
     async fn put_node_nexus(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, Uuid)>,
         Body(create_nexus_body): Body<models::CreateNexusBody>,
     ) -> Result<models::Nexus, RestError<RestJsonError>> {
         let create =
@@ -96,7 +99,7 @@ impl apis::Nexuses for RestApi {
     }
 
     async fn put_node_nexus_share(
-        Path((node_id, nexus_id, protocol)): Path<(String, String, models::NexusShareProtocol)>,
+        Path((node_id, nexus_id, protocol)): Path<(String, Uuid, models::NexusShareProtocol)>,
     ) -> Result<String, RestError<RestJsonError>> {
         let share = ShareNexus {
             node: node_id.into(),

--- a/control-plane/rest/service/src/v0/replicas.rs
+++ b/control-plane/rest/service/src/v0/replicas.rs
@@ -1,6 +1,7 @@
 use super::*;
-use common_lib::types::v0::message_bus::{
-    DestroyReplica, Filter, ReplicaShareProtocol, ShareReplica, UnshareReplica,
+use common_lib::types::v0::{
+    message_bus::{DestroyReplica, Filter, ReplicaShareProtocol, ShareReplica, UnshareReplica},
+    openapi::apis::Uuid,
 };
 use mbus_api::{
     message_bus::v0::{BusError, MessageBus, MessageBusTrait},
@@ -151,7 +152,7 @@ async fn unshare_replica(filter: Filter) -> Result<(), RestError<RestJsonError>>
 #[async_trait::async_trait]
 impl apis::Replicas for RestApi {
     async fn del_node_pool_replica(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, Uuid)>,
     ) -> Result<(), RestError<RestJsonError>> {
         destroy_replica(Filter::NodePoolReplica(
             node_id.into(),
@@ -162,7 +163,7 @@ impl apis::Replicas for RestApi {
     }
 
     async fn del_node_pool_replica_share(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, Uuid)>,
     ) -> Result<(), RestError<RestJsonError>> {
         unshare_replica(Filter::NodePoolReplica(
             node_id.into(),
@@ -173,19 +174,19 @@ impl apis::Replicas for RestApi {
     }
 
     async fn del_pool_replica(
-        Path((pool_id, replica_id)): Path<(String, String)>,
+        Path((pool_id, replica_id)): Path<(String, Uuid)>,
     ) -> Result<(), RestError<RestJsonError>> {
         destroy_replica(Filter::PoolReplica(pool_id.into(), replica_id.into())).await
     }
 
     async fn del_pool_replica_share(
-        Path((pool_id, replica_id)): Path<(String, String)>,
+        Path((pool_id, replica_id)): Path<(String, Uuid)>,
     ) -> Result<(), RestError<RestJsonError>> {
         unshare_replica(Filter::PoolReplica(pool_id.into(), replica_id.into())).await
     }
 
     async fn get_node_pool_replica(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, Uuid)>,
     ) -> Result<models::Replica, RestError<RestJsonError>> {
         let replica = MessageBus::get_replica(Filter::NodePoolReplica(
             node_id.into(),
@@ -212,7 +213,7 @@ impl apis::Replicas for RestApi {
     }
 
     async fn get_replica(
-        Path(id): Path<String>,
+        Path(id): Path<Uuid>,
     ) -> Result<models::Replica, RestError<RestJsonError>> {
         let replica = MessageBus::get_replica(Filter::Replica(id.into())).await?;
         Ok(replica.into())
@@ -224,7 +225,7 @@ impl apis::Replicas for RestApi {
     }
 
     async fn put_node_pool_replica(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, Uuid)>,
         Body(create_replica_body): Body<models::CreateReplicaBody>,
     ) -> Result<models::Replica, RestError<RestJsonError>> {
         put_replica(
@@ -235,7 +236,7 @@ impl apis::Replicas for RestApi {
     }
 
     async fn put_node_pool_replica_share(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, Uuid)>,
     ) -> Result<String, RestError<RestJsonError>> {
         share_replica(
             Filter::NodePoolReplica(node_id.into(), pool_id.into(), replica_id.into()),
@@ -245,7 +246,7 @@ impl apis::Replicas for RestApi {
     }
 
     async fn put_pool_replica(
-        Path((pool_id, replica_id)): Path<(String, String)>,
+        Path((pool_id, replica_id)): Path<(String, Uuid)>,
         Body(create_replica_body): Body<models::CreateReplicaBody>,
     ) -> Result<models::Replica, RestError<RestJsonError>> {
         put_replica(
@@ -256,7 +257,7 @@ impl apis::Replicas for RestApi {
     }
 
     async fn put_pool_replica_share(
-        Path((pool_id, replica_id)): Path<(String, String)>,
+        Path((pool_id, replica_id)): Path<(String, Uuid)>,
     ) -> Result<String, RestError<RestJsonError>> {
         share_replica(
             Filter::PoolReplica(pool_id.into(), replica_id.into()),

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -1,18 +1,18 @@
 use super::*;
 use common_lib::types::v0::{
     message_bus::{DestroyVolume, Filter},
-    openapi::models::VolumeShareProtocol,
+    openapi::{apis::Uuid, models::VolumeShareProtocol},
 };
 use mbus_api::message_bus::v0::{MessageBus, MessageBusTrait};
 
 #[async_trait::async_trait]
 impl apis::Volumes for RestApi {
-    async fn del_share(Path(volume_id): Path<String>) -> Result<(), RestError<RestJsonError>> {
+    async fn del_share(Path(volume_id): Path<Uuid>) -> Result<(), RestError<RestJsonError>> {
         MessageBus::unshare_volume(volume_id.into()).await?;
         Ok(())
     }
 
-    async fn del_volume(Path(volume_id): Path<String>) -> Result<(), RestError<RestJsonError>> {
+    async fn del_volume(Path(volume_id): Path<Uuid>) -> Result<(), RestError<RestJsonError>> {
         let request = DestroyVolume {
             uuid: volume_id.into(),
         };
@@ -21,7 +21,7 @@ impl apis::Volumes for RestApi {
     }
 
     async fn del_volume_target(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<Uuid>,
     ) -> Result<models::Volume, RestError<RestJsonError>> {
         let volume = MessageBus::unpublish_volume(volume_id.into()).await?;
         Ok(volume.into())
@@ -35,7 +35,7 @@ impl apis::Volumes for RestApi {
     }
 
     async fn get_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<Uuid>,
     ) -> Result<models::Volume, RestError<RestJsonError>> {
         let volume = MessageBus::get_volume(Filter::Volume(volume_id.into())).await?;
         Ok(volume.into())
@@ -47,7 +47,7 @@ impl apis::Volumes for RestApi {
     }
 
     async fn put_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<Uuid>,
         Body(create_volume_body): Body<models::CreateVolumeBody>,
     ) -> Result<models::Volume, RestError<RestJsonError>> {
         let create = CreateVolumeBody::from(create_volume_body).bus_request(volume_id.into());
@@ -56,21 +56,21 @@ impl apis::Volumes for RestApi {
     }
 
     async fn put_volume_replica_count(
-        Path((volume_id, replica_count)): Path<(String, u8)>,
+        Path((volume_id, replica_count)): Path<(Uuid, u8)>,
     ) -> Result<models::Volume, RestError<RestJsonError>> {
         let volume = MessageBus::set_volume_replica(volume_id.into(), replica_count).await?;
         Ok(volume.into())
     }
 
     async fn put_volume_share(
-        Path((volume_id, protocol)): Path<(String, models::VolumeShareProtocol)>,
+        Path((volume_id, protocol)): Path<(Uuid, models::VolumeShareProtocol)>,
     ) -> Result<String, RestError<RestJsonError>> {
         let share_uri = MessageBus::share_volume(volume_id.into(), protocol.into()).await?;
         Ok(share_uri)
     }
 
     async fn put_volume_target(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<Uuid>,
         Query((node, protocol)): Query<(String, VolumeShareProtocol)>,
     ) -> Result<models::Volume, RestError<RestJsonError>> {
         let volume =

--- a/control-plane/rest/service/src/v0/watches.rs
+++ b/control-plane/rest/service/src/v0/watches.rs
@@ -1,6 +1,9 @@
 use super::*;
-use common_lib::types::v0::message_bus::{
-    CreateWatch, DeleteWatch, GetWatchers, WatchCallback, WatchResourceId, WatchType,
+use common_lib::types::v0::{
+    message_bus::{
+        CreateWatch, DeleteWatch, GetWatchers, WatchCallback, WatchResourceId, WatchType,
+    },
+    openapi::apis::Uuid,
 };
 use mbus_api::Message;
 use std::convert::TryFrom;
@@ -8,7 +11,7 @@ use std::convert::TryFrom;
 #[async_trait::async_trait]
 impl apis::Watches for RestApi {
     async fn del_watch_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<Uuid>,
         Query(callback): Query<url::Url>,
     ) -> Result<(), RestError<RestJsonError>> {
         DeleteWatch {
@@ -23,7 +26,7 @@ impl apis::Watches for RestApi {
     }
 
     async fn get_watch_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<Uuid>,
     ) -> Result<Vec<models::RestWatch>, RestError<RestJsonError>> {
         let watches = GetWatchers {
             resource: WatchResourceId::Volume(volume_id.into()),
@@ -38,7 +41,7 @@ impl apis::Watches for RestApi {
     }
 
     async fn put_watch_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<Uuid>,
         Query(callback): Query<url::Url>,
     ) -> Result<(), RestError<RestJsonError>> {
         CreateWatch {

--- a/deployer/src/infra/mayastor.rs
+++ b/deployer/src/infra/mayastor.rs
@@ -15,7 +15,6 @@ impl ComponentAction for Mayastor {
             let mut spec = if let Some(binary) = binary {
                 ContainerSpec::from_binary(&name, Binary::from_path(&binary))
             } else {
-                println!("using: {}", options.mayastor_image);
                 ContainerSpec::from_image(&name, &options.mayastor_image)
             }
             .with_args(vec!["-n", &nats])

--- a/kubectl-plugin/src/resources/mod.rs
+++ b/kubectl-plugin/src/resources/mod.rs
@@ -4,7 +4,7 @@ pub mod volume;
 
 use structopt::StructOpt;
 
-pub(crate) type VolumeId = String;
+pub(crate) type VolumeId = openapi::apis::Uuid;
 pub(crate) type ReplicaCount = u8;
 pub(crate) type PoolId = String;
 

--- a/kubectl-plugin/src/rest_wrapper.rs
+++ b/kubectl-plugin/src/rest_wrapper.rs
@@ -17,8 +17,10 @@ impl RestClient {
         let mut url = url.clone();
         url.set_scheme("http")
             .map_err(|_| anyhow::anyhow!("Failed to set REST client scheme"))?;
-        url.set_port(Some(30011))
-            .map_err(|_| anyhow::anyhow!("Failed to set REST client port"))?;
+        if url.port().is_none() {
+            url.set_port(Some(30011))
+                .map_err(|_| anyhow::anyhow!("Failed to set REST client port"))?;
+        }
         REST_SERVER.get_or_init(|| url);
         Ok(())
     }

--- a/nix/pkgs/openapi-generator/source.json
+++ b/nix/pkgs/openapi-generator/source.json
@@ -1,6 +1,6 @@
 {
   "owner": "openebs",
   "repo": "openapi-generator",
-  "rev": "0a43dc6a4711c5bb6fab23d0f6aee0ef5298c1c8",
-  "sha256": "1484z2k5g6v65445jrvvmq15k9j2nmxi172qzmca00biwamd4cdp"
+  "rev": "7b7ff247f4d9166d9daeaf160fd63512fc8ee039",
+  "sha256": "09vss8yc1anbs6wp1l7x2ckpjl5h5wns7l434byzy2p4srlvz8k7"
 }

--- a/openapi/src/apis/children_api.rs
+++ b/openapi/src/apis/children_api.rs
@@ -15,32 +15,32 @@ use actix_web::web::Json;
 pub trait Children {
     async fn del_nexus_child(
         query: &str,
-        Path((nexus_id, child_id)): Path<(String, String)>,
+        Path((nexus_id, child_id)): Path<(uuid::Uuid, String)>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn del_node_nexus_child(
         query: &str,
-        Path((node_id, nexus_id, child_id)): Path<(String, String, String)>,
+        Path((node_id, nexus_id, child_id)): Path<(String, uuid::Uuid, String)>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_nexus_child(
         query: &str,
-        Path((nexus_id, child_id)): Path<(String, String)>,
+        Path((nexus_id, child_id)): Path<(uuid::Uuid, String)>,
     ) -> Result<crate::models::Child, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_nexus_children(
-        Path(nexus_id): Path<String>,
+        Path(nexus_id): Path<uuid::Uuid>,
     ) -> Result<Vec<crate::models::Child>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_node_nexus_child(
         query: &str,
-        Path((node_id, nexus_id, child_id)): Path<(String, String, String)>,
+        Path((node_id, nexus_id, child_id)): Path<(String, uuid::Uuid, String)>,
     ) -> Result<crate::models::Child, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_node_nexus_children(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, uuid::Uuid)>,
     ) -> Result<Vec<crate::models::Child>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_nexus_child(
         query: &str,
-        Path((nexus_id, child_id)): Path<(String, String)>,
+        Path((nexus_id, child_id)): Path<(uuid::Uuid, String)>,
     ) -> Result<crate::models::Child, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_node_nexus_child(
         query: &str,
-        Path((node_id, nexus_id, child_id)): Path<(String, String, String)>,
+        Path((node_id, nexus_id, child_id)): Path<(String, uuid::Uuid, String)>,
     ) -> Result<crate::models::Child, crate::apis::RestError<crate::models::RestJsonError>>;
 }

--- a/openapi/src/apis/children_api_client.rs
+++ b/openapi/src/apis/children_api_client.rs
@@ -23,44 +23,44 @@ impl ChildrenClient {
 pub trait Children: Clone {
     async fn del_nexus_child(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn del_node_nexus_child(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn get_nexus_child(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<crate::models::Child, Error<crate::models::RestJsonError>>;
     async fn get_nexus_children(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<Vec<crate::models::Child>, Error<crate::models::RestJsonError>>;
     async fn get_node_nexus_child(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<crate::models::Child, Error<crate::models::RestJsonError>>;
     async fn get_node_nexus_children(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<Vec<crate::models::Child>, Error<crate::models::RestJsonError>>;
     async fn put_nexus_child(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<crate::models::Child, Error<crate::models::RestJsonError>>;
     async fn put_node_nexus_child(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<crate::models::Child, Error<crate::models::RestJsonError>>;
 }
@@ -69,7 +69,7 @@ pub trait Children: Clone {
 impl Children for ChildrenClient {
     async fn del_nexus_child(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -117,7 +117,7 @@ impl Children for ChildrenClient {
     async fn del_node_nexus_child(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -165,7 +165,7 @@ impl Children for ChildrenClient {
     }
     async fn get_nexus_child(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<crate::models::Child, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -213,7 +213,7 @@ impl Children for ChildrenClient {
     }
     async fn get_nexus_children(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<Vec<crate::models::Child>, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -260,7 +260,7 @@ impl Children for ChildrenClient {
     async fn get_node_nexus_child(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<crate::models::Child, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -310,7 +310,7 @@ impl Children for ChildrenClient {
     async fn get_node_nexus_children(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<Vec<crate::models::Child>, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -357,7 +357,7 @@ impl Children for ChildrenClient {
     }
     async fn put_nexus_child(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<crate::models::Child, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -406,7 +406,7 @@ impl Children for ChildrenClient {
     async fn put_node_nexus_child(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         child_id: &str,
     ) -> Result<crate::models::Child, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;

--- a/openapi/src/apis/children_api_handlers.rs
+++ b/openapi/src/apis/children_api_handlers.rs
@@ -71,7 +71,7 @@ pub fn configure<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
 async fn del_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
     request: HttpRequest,
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(uuid::Uuid, String)>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_nexus_child(request.query_string(), crate::apis::Path(path.into_inner()))
         .await
@@ -82,7 +82,7 @@ async fn del_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 's
 async fn del_node_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
     request: HttpRequest,
     _token: A,
-    path: Path<(String, String, String)>,
+    path: Path<(String, uuid::Uuid, String)>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_node_nexus_child(request.query_string(), crate::apis::Path(path.into_inner()))
         .await
@@ -93,7 +93,7 @@ async fn del_node_nexus_child<T: crate::apis::Children + 'static, A: FromRequest
 async fn get_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
     request: HttpRequest,
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(uuid::Uuid, String)>,
 ) -> Result<Json<crate::models::Child>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_nexus_child(request.query_string(), crate::apis::Path(path.into_inner()))
         .await
@@ -102,7 +102,7 @@ async fn get_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 's
 
 async fn get_nexus_children<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<Json<Vec<crate::models::Child>>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_nexus_children(crate::apis::Path(path.into_inner()))
         .await
@@ -112,7 +112,7 @@ async fn get_nexus_children<T: crate::apis::Children + 'static, A: FromRequest +
 async fn get_node_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
     request: HttpRequest,
     _token: A,
-    path: Path<(String, String, String)>,
+    path: Path<(String, uuid::Uuid, String)>,
 ) -> Result<Json<crate::models::Child>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_node_nexus_child(request.query_string(), crate::apis::Path(path.into_inner()))
         .await
@@ -121,7 +121,7 @@ async fn get_node_nexus_child<T: crate::apis::Children + 'static, A: FromRequest
 
 async fn get_node_nexus_children<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
 ) -> Result<Json<Vec<crate::models::Child>>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_node_nexus_children(crate::apis::Path(path.into_inner()))
         .await
@@ -131,7 +131,7 @@ async fn get_node_nexus_children<T: crate::apis::Children + 'static, A: FromRequ
 async fn put_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
     request: HttpRequest,
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(uuid::Uuid, String)>,
 ) -> Result<Json<crate::models::Child>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_nexus_child(request.query_string(), crate::apis::Path(path.into_inner()))
         .await
@@ -141,7 +141,7 @@ async fn put_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 's
 async fn put_node_nexus_child<T: crate::apis::Children + 'static, A: FromRequest + 'static>(
     request: HttpRequest,
     _token: A,
-    path: Path<(String, String, String)>,
+    path: Path<(String, uuid::Uuid, String)>,
 ) -> Result<Json<crate::models::Child>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_node_nexus_child(request.query_string(), crate::apis::Path(path.into_inner()))
         .await

--- a/openapi/src/apis/nexuses_api.rs
+++ b/openapi/src/apis/nexuses_api.rs
@@ -14,33 +14,33 @@ use actix_web::web::Json;
 #[async_trait::async_trait]
 pub trait Nexuses {
     async fn del_nexus(
-        Path(nexus_id): Path<String>,
+        Path(nexus_id): Path<uuid::Uuid>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn del_node_nexus(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, uuid::Uuid)>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn del_node_nexus_share(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, uuid::Uuid)>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_nexus(
-        Path(nexus_id): Path<String>,
+        Path(nexus_id): Path<uuid::Uuid>,
     ) -> Result<crate::models::Nexus, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_nexuses(
     ) -> Result<Vec<crate::models::Nexus>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_node_nexus(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, uuid::Uuid)>,
     ) -> Result<crate::models::Nexus, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_node_nexuses(
         Path(id): Path<String>,
     ) -> Result<Vec<crate::models::Nexus>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_node_nexus(
-        Path((node_id, nexus_id)): Path<(String, String)>,
+        Path((node_id, nexus_id)): Path<(String, uuid::Uuid)>,
         Body(create_nexus_body): Body<crate::models::CreateNexusBody>,
     ) -> Result<crate::models::Nexus, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_node_nexus_share(
         Path((node_id, nexus_id, protocol)): Path<(
             String,
-            String,
+            uuid::Uuid,
             crate::models::NexusShareProtocol,
         )>,
     ) -> Result<String, crate::apis::RestError<crate::models::RestJsonError>>;

--- a/openapi/src/apis/nexuses_api_client.rs
+++ b/openapi/src/apis/nexuses_api_client.rs
@@ -21,20 +21,23 @@ impl NexusesClient {
 #[async_trait::async_trait(?Send)]
 #[dyn_clonable::clonable]
 pub trait Nexuses: Clone {
-    async fn del_nexus(&self, nexus_id: &str) -> Result<(), Error<crate::models::RestJsonError>>;
+    async fn del_nexus(
+        &self,
+        nexus_id: &uuid::Uuid,
+    ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn del_node_nexus(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn del_node_nexus_share(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn get_nexus(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<crate::models::Nexus, Error<crate::models::RestJsonError>>;
     async fn get_nexuses(
         &self,
@@ -42,7 +45,7 @@ pub trait Nexuses: Clone {
     async fn get_node_nexus(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<crate::models::Nexus, Error<crate::models::RestJsonError>>;
     async fn get_node_nexuses(
         &self,
@@ -51,20 +54,23 @@ pub trait Nexuses: Clone {
     async fn put_node_nexus(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         create_nexus_body: crate::models::CreateNexusBody,
     ) -> Result<crate::models::Nexus, Error<crate::models::RestJsonError>>;
     async fn put_node_nexus_share(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         protocol: crate::models::NexusShareProtocol,
     ) -> Result<String, Error<crate::models::RestJsonError>>;
 }
 
 #[async_trait::async_trait(?Send)]
 impl Nexuses for NexusesClient {
-    async fn del_nexus(&self, nexus_id: &str) -> Result<(), Error<crate::models::RestJsonError>> {
+    async fn del_nexus(
+        &self,
+        nexus_id: &uuid::Uuid,
+    ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
 
@@ -109,7 +115,7 @@ impl Nexuses for NexusesClient {
     async fn del_node_nexus(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -156,7 +162,7 @@ impl Nexuses for NexusesClient {
     async fn del_node_nexus_share(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -202,7 +208,7 @@ impl Nexuses for NexusesClient {
     }
     async fn get_nexus(
         &self,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<crate::models::Nexus, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -290,7 +296,7 @@ impl Nexuses for NexusesClient {
     async fn get_node_nexus(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
     ) -> Result<crate::models::Nexus, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -384,7 +390,7 @@ impl Nexuses for NexusesClient {
     async fn put_node_nexus(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         create_nexus_body: crate::models::CreateNexusBody,
     ) -> Result<crate::models::Nexus, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -436,7 +442,7 @@ impl Nexuses for NexusesClient {
     async fn put_node_nexus_share(
         &self,
         node_id: &str,
-        nexus_id: &str,
+        nexus_id: &uuid::Uuid,
         protocol: crate::models::NexusShareProtocol,
     ) -> Result<String, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;

--- a/openapi/src/apis/nexuses_api_handlers.rs
+++ b/openapi/src/apis/nexuses_api_handlers.rs
@@ -76,7 +76,7 @@ pub fn configure<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
 
 async fn del_nexus<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_nexus(crate::apis::Path(path.into_inner()))
         .await
@@ -86,7 +86,7 @@ async fn del_nexus<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
 
 async fn del_node_nexus<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_node_nexus(crate::apis::Path(path.into_inner()))
         .await
@@ -96,7 +96,7 @@ async fn del_node_nexus<T: crate::apis::Nexuses + 'static, A: FromRequest + 'sta
 
 async fn del_node_nexus_share<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_node_nexus_share(crate::apis::Path(path.into_inner()))
         .await
@@ -106,7 +106,7 @@ async fn del_node_nexus_share<T: crate::apis::Nexuses + 'static, A: FromRequest 
 
 async fn get_nexus<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<Json<crate::models::Nexus>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_nexus(crate::apis::Path(path.into_inner()))
         .await
@@ -121,7 +121,7 @@ async fn get_nexuses<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static
 
 async fn get_node_nexus<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
 ) -> Result<Json<crate::models::Nexus>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_node_nexus(crate::apis::Path(path.into_inner()))
         .await
@@ -139,7 +139,7 @@ async fn get_node_nexuses<T: crate::apis::Nexuses + 'static, A: FromRequest + 's
 
 async fn put_node_nexus<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
     Json(create_nexus_body): Json<crate::models::CreateNexusBody>,
 ) -> Result<Json<crate::models::Nexus>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_node_nexus(
@@ -152,7 +152,7 @@ async fn put_node_nexus<T: crate::apis::Nexuses + 'static, A: FromRequest + 'sta
 
 async fn put_node_nexus_share<T: crate::apis::Nexuses + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String, crate::models::NexusShareProtocol)>,
+    path: Path<(String, uuid::Uuid, crate::models::NexusShareProtocol)>,
 ) -> Result<Json<String>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_node_nexus_share(crate::apis::Path(path.into_inner()))
         .await

--- a/openapi/src/apis/replicas_api.rs
+++ b/openapi/src/apis/replicas_api.rs
@@ -14,19 +14,19 @@ use actix_web::web::Json;
 #[async_trait::async_trait]
 pub trait Replicas {
     async fn del_node_pool_replica(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, uuid::Uuid)>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn del_node_pool_replica_share(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, uuid::Uuid)>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn del_pool_replica(
-        Path((pool_id, replica_id)): Path<(String, String)>,
+        Path((pool_id, replica_id)): Path<(String, uuid::Uuid)>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn del_pool_replica_share(
-        Path((pool_id, replica_id)): Path<(String, String)>,
+        Path((pool_id, replica_id)): Path<(String, uuid::Uuid)>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_node_pool_replica(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, uuid::Uuid)>,
     ) -> Result<crate::models::Replica, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_node_pool_replicas(
         Path((node_id, pool_id)): Path<(String, String)>,
@@ -35,22 +35,22 @@ pub trait Replicas {
         Path(id): Path<String>,
     ) -> Result<Vec<crate::models::Replica>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_replica(
-        Path(id): Path<String>,
+        Path(id): Path<uuid::Uuid>,
     ) -> Result<crate::models::Replica, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_replicas(
     ) -> Result<Vec<crate::models::Replica>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_node_pool_replica(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, uuid::Uuid)>,
         Body(create_replica_body): Body<crate::models::CreateReplicaBody>,
     ) -> Result<crate::models::Replica, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_node_pool_replica_share(
-        Path((node_id, pool_id, replica_id)): Path<(String, String, String)>,
+        Path((node_id, pool_id, replica_id)): Path<(String, String, uuid::Uuid)>,
     ) -> Result<String, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_pool_replica(
-        Path((pool_id, replica_id)): Path<(String, String)>,
+        Path((pool_id, replica_id)): Path<(String, uuid::Uuid)>,
         Body(create_replica_body): Body<crate::models::CreateReplicaBody>,
     ) -> Result<crate::models::Replica, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_pool_replica_share(
-        Path((pool_id, replica_id)): Path<(String, String)>,
+        Path((pool_id, replica_id)): Path<(String, uuid::Uuid)>,
     ) -> Result<String, crate::apis::RestError<crate::models::RestJsonError>>;
 }

--- a/openapi/src/apis/replicas_api_client.rs
+++ b/openapi/src/apis/replicas_api_client.rs
@@ -25,29 +25,29 @@ pub trait Replicas: Clone {
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn del_node_pool_replica_share(
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn del_pool_replica(
         &self,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn del_pool_replica_share(
         &self,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn get_node_pool_replica(
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<crate::models::Replica, Error<crate::models::RestJsonError>>;
     async fn get_node_pool_replicas(
         &self,
@@ -60,7 +60,7 @@ pub trait Replicas: Clone {
     ) -> Result<Vec<crate::models::Replica>, Error<crate::models::RestJsonError>>;
     async fn get_replica(
         &self,
-        id: &str,
+        id: &uuid::Uuid,
     ) -> Result<crate::models::Replica, Error<crate::models::RestJsonError>>;
     async fn get_replicas(
         &self,
@@ -69,25 +69,25 @@ pub trait Replicas: Clone {
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
         create_replica_body: crate::models::CreateReplicaBody,
     ) -> Result<crate::models::Replica, Error<crate::models::RestJsonError>>;
     async fn put_node_pool_replica_share(
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<String, Error<crate::models::RestJsonError>>;
     async fn put_pool_replica(
         &self,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
         create_replica_body: crate::models::CreateReplicaBody,
     ) -> Result<crate::models::Replica, Error<crate::models::RestJsonError>>;
     async fn put_pool_replica_share(
         &self,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<String, Error<crate::models::RestJsonError>>;
 }
 
@@ -97,7 +97,7 @@ impl Replicas for ReplicasClient {
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -146,7 +146,7 @@ impl Replicas for ReplicasClient {
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -194,7 +194,7 @@ impl Replicas for ReplicasClient {
     async fn del_pool_replica(
         &self,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -241,7 +241,7 @@ impl Replicas for ReplicasClient {
     async fn del_pool_replica_share(
         &self,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -289,7 +289,7 @@ impl Replicas for ReplicasClient {
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<crate::models::Replica, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -431,7 +431,7 @@ impl Replicas for ReplicasClient {
     }
     async fn get_replica(
         &self,
-        id: &str,
+        id: &uuid::Uuid,
     ) -> Result<crate::models::Replica, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -520,7 +520,7 @@ impl Replicas for ReplicasClient {
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
         create_replica_body: crate::models::CreateReplicaBody,
     ) -> Result<crate::models::Replica, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -574,7 +574,7 @@ impl Replicas for ReplicasClient {
         &self,
         node_id: &str,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<String, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -623,7 +623,7 @@ impl Replicas for ReplicasClient {
     async fn put_pool_replica(
         &self,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
         create_replica_body: crate::models::CreateReplicaBody,
     ) -> Result<crate::models::Replica, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -675,7 +675,7 @@ impl Replicas for ReplicasClient {
     async fn put_pool_replica_share(
         &self,
         pool_id: &str,
-        replica_id: &str,
+        replica_id: &uuid::Uuid,
     ) -> Result<String, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;

--- a/openapi/src/apis/replicas_api_handlers.rs
+++ b/openapi/src/apis/replicas_api_handlers.rs
@@ -102,7 +102,7 @@ pub fn configure<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
 
 async fn del_node_pool_replica<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String, String)>,
+    path: Path<(String, String, uuid::Uuid)>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_node_pool_replica(crate::apis::Path(path.into_inner()))
         .await
@@ -115,7 +115,7 @@ async fn del_node_pool_replica_share<
     A: FromRequest + 'static,
 >(
     _token: A,
-    path: Path<(String, String, String)>,
+    path: Path<(String, String, uuid::Uuid)>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_node_pool_replica_share(crate::apis::Path(path.into_inner()))
         .await
@@ -125,7 +125,7 @@ async fn del_node_pool_replica_share<
 
 async fn del_pool_replica<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_pool_replica(crate::apis::Path(path.into_inner()))
         .await
@@ -135,7 +135,7 @@ async fn del_pool_replica<T: crate::apis::Replicas + 'static, A: FromRequest + '
 
 async fn del_pool_replica_share<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_pool_replica_share(crate::apis::Path(path.into_inner()))
         .await
@@ -145,7 +145,7 @@ async fn del_pool_replica_share<T: crate::apis::Replicas + 'static, A: FromReque
 
 async fn get_node_pool_replica<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String, String)>,
+    path: Path<(String, String, uuid::Uuid)>,
 ) -> Result<Json<crate::models::Replica>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_node_pool_replica(crate::apis::Path(path.into_inner()))
         .await
@@ -174,7 +174,7 @@ async fn get_node_replicas<T: crate::apis::Replicas + 'static, A: FromRequest + 
 
 async fn get_replica<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<Json<crate::models::Replica>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_replica(crate::apis::Path(path.into_inner()))
         .await
@@ -190,7 +190,7 @@ async fn get_replicas<T: crate::apis::Replicas + 'static, A: FromRequest + 'stat
 
 async fn put_node_pool_replica<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String, String)>,
+    path: Path<(String, String, uuid::Uuid)>,
     Json(create_replica_body): Json<crate::models::CreateReplicaBody>,
 ) -> Result<Json<crate::models::Replica>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_node_pool_replica(
@@ -206,7 +206,7 @@ async fn put_node_pool_replica_share<
     A: FromRequest + 'static,
 >(
     _token: A,
-    path: Path<(String, String, String)>,
+    path: Path<(String, String, uuid::Uuid)>,
 ) -> Result<Json<String>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_node_pool_replica_share(crate::apis::Path(path.into_inner()))
         .await
@@ -215,7 +215,7 @@ async fn put_node_pool_replica_share<
 
 async fn put_pool_replica<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
     Json(create_replica_body): Json<crate::models::CreateReplicaBody>,
 ) -> Result<Json<crate::models::Replica>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_pool_replica(
@@ -228,7 +228,7 @@ async fn put_pool_replica<T: crate::apis::Replicas + 'static, A: FromRequest + '
 
 async fn put_pool_replica_share<T: crate::apis::Replicas + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, String)>,
+    path: Path<(String, uuid::Uuid)>,
 ) -> Result<Json<String>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_pool_replica_share(crate::apis::Path(path.into_inner()))
         .await

--- a/openapi/src/apis/volumes_api.rs
+++ b/openapi/src/apis/volumes_api.rs
@@ -14,36 +14,36 @@ use actix_web::web::Json;
 #[async_trait::async_trait]
 pub trait Volumes {
     async fn del_share(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn del_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn del_volume_target(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
     ) -> Result<crate::models::Volume, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_node_volumes(
         Path(node_id): Path<String>,
     ) -> Result<Vec<crate::models::Volume>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
     ) -> Result<crate::models::Volume, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_volumes(
     ) -> Result<Vec<crate::models::Volume>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
         Body(create_volume_body): Body<crate::models::CreateVolumeBody>,
     ) -> Result<crate::models::Volume, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_volume_replica_count(
-        Path((volume_id, replica_count)): Path<(String, u8)>,
+        Path((volume_id, replica_count)): Path<(uuid::Uuid, u8)>,
     ) -> Result<crate::models::Volume, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_volume_share(
-        Path((volume_id, protocol)): Path<(String, crate::models::VolumeShareProtocol)>,
+        Path((volume_id, protocol)): Path<(uuid::Uuid, crate::models::VolumeShareProtocol)>,
     ) -> Result<String, crate::apis::RestError<crate::models::RestJsonError>>;
     /// Create a volume target connectable for front-end IO from the specified node. Due to a
     /// limitation, this must currently be a mayastor storage node.
     async fn put_volume_target(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
         Query((node, protocol)): Query<(String, crate::models::VolumeShareProtocol)>,
     ) -> Result<crate::models::Volume, crate::apis::RestError<crate::models::RestJsonError>>;
 }

--- a/openapi/src/apis/volumes_api_client.rs
+++ b/openapi/src/apis/volumes_api_client.rs
@@ -21,11 +21,17 @@ impl VolumesClient {
 #[async_trait::async_trait(?Send)]
 #[dyn_clonable::clonable]
 pub trait Volumes: Clone {
-    async fn del_share(&self, volume_id: &str) -> Result<(), Error<crate::models::RestJsonError>>;
-    async fn del_volume(&self, volume_id: &str) -> Result<(), Error<crate::models::RestJsonError>>;
+    async fn del_share(
+        &self,
+        volume_id: &uuid::Uuid,
+    ) -> Result<(), Error<crate::models::RestJsonError>>;
+    async fn del_volume(
+        &self,
+        volume_id: &uuid::Uuid,
+    ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn del_volume_target(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>>;
     async fn get_node_volumes(
         &self,
@@ -33,31 +39,31 @@ pub trait Volumes: Clone {
     ) -> Result<Vec<crate::models::Volume>, Error<crate::models::RestJsonError>>;
     async fn get_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>>;
     async fn get_volumes(
         &self,
     ) -> Result<Vec<crate::models::Volume>, Error<crate::models::RestJsonError>>;
     async fn put_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         create_volume_body: crate::models::CreateVolumeBody,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>>;
     async fn put_volume_replica_count(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         replica_count: u8,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>>;
     async fn put_volume_share(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         protocol: crate::models::VolumeShareProtocol,
     ) -> Result<String, Error<crate::models::RestJsonError>>;
     /// Create a volume target connectable for front-end IO from the specified node. Due to a
     /// limitation, this must currently be a mayastor storage node.
     async fn put_volume_target(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         node: &str,
         protocol: crate::models::VolumeShareProtocol,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>>;
@@ -65,7 +71,10 @@ pub trait Volumes: Clone {
 
 #[async_trait::async_trait(?Send)]
 impl Volumes for VolumesClient {
-    async fn del_share(&self, volume_id: &str) -> Result<(), Error<crate::models::RestJsonError>> {
+    async fn del_share(
+        &self,
+        volume_id: &uuid::Uuid,
+    ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
 
@@ -107,7 +116,10 @@ impl Volumes for VolumesClient {
             }
         }
     }
-    async fn del_volume(&self, volume_id: &str) -> Result<(), Error<crate::models::RestJsonError>> {
+    async fn del_volume(
+        &self,
+        volume_id: &uuid::Uuid,
+    ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
 
@@ -151,7 +163,7 @@ impl Volumes for VolumesClient {
     }
     async fn del_volume_target(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -243,7 +255,7 @@ impl Volumes for VolumesClient {
     }
     async fn get_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -330,7 +342,7 @@ impl Volumes for VolumesClient {
     }
     async fn put_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         create_volume_body: crate::models::CreateVolumeBody,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -380,7 +392,7 @@ impl Volumes for VolumesClient {
     }
     async fn put_volume_replica_count(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         replica_count: u8,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -428,7 +440,7 @@ impl Volumes for VolumesClient {
     }
     async fn put_volume_share(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         protocol: crate::models::VolumeShareProtocol,
     ) -> Result<String, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -476,7 +488,7 @@ impl Volumes for VolumesClient {
     }
     async fn put_volume_target(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         node: &str,
         protocol: crate::models::VolumeShareProtocol,
     ) -> Result<crate::models::Volume, Error<crate::models::RestJsonError>> {

--- a/openapi/src/apis/volumes_api_handlers.rs
+++ b/openapi/src/apis/volumes_api_handlers.rs
@@ -93,7 +93,7 @@ struct put_volume_targetQueryParams {
 
 async fn del_share<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_share(crate::apis::Path(path.into_inner()))
         .await
@@ -103,7 +103,7 @@ async fn del_share<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
 
 async fn del_volume<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_volume(crate::apis::Path(path.into_inner()))
         .await
@@ -113,7 +113,7 @@ async fn del_volume<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>
 
 async fn del_volume_target<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<Json<crate::models::Volume>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::del_volume_target(crate::apis::Path(path.into_inner()))
         .await
@@ -132,7 +132,7 @@ async fn get_node_volumes<T: crate::apis::Volumes + 'static, A: FromRequest + 's
 
 async fn get_volume<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<Json<crate::models::Volume>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::get_volume(crate::apis::Path(path.into_inner()))
         .await
@@ -148,7 +148,7 @@ async fn get_volumes<T: crate::apis::Volumes + 'static, A: FromRequest + 'static
 
 async fn put_volume<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
     Json(create_volume_body): Json<crate::models::CreateVolumeBody>,
 ) -> Result<Json<crate::models::Volume>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_volume(
@@ -161,7 +161,7 @@ async fn put_volume<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>
 
 async fn put_volume_replica_count<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, u8)>,
+    path: Path<(uuid::Uuid, u8)>,
 ) -> Result<Json<crate::models::Volume>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_volume_replica_count(crate::apis::Path(path.into_inner()))
         .await
@@ -170,7 +170,7 @@ async fn put_volume_replica_count<T: crate::apis::Volumes + 'static, A: FromRequ
 
 async fn put_volume_share<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<(String, crate::models::VolumeShareProtocol)>,
+    path: Path<(uuid::Uuid, crate::models::VolumeShareProtocol)>,
 ) -> Result<Json<String>, crate::apis::RestError<crate::models::RestJsonError>> {
     T::put_volume_share(crate::apis::Path(path.into_inner()))
         .await
@@ -181,7 +181,7 @@ async fn put_volume_share<T: crate::apis::Volumes + 'static, A: FromRequest + 's
 /// limitation, this must currently be a mayastor storage node.
 async fn put_volume_target<T: crate::apis::Volumes + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
     query: Query<put_volume_targetQueryParams>,
 ) -> Result<Json<crate::models::Volume>, crate::apis::RestError<crate::models::RestJsonError>> {
     let query = query.into_inner();

--- a/openapi/src/apis/watches_api.rs
+++ b/openapi/src/apis/watches_api.rs
@@ -14,14 +14,14 @@ use actix_web::web::Json;
 #[async_trait::async_trait]
 pub trait Watches {
     async fn del_watch_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
         Query(callback): Query<url::Url>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
     async fn get_watch_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
     ) -> Result<Vec<crate::models::RestWatch>, crate::apis::RestError<crate::models::RestJsonError>>;
     async fn put_watch_volume(
-        Path(volume_id): Path<String>,
+        Path(volume_id): Path<uuid::Uuid>,
         Query(callback): Query<url::Url>,
     ) -> Result<(), crate::apis::RestError<crate::models::RestJsonError>>;
 }

--- a/openapi/src/apis/watches_api_client.rs
+++ b/openapi/src/apis/watches_api_client.rs
@@ -23,16 +23,16 @@ impl WatchesClient {
 pub trait Watches: Clone {
     async fn del_watch_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         callback: &str,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
     async fn get_watch_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
     ) -> Result<Vec<crate::models::RestWatch>, Error<crate::models::RestJsonError>>;
     async fn put_watch_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         callback: &str,
     ) -> Result<(), Error<crate::models::RestJsonError>>;
 }
@@ -41,7 +41,7 @@ pub trait Watches: Clone {
 impl Watches for WatchesClient {
     async fn del_watch_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         callback: &str,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
@@ -90,7 +90,7 @@ impl Watches for WatchesClient {
     }
     async fn get_watch_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
     ) -> Result<Vec<crate::models::RestWatch>, Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;
         let local_var_client = &configuration.client;
@@ -138,7 +138,7 @@ impl Watches for WatchesClient {
     }
     async fn put_watch_volume(
         &self,
-        volume_id: &str,
+        volume_id: &uuid::Uuid,
         callback: &str,
     ) -> Result<(), Error<crate::models::RestJsonError>> {
         let configuration = &self.configuration;

--- a/openapi/src/apis/watches_api_handlers.rs
+++ b/openapi/src/apis/watches_api_handlers.rs
@@ -53,7 +53,7 @@ struct put_watch_volumeQueryParams {
 
 async fn del_watch_volume<T: crate::apis::Watches + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
     query: Query<del_watch_volumeQueryParams>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     let query = query.into_inner();
@@ -68,7 +68,7 @@ async fn del_watch_volume<T: crate::apis::Watches + 'static, A: FromRequest + 's
 
 async fn get_watch_volume<T: crate::apis::Watches + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
 ) -> Result<Json<Vec<crate::models::RestWatch>>, crate::apis::RestError<crate::models::RestJsonError>>
 {
     T::get_watch_volume(crate::apis::Path(path.into_inner()))
@@ -78,7 +78,7 @@ async fn get_watch_volume<T: crate::apis::Watches + 'static, A: FromRequest + 's
 
 async fn put_watch_volume<T: crate::apis::Watches + 'static, A: FromRequest + 'static>(
     _token: A,
-    path: Path<String>,
+    path: Path<uuid::Uuid>,
     query: Query<put_watch_volumeQueryParams>,
 ) -> Result<NoContent, crate::apis::RestError<crate::models::RestJsonError>> {
     let query = query.into_inner();

--- a/tests/tests-mayastor/src/lib.rs
+++ b/tests/tests-mayastor/src/lib.rs
@@ -37,7 +37,7 @@ pub mod v0 {
     pub use models::rest_json_error::Kind as RestJsonErrorKind;
 }
 
-use std::{collections::HashMap, rc::Rc, time::Duration};
+use std::{collections::HashMap, convert::TryInto, rc::Rc, time::Duration};
 use structopt::StructOpt;
 
 #[actix_rt::test]
@@ -106,7 +106,8 @@ impl Cluster {
             "{}{:02x}{:02x}{:08x}",
             uuid, node as u8, pool as u8, replica
         )
-        .into()
+        .try_into()
+        .unwrap()
     }
 
     /// openapi rest client v0

--- a/tests/tests-mayastor/tests/nexus.rs
+++ b/tests/tests-mayastor/tests/nexus.rs
@@ -118,7 +118,7 @@ async fn create_nexus_local_replica() {
     let replica = cluster
         .rest_v00()
         .replicas_api()
-        .get_replica(Cluster::replica(0, 0, 0).as_str())
+        .get_replica(&Cluster::replica(0, 0, 0))
         .await
         .unwrap();
 
@@ -148,7 +148,7 @@ async fn create_nexus_replicas() {
     let local = cluster
         .rest_v00()
         .replicas_api()
-        .get_replica(Cluster::replica(0, 0, 0).as_str())
+        .get_replica(&Cluster::replica(0, 0, 0))
         .await
         .unwrap();
     let remote = v0::ShareReplica {
@@ -188,25 +188,19 @@ async fn create_nexus_replica_not_available() {
     let local = cluster
         .rest_v00()
         .replicas_api()
-        .get_replica(Cluster::replica(0, 0, 0).as_str())
+        .get_replica(&Cluster::replica(0, 0, 0))
         .await
         .unwrap();
     let remote = cluster
         .rest_v00()
         .replicas_api()
-        .put_pool_replica_share(
-            cluster.pool(1, 0).as_str(),
-            Cluster::replica(1, 0, 0).as_str(),
-        )
+        .put_pool_replica_share(cluster.pool(1, 0).as_str(), &Cluster::replica(1, 0, 0))
         .await
         .unwrap();
     cluster
         .rest_v00()
         .replicas_api()
-        .del_pool_replica_share(
-            cluster.pool(1, 0).as_str(),
-            Cluster::replica(1, 0, 0).as_str(),
-        )
+        .del_pool_replica_share(cluster.pool(1, 0).as_str(), &Cluster::replica(1, 0, 0))
         .await
         .unwrap();
     cluster
@@ -214,7 +208,7 @@ async fn create_nexus_replica_not_available() {
         .nexuses_api()
         .put_node_nexus(
             cluster.node(0).as_str(),
-            v0::NexusId::new().as_str(),
+            &v0::NexusId::new(),
             models::CreateNexusBody::new(vec![local.uri, remote], size),
         )
         .await


### PR DESCRIPTION
chore: update openapi to include Uuid's

---
fix: don't use unknown pools when creating volumes

---
fix: finally use uuid as a Uuid

Includes changing the "inner" fields of the Id types to have a Uuid and also
all the associated usage of the Uuid (tests etc)
