### PR TITLE
fix(kubectl-mayastor): return single element on get volumes or pools json or yaml output

### DIFF
--- a/kubectl-plugin/src/resources/pool.rs
+++ b/kubectl-plugin/src/resources/pool.rs
@@ -15,47 +15,45 @@ use structopt::StructOpt;
 #[derive(StructOpt, Debug)]
 pub struct Pools {}
 
-// CreateRows being trait for Vec<Pool> would create the rows from the list of
+// CreateRows being trait for Pool would create the rows from the list of
 // Pools returned from REST call.
-impl CreateRows for Vec<openapi::models::Pool> {
+impl CreateRows for openapi::models::Pool {
     fn create_rows(&self) -> Vec<Row> {
         let mut rows: Vec<Row> = Vec::new();
-        for pool in self {
-            let mut managed = true;
-            if pool.spec.is_none() {
-                managed = false;
-            }
-            // The spec would be empty if it was not created using
-            // control plane.
-            let spec = pool.spec.clone().unwrap_or_default();
-            // In case the state is not coming as filled, either due to pool, node lost, fill in
-            // spec data and mark the status as Unknown.
-            let state = pool.state.clone().unwrap_or(openapi::models::PoolState {
-                capacity: 0,
-                disks: spec.disks,
-                id: spec.id,
-                node: spec.node,
-                status: openapi::models::PoolStatus::Unknown,
-                used: 0,
-            });
-            let disks = state.disks.join(", ");
-            rows.push(row![
-                pool.id,
-                state.capacity,
-                state.used,
-                disks,
-                state.node,
-                state.status,
-                managed
-            ]);
+        let mut managed = true;
+        if self.spec.is_none() {
+            managed = false;
         }
+        // The spec would be empty if it was not created using
+        // control plane.
+        let spec = self.spec.clone().unwrap_or_default();
+        // In case the state is not coming as filled, either due to pool, node lost, fill in
+        // spec data and mark the status as Unknown.
+        let state = self.state.clone().unwrap_or(openapi::models::PoolState {
+            capacity: 0,
+            disks: spec.disks,
+            id: spec.id,
+            node: spec.node,
+            status: openapi::models::PoolStatus::Unknown,
+            used: 0,
+        });
+        let disks = state.disks.join(", ");
+        rows.push(row![
+            self.id,
+            state.capacity,
+            state.used,
+            disks,
+            state.node,
+            state.status,
+            managed
+        ]);
         rows
     }
 }
 
 // GetHeaderRow being trait for Pool would return the Header Row for
 // Pool.
-impl GetHeaderRow for Vec<openapi::models::Pool> {
+impl GetHeaderRow for openapi::models::Pool {
     fn get_header_row(&self) -> Row {
         (&*utils::POOLS_HEADERS).clone()
     }
@@ -67,7 +65,7 @@ impl List for Pools {
         match RestClient::client().pools_api().get_pools().await {
             Ok(pools) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Pool>(output, pools, utils::LIST);
+                utils::print_table::<Vec<openapi::models::Pool>>(output, pools);
             }
             Err(e) => {
                 println!("Failed to list pools. Error {}", e)
@@ -90,7 +88,7 @@ impl Get for Pool {
         match RestClient::client().pools_api().get_pool(id).await {
             Ok(pool) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Pool>(output, vec![pool], utils::GET);
+                utils::print_table::<openapi::models::Pool>(output, pool);
             }
             Err(e) => {
                 println!("Failed to get pool {}. Error {}", id, e)

--- a/kubectl-plugin/src/resources/pool.rs
+++ b/kubectl-plugin/src/resources/pool.rs
@@ -67,7 +67,7 @@ impl List for Pools {
         match RestClient::client().pools_api().get_pools().await {
             Ok(pools) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Pool>(output, pools);
+                utils::print_table::<openapi::models::Pool>(output, pools, "list");
             }
             Err(e) => {
                 println!("Failed to list pools. Error {}", e)
@@ -90,7 +90,7 @@ impl Get for Pool {
         match RestClient::client().pools_api().get_pool(id).await {
             Ok(pool) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Pool>(output, vec![pool]);
+                utils::print_table::<openapi::models::Pool>(output, vec![pool], "get");
             }
             Err(e) => {
                 println!("Failed to get pool {}. Error {}", id, e)

--- a/kubectl-plugin/src/resources/pool.rs
+++ b/kubectl-plugin/src/resources/pool.rs
@@ -19,7 +19,6 @@ pub struct Pools {}
 // Pools returned from REST call.
 impl CreateRows for openapi::models::Pool {
     fn create_rows(&self) -> Vec<Row> {
-        let mut rows: Vec<Row> = Vec::new();
         let mut managed = true;
         if self.spec.is_none() {
             managed = false;
@@ -38,7 +37,7 @@ impl CreateRows for openapi::models::Pool {
             used: 0,
         });
         let disks = state.disks.join(", ");
-        rows.push(row![
+        let rows = vec![row![
             self.id,
             state.capacity,
             state.used,
@@ -46,7 +45,7 @@ impl CreateRows for openapi::models::Pool {
             state.node,
             state.status,
             managed
-        ]);
+        ]];
         rows
     }
 }
@@ -65,7 +64,7 @@ impl List for Pools {
         match RestClient::client().pools_api().get_pools().await {
             Ok(pools) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<Vec<openapi::models::Pool>>(output, pools);
+                utils::print_table(output, pools);
             }
             Err(e) => {
                 println!("Failed to list pools. Error {}", e)
@@ -88,7 +87,7 @@ impl Get for Pool {
         match RestClient::client().pools_api().get_pool(id).await {
             Ok(pool) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Pool>(output, pool);
+                utils::print_table(output, pool);
             }
             Err(e) => {
                 println!("Failed to get pool {}. Error {}", id, e)

--- a/kubectl-plugin/src/resources/pool.rs
+++ b/kubectl-plugin/src/resources/pool.rs
@@ -67,7 +67,7 @@ impl List for Pools {
         match RestClient::client().pools_api().get_pools().await {
             Ok(pools) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Pool>(output, pools, "list");
+                utils::print_table::<openapi::models::Pool>(output, pools, utils::LIST);
             }
             Err(e) => {
                 println!("Failed to list pools. Error {}", e)
@@ -90,7 +90,7 @@ impl Get for Pool {
         match RestClient::client().pools_api().get_pool(id).await {
             Ok(pool) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Pool>(output, vec![pool], "get");
+                utils::print_table::<openapi::models::Pool>(output, vec![pool], utils::GET);
             }
             Err(e) => {
                 println!("Failed to get pool {}. Error {}", id, e)

--- a/kubectl-plugin/src/resources/utils.rs
+++ b/kubectl-plugin/src/resources/utils.rs
@@ -4,6 +4,8 @@ use serde::ser;
 // Constant to specify the output formats, these should work irrespective of case.
 pub const YAML_FORMAT: &str = "yaml";
 pub const JSON_FORMAT: &str = "json";
+pub const GET: &str = "get";
+pub const LIST: &str = "list";
 
 // Constants to store the table headers of the Tabular output formats.
 lazy_static! {
@@ -69,7 +71,7 @@ where
     match output {
         OutputFormat::Yaml => {
             // Show the YAML form output if output format is YAML.
-            let s = if call_type == "get" {
+            let s = if call_type == GET {
                 serde_yaml::to_string(&(obj[0])).unwrap()
             } else {
                 serde_yaml::to_string(&obj).unwrap()
@@ -78,7 +80,7 @@ where
         }
         OutputFormat::Json => {
             // Show the JSON form output if output format is JSON.
-            let s = if call_type == "get" {
+            let s = if call_type == GET {
                 serde_json::to_string(&(obj[0])).unwrap()
             } else {
                 serde_json::to_string(&obj).unwrap()

--- a/kubectl-plugin/src/resources/utils.rs
+++ b/kubectl-plugin/src/resources/utils.rs
@@ -65,8 +65,7 @@ where
     T: CreateRows,
 {
     fn create_rows(&self) -> Vec<Row> {
-        let mut rows = vec![];
-        self.iter().for_each(|i| rows.extend(i.create_rows()));
+        let rows = self.iter().map(|i| i.create_rows()).flatten().collect();
         rows
     }
 }
@@ -77,7 +76,9 @@ where
     T: GetHeaderRow,
 {
     fn get_header_row(&self) -> Row {
-        self[0].get_header_row()
+        self.get(0)
+            .map(GetHeaderRow::get_header_row)
+            .unwrap_or_default()
     }
 }
 

--- a/kubectl-plugin/src/resources/utils.rs
+++ b/kubectl-plugin/src/resources/utils.rs
@@ -60,7 +60,7 @@ impl From<&str> for OutputFormat {
     }
 }
 
-pub fn print_table<T>(output: &OutputFormat, obj: Vec<T>)
+pub fn print_table<T>(output: &OutputFormat, obj: Vec<T>, call_type: &str)
 where
     T: ser::Serialize,
     Vec<T>: CreateRows,
@@ -69,12 +69,20 @@ where
     match output {
         OutputFormat::Yaml => {
             // Show the YAML form output if output format is YAML.
-            let s = serde_yaml::to_string(&obj).unwrap();
+            let s = if call_type == "get" {
+                serde_yaml::to_string(&(obj[0])).unwrap()
+            } else {
+                serde_yaml::to_string(&obj).unwrap()
+            };
             println!("{}", s);
         }
         OutputFormat::Json => {
             // Show the JSON form output if output format is JSON.
-            let s = serde_json::to_string(&obj).unwrap();
+            let s = if call_type == "get" {
+                serde_json::to_string(&(obj[0])).unwrap()
+            } else {
+                serde_json::to_string(&obj).unwrap()
+            };
             println!("{}", s);
         }
         OutputFormat::NoFormat => {

--- a/kubectl-plugin/src/resources/volume.rs
+++ b/kubectl-plugin/src/resources/volume.rs
@@ -56,7 +56,7 @@ impl List for Volumes {
         match RestClient::client().volumes_api().get_volumes().await {
             Ok(volumes) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Volume>(output, volumes, "list");
+                utils::print_table::<openapi::models::Volume>(output, volumes, utils::LIST);
             }
             Err(e) => {
                 println!("Failed to list volumes. Error {}", e)
@@ -81,7 +81,7 @@ impl Get for Volume {
         match RestClient::client().volumes_api().get_volume(id).await {
             Ok(volume) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Volume>(output, vec![volume], "get");
+                utils::print_table::<openapi::models::Volume>(output, vec![volume], utils::GET);
             }
             Err(e) => {
                 println!("Failed to get volume {}. Error {}", id, e)
@@ -102,7 +102,7 @@ impl Scale for Volume {
             Ok(volume) => match output {
                 OutputFormat::Yaml | OutputFormat::Json => {
                     // Print json or yaml based on output format.
-                    utils::print_table::<openapi::models::Volume>(output, vec![volume], "get");
+                    utils::print_table::<openapi::models::Volume>(output, vec![volume], utils::GET);
                 }
                 OutputFormat::NoFormat => {
                     // Incase the output format is not specified, show a success message.

--- a/kubectl-plugin/src/resources/volume.rs
+++ b/kubectl-plugin/src/resources/volume.rs
@@ -17,7 +17,6 @@ pub(crate) struct Volumes {}
 // Volumes returned from REST call.
 impl CreateRows for openapi::models::Volume {
     fn create_rows(&self) -> Vec<Row> {
-        let mut rows: Vec<Row> = Vec::new();
         let state = self
             .state
             .clone()
@@ -29,13 +28,13 @@ impl CreateRows for openapi::models::Volume {
                 status: openapi::models::VolumeStatus::Unknown,
                 uuid: self.spec.uuid,
             });
-        rows.push(row![
+        let rows = vec![row![
             state.uuid,
             self.spec.num_replicas,
             state.protocol,
             state.status,
             state.size
-        ]);
+        ]];
         rows
     }
 }
@@ -54,7 +53,7 @@ impl List for Volumes {
         match RestClient::client().volumes_api().get_volumes().await {
             Ok(volumes) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<Vec<openapi::models::Volume>>(output, volumes);
+                utils::print_table(output, volumes);
             }
             Err(e) => {
                 println!("Failed to list volumes. Error {}", e)
@@ -79,7 +78,7 @@ impl Get for Volume {
         match RestClient::client().volumes_api().get_volume(id).await {
             Ok(volume) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Volume>(output, volume);
+                utils::print_table(output, volume);
             }
             Err(e) => {
                 println!("Failed to get volume {}. Error {}", id, e)
@@ -100,7 +99,7 @@ impl Scale for Volume {
             Ok(volume) => match output {
                 OutputFormat::Yaml | OutputFormat::Json => {
                     // Print json or yaml based on output format.
-                    utils::print_table::<openapi::models::Volume>(output, volume);
+                    utils::print_table(output, volume);
                 }
                 OutputFormat::NoFormat => {
                     // Incase the output format is not specified, show a success message.

--- a/kubectl-plugin/src/resources/volume.rs
+++ b/kubectl-plugin/src/resources/volume.rs
@@ -56,7 +56,7 @@ impl List for Volumes {
         match RestClient::client().volumes_api().get_volumes().await {
             Ok(volumes) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Volume>(output, volumes);
+                utils::print_table::<openapi::models::Volume>(output, volumes, "list");
             }
             Err(e) => {
                 println!("Failed to list volumes. Error {}", e)
@@ -81,7 +81,7 @@ impl Get for Volume {
         match RestClient::client().volumes_api().get_volume(id).await {
             Ok(volume) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Volume>(output, vec![volume]);
+                utils::print_table::<openapi::models::Volume>(output, vec![volume], "get");
             }
             Err(e) => {
                 println!("Failed to get volume {}. Error {}", id, e)
@@ -102,7 +102,7 @@ impl Scale for Volume {
             Ok(volume) => match output {
                 OutputFormat::Yaml | OutputFormat::Json => {
                     // Print json or yaml based on output format.
-                    utils::print_table::<openapi::models::Volume>(output, vec![volume]);
+                    utils::print_table::<openapi::models::Volume>(output, vec![volume], "get");
                 }
                 OutputFormat::NoFormat => {
                     // Incase the output format is not specified, show a success message.

--- a/kubectl-plugin/src/resources/volume.rs
+++ b/kubectl-plugin/src/resources/volume.rs
@@ -15,36 +15,34 @@ pub(crate) struct Volumes {}
 
 // CreateRows being trait for Vec<Volume> would create the rows from the list of
 // Volumes returned from REST call.
-impl CreateRows for Vec<openapi::models::Volume> {
+impl CreateRows for openapi::models::Volume {
     fn create_rows(&self) -> Vec<Row> {
         let mut rows: Vec<Row> = Vec::new();
-        for volume in self {
-            let state = volume
-                .state
-                .clone()
-                // If the state comes as empty fill in the spec data and mark the status as Unknown.
-                .unwrap_or(openapi::models::VolumeState {
-                    child: None,
-                    protocol: volume.spec.protocol,
-                    size: volume.spec.size,
-                    status: openapi::models::VolumeStatus::Unknown,
-                    uuid: volume.spec.uuid,
-                });
-            rows.push(row![
-                state.uuid,
-                volume.spec.num_replicas,
-                state.protocol,
-                state.status,
-                state.size
-            ]);
-        }
+        let state = self
+            .state
+            .clone()
+            // If the state comes as empty fill in the spec data and mark the status as Unknown.
+            .unwrap_or(openapi::models::VolumeState {
+                child: None,
+                protocol: self.spec.protocol,
+                size: self.spec.size,
+                status: openapi::models::VolumeStatus::Unknown,
+                uuid: self.spec.uuid,
+            });
+        rows.push(row![
+            state.uuid,
+            self.spec.num_replicas,
+            state.protocol,
+            state.status,
+            state.size
+        ]);
         rows
     }
 }
 
 // GetHeaderRow being trait for Volume would return the Header Row for
 // Volume.
-impl GetHeaderRow for Vec<openapi::models::Volume> {
+impl GetHeaderRow for openapi::models::Volume {
     fn get_header_row(&self) -> Row {
         (&*utils::VOLUME_HEADERS).clone()
     }
@@ -56,7 +54,7 @@ impl List for Volumes {
         match RestClient::client().volumes_api().get_volumes().await {
             Ok(volumes) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Volume>(output, volumes, utils::LIST);
+                utils::print_table::<Vec<openapi::models::Volume>>(output, volumes);
             }
             Err(e) => {
                 println!("Failed to list volumes. Error {}", e)
@@ -81,7 +79,7 @@ impl Get for Volume {
         match RestClient::client().volumes_api().get_volume(id).await {
             Ok(volume) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table::<openapi::models::Volume>(output, vec![volume], utils::GET);
+                utils::print_table::<openapi::models::Volume>(output, volume);
             }
             Err(e) => {
                 println!("Failed to get volume {}. Error {}", id, e)
@@ -102,7 +100,7 @@ impl Scale for Volume {
             Ok(volume) => match output {
                 OutputFormat::Yaml | OutputFormat::Json => {
                     // Print json or yaml based on output format.
-                    utils::print_table::<openapi::models::Volume>(output, vec![volume], utils::GET);
+                    utils::print_table::<openapi::models::Volume>(output, volume);
                 }
                 OutputFormat::NoFormat => {
                     // Incase the output format is not specified, show a success message.


### PR DESCRIPTION
### Why do we need this PR?
- Previously to reuse the code, the get and list methods were returning a json array, which is not the correct type for get.
- This fix will identify each api call and return it corresponding format.