### PR TITLE
chore(tf): deploy the csi-controller with terraform

### DIFF
--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -69,6 +69,22 @@ module "csi-agent" {
   grace_period   = var.csi_agent_grace_period
 }
 
+module "csi-controller" {
+  source = "./mod/csi-controller"
+  depends_on = [
+    module.core,
+    module.rest,
+    module.mayastor
+  ]
+  image        = var.csi_controller_image
+  registry     = var.registry
+  tag          = var.tag
+  control_node = var.control_node
+  csi_provisioner = var.csi_provisioner
+  csi_attacher_image = var.csi_attacher_image
+  credentials  = kubernetes_secret.regcred.metadata[0].name
+}
+
 module "msp-operator" {
   source = "./mod/k8s-operator"
   depends_on = [

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -66,6 +66,7 @@ module "csi-agent" {
   tag            = var.tag
   registry       = var.registry
   registar_image = var.csi_registar_image
+  grace_period   = var.csi_agent_grace_period
 }
 
 module "msp-operator" {
@@ -73,12 +74,16 @@ module "msp-operator" {
   depends_on = [
     module.rbac,
     module.core,
-    module.rest
+    module.rest,
+    module.mayastor
   ]
   image        = var.msp_operator_image
   registry     = var.registry
   tag          = var.tag
   control_node = var.control_node
+  res_limits   = var.control_resource_limits
+  res_requests = var.control_resource_requests
+  cache_period = var.control_cache_period
   credentials  = kubernetes_secret.regcred.metadata[0].name
 }
 
@@ -94,7 +99,9 @@ module "rest" {
   tag          = var.tag
   control_node = var.control_node
   credentials  = kubernetes_secret.regcred.metadata[0].name
-
+  res_limits   = var.control_resource_limits
+  res_requests = var.control_resource_requests
+  request_timeout = var.control_request_timeout
 }
 
 module "core" {
@@ -107,6 +114,10 @@ module "core" {
   registry     = var.registry
   tag          = var.tag
   control_node = var.control_node
+  res_limits   = var.control_resource_limits
+  res_requests = var.control_resource_requests
+  request_timeout = var.control_request_timeout
+  cache_period = var.control_cache_period
   credentials  = kubernetes_secret.regcred.metadata[0].name
 }
 
@@ -128,6 +139,7 @@ module "mayastor" {
   ]
   hugepages = var.mayastor_hugepages_2Mi
   cpus      = var.mayastor_cpus
+  cpu_list  = var.mayastor_cpu_list
   memory    = var.mayastor_memory
   image     = var.mayastor_image
   registry  = var.registry

--- a/deploy/terraform/mod/core/main.tf
+++ b/deploy/terraform/mod/core/main.tf
@@ -8,7 +8,7 @@ variable "request_timeout" {}
 variable "cache_period" {}
 variable "credentials" {}
 
-resource "kubernetes_stateful_set" "core_deployment" {
+resource "kubernetes_stateful_set" "core_stateful_set" {
   metadata {
     labels = {
       app = "core"

--- a/deploy/terraform/mod/csi-agent/main.tf
+++ b/deploy/terraform/mod/csi-agent/main.tf
@@ -2,6 +2,7 @@ variable "image" {
 }
 variable "tag" {}
 variable "registry" {}
+variable "grace_period" {}
 
 variable "registar_image" {
 }
@@ -30,6 +31,8 @@ resource "kubernetes_daemonset" "mayastor_csi_agent" {
       }
 
       spec {
+        termination_grace_period_seconds = var.grace_period
+
         volume {
           name = "device"
 

--- a/deploy/terraform/mod/csi-controller/main.tf
+++ b/deploy/terraform/mod/csi-controller/main.tf
@@ -1,0 +1,124 @@
+variable "image" {}
+variable "registry" {}
+variable "tag" {}
+variable "control_node" {}
+variable "credentials" {}
+variable "csi_provisioner" {}
+variable "csi_attacher_image" {}
+
+resource "kubernetes_deployment" "deployment_csi_controller" {
+  metadata {
+    labels = {
+      app = "csi-controller"
+    }
+    name      = "csi-controller"
+    namespace = "mayastor"
+  }
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app = "csi-controller"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "csi-controller"
+        }
+      }
+      spec {
+        host_network = true
+        service_account_name = "mayastor-service-account"
+        dns_policy = "ClusterFirstWithHostNet"
+
+        volume {
+          name = "socket-dir"
+          empty_dir { }
+        }
+
+        container {
+          name  = "csi-provisioner"
+          image = var.csi_provisioner
+          args = [
+            "--v=2",
+            "--csi-address=$(ADDRESS)",
+            "--feature-gates=Topology=true",
+            "--strict-topology=false",
+            "--default-fstype=ext4"
+          ]
+          env {
+            name = "ADDRESS"
+            value = "/var/lib/csi/sockets/pluginproxy/csi.sock"
+          }
+          image_pull_policy = "IfNotPresent"
+
+          volume_mount {
+            name       = "socket-dir"
+            mount_path = "/var/lib/csi/sockets/pluginproxy/"
+          }
+        }
+
+        container {
+          name  = "csi-attacher"
+          image = var.csi_attacher_image
+          args = [
+            "--v=2",
+            "--csi-address=$(ADDRESS)"
+          ]
+          env {
+            name = "ADDRESS"
+            value = "/var/lib/csi/sockets/pluginproxy/csi.sock"
+          }
+          image_pull_policy = "IfNotPresent"
+
+          volume_mount {
+            name       = "socket-dir"
+            mount_path = "/var/lib/csi/sockets/pluginproxy/"
+          }
+        }
+
+        container {
+          name  = "csi-controller"
+          image = format("%s/%s:%s", var.registry, var.image, var.tag)
+          image_pull_policy = "Always"
+
+          args = [
+            "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock",
+            "--rest-endpoint=http://$(REST_SERVICE_HOST):8081",
+            "--log-level=debug"
+          ]
+
+          env {
+            name = "ADDRESS"
+            value = "/var/lib/csi/sockets/pluginproxy/csi.sock"
+          }
+
+          volume_mount {
+            name       = "socket-dir"
+            mount_path = "/var/lib/csi/sockets/pluginproxy/"
+          }
+        }
+
+        affinity {
+          node_affinity {
+            preferred_during_scheduling_ignored_during_execution {
+              weight = 1
+
+              preference {
+                match_expressions {
+                  key      = "kubernetes.io/hostname"
+                  operator = "In"
+                  values   = [var.control_node]
+                }
+              }
+            }
+          }
+        }
+        image_pull_secrets {
+          name = var.credentials
+        }
+      }
+    }
+  }
+}

--- a/deploy/terraform/mod/etcd/main.tf
+++ b/deploy/terraform/mod/etcd/main.tf
@@ -150,9 +150,9 @@ resource "kubernetes_stateful_set" "mayastor" {
               command = ["/opt/bitnami/scripts/etcd/healthcheck.sh"]
             }
 
-            initial_delay_seconds = 60
+            initial_delay_seconds = 10
             timeout_seconds       = 5
-            period_seconds        = 30
+            period_seconds        = 5
             success_threshold     = 1
             failure_threshold     = 5
           }
@@ -162,9 +162,9 @@ resource "kubernetes_stateful_set" "mayastor" {
               command = ["/opt/bitnami/scripts/etcd/healthcheck.sh"]
             }
 
-            initial_delay_seconds = 60
+            initial_delay_seconds = 10
             timeout_seconds       = 5
-            period_seconds        = 10
+            period_seconds        = 5
             success_threshold     = 1
             failure_threshold     = 5
           }

--- a/deploy/terraform/mod/k8s-operator/main.tf
+++ b/deploy/terraform/mod/k8s-operator/main.tf
@@ -3,6 +3,9 @@ variable "registry" {}
 variable "tag" {}
 variable "control_node" {}
 variable "credentials" {}
+variable "res_limits" {}
+variable "res_requests" {}
+variable "cache_period" {}
 
 resource "kubernetes_deployment" "deployment_msp_operator" {
   metadata {
@@ -30,6 +33,7 @@ resource "kubernetes_deployment" "deployment_msp_operator" {
         container {
           args = [
             "-e http://$(REST_SERVICE_HOST):8081",
+            "--interval=${var.cache_period}"
           ]
           env {
             name  = "RUST_LOG"
@@ -41,16 +45,9 @@ resource "kubernetes_deployment" "deployment_msp_operator" {
 
           image_pull_policy = "Always"
           resources {
-            limits = {
-              cpu    = "1000m"
-              memory = "1Gi"
-            }
-            requests = {
-              cpu    = "250m"
-              memory = "500Mi"
-            }
+            limits = var.res_limits
+            requests = var.res_requests
           }
-
         }
         affinity {
           node_affinity {

--- a/deploy/terraform/mod/mayastor/main.tf
+++ b/deploy/terraform/mod/mayastor/main.tf
@@ -78,7 +78,7 @@ resource "kubernetes_daemonset" "mayastor" {
         init_container {
           name    = "message-bus-probe"
           image   = "busybox:latest"
-          command = ["sh", "-c", "until nc -vz nats 4222; do echo \"Waiting for message bus...\"; sleep 1; done;"]
+          command = ["sh", "-c", "trap 'exit 1' TERM; until nc -vz nats 4222; do echo \"Waiting for message bus...\"; sleep 1; done;"]
         }
 
         container {

--- a/deploy/terraform/mod/mayastor/main.tf
+++ b/deploy/terraform/mod/mayastor/main.tf
@@ -1,4 +1,5 @@
 variable "cpus" {}
+variable "cpu_list" {}
 variable "memory" {}
 variable "hugepages" {}
 
@@ -88,7 +89,7 @@ resource "kubernetes_daemonset" "mayastor" {
             "-N$(MY_NODE_NAME)",
             "-g$(MY_POD_IP)",
             "-nnats",
-            "-l2,3",
+            format("-l%s", var.cpu_list),
             "-pmayastor-etcd"
           ]
 
@@ -186,5 +187,4 @@ resource "kubernetes_daemonset" "mayastor" {
 
     min_ready_seconds = 10
   }
-
 }

--- a/deploy/terraform/mod/nats/main.tf
+++ b/deploy/terraform/mod/nats/main.tf
@@ -165,6 +165,7 @@ resource "kubernetes_stateful_set" "nats" {
 
             initial_delay_seconds = 10
             timeout_seconds       = 5
+            period_seconds        = 5
           }
 
           readiness_probe {
@@ -175,6 +176,7 @@ resource "kubernetes_stateful_set" "nats" {
 
             initial_delay_seconds = 10
             timeout_seconds       = 5
+            period_seconds        = 5
           }
 
           lifecycle {

--- a/deploy/terraform/mod/rest/main.tf
+++ b/deploy/terraform/mod/rest/main.tf
@@ -3,6 +3,10 @@ variable "registry" {}
 variable "tag" {}
 variable "control_node" {}
 variable "credentials" {}
+variable "res_limits" {}
+variable "request_timeout" {}
+variable "res_requests" {}
+
 resource "kubernetes_service" "service_mayastor_rest" {
   metadata {
     labels = {
@@ -61,7 +65,7 @@ resource "kubernetes_deployment" "rest_deployment" {
             "--no-auth",
             "-nnats",
             "--http=0.0.0.0:8081",
-            "--request-timeout=30s",
+            "--request-timeout=${var.request_timeout}",
           ]
           port {
             name           = "https"
@@ -74,7 +78,7 @@ resource "kubernetes_deployment" "rest_deployment" {
 
           env {
             name  = "RUST_LOG"
-            value = "info,msp_operator=info"
+            value = "info,rest=info"
           }
 
           image             = format("%s/%s:%s", var.registry, var.image, var.tag)
@@ -82,14 +86,8 @@ resource "kubernetes_deployment" "rest_deployment" {
           name              = "rest-service"
 
           resources {
-            limits = {
-              cpu    = "1000m"
-              memory = "1Gi"
-            }
-            requests = {
-              cpu    = "250m"
-              memory = "500Mi"
-            }
+            limits = var.res_limits
+            requests = var.res_requests
           }
         }
         affinity {

--- a/deploy/terraform/simple.tfvars
+++ b/deploy/terraform/simple.tfvars
@@ -1,0 +1,27 @@
+### Example of how to change variables to use a less bulky local cluster
+### terraform apply -var-file=./simple.tfvars
+###
+
+# mayastor daemon options
+mayastor_hugepages_2Mi="1Gi"
+mayastor_cpus=1
+mayastor_memory="2Gi"
+mayastor_cpu_list="1"
+
+# global registry and tag options
+registry="192.168.1.137:5000/mayadata"
+tag="latest"
+
+# control plane configuration
+control_node="ksnode-2"
+control_resource_requests = {
+  "cpu"    = "100m"
+  "memory" = "100Mi"
+}
+control_resource_limits = {
+  "cpu"    = "200m"
+  "memory" = "250Mi"
+}
+
+# csi agent configuration
+csi_agent_grace_period=2

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,6 +1,6 @@
 variable "registry" {
   type        = string
-  description = "The docker registery to pull from"
+  description = "The docker registry to pull from"
   default     = "mayadata"
 }
 
@@ -19,7 +19,7 @@ variable "etcd_image" {
 variable "control_node" {
   type        = string
   default     = "ksnode-1"
-  description = "The on which control plane components are scheduled soft requirement"
+  description = "The node on which control plane components are scheduled - soft requirement"
 }
 
 variable "control_resource_limits" {
@@ -84,7 +84,7 @@ variable "mayastor_cpu_list" {
 
 variable "mayastor_memory" {
   type        = string
-  description = "number of CPUs to use"
+  description = "amount of memory to request for mayastor"
   default     = "4Gi"
 }
 
@@ -116,6 +116,12 @@ variable "csi_provisioner" {
   type        = string
   default     = "quay.io/k8scsi/csi-provisioner:v2.1.1"
   description = "csi-provisioner to use"
+}
+
+variable "csi_controller_image" {
+  type        = string
+  description = "mayastor CSI controller image to use"
+  default     = "mcp-csi-controller"
 }
 
 variable "control_request_timeout" {

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -22,6 +22,21 @@ variable "control_node" {
   description = "The on which control plane components are scheduled soft requirement"
 }
 
+variable "control_resource_limits" {
+  type    = map
+  default = {
+    "cpu"    = "1000m"
+    "memory" = "1Gi"
+  }
+}
+variable "control_resource_requests" {
+  type    = map
+  default = {
+    "cpu"    = "250m"
+    "memory" = "500Mi"
+  }
+}
+
 variable "nats_image" {
   type        = string
   description = "amount of hugepages to allocate for mayastor"
@@ -61,6 +76,11 @@ variable "mayastor_cpus" {
   description = "number of CPUs to use"
   default     = 2
 }
+variable "mayastor_cpu_list" {
+  type        = string
+  description = "List of cores to run on, eg: 2,3"
+  default     = "2,3"
+}
 
 variable "mayastor_memory" {
   type        = string
@@ -72,6 +92,12 @@ variable "csi_agent_image" {
   type        = string
   description = "mayastor CSI agent image to use"
   default     = "mayastor-csi"
+}
+
+variable "csi_agent_grace_period" {
+  type        = string
+  description = "termination grace period in seconds for the mayastor CSI pod"
+  default     = 30
 }
 
 variable "csi_registar_image" {
@@ -90,4 +116,16 @@ variable "csi_provisioner" {
   type        = string
   default     = "quay.io/k8scsi/csi-provisioner:v2.1.1"
   description = "csi-provisioner to use"
+}
+
+variable "control_request_timeout" {
+  type        = string
+  description = "default request timeout for any NATS or GRPC request"
+  default     = "5s"
+}
+
+variable "control_cache_period" {
+  type        = string
+  description = "the period at which a component updates its resource cache"
+  default     = "30s"
 }


### PR DESCRIPTION
chore: add variables and example file for less powered vms

Add variables to modify the hugepages, cpu, cpu mask, resource requests and
resource limits and request timeouts and poll periods.

----
chore(tf): deploy the csi-controller with terraform

---
chore: match up nats and etcd probe configs