### PR TITLE
feat(pool-labels): add a unique label to all pools created by control plane on request from msp

### DIFF
--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -18,3 +18,9 @@ pub const MAYASTOR_BINARY: &str = "MAYASTOR_BIN";
 
 /// The period at which a component updates its resource cache
 pub const CACHE_POLL_PERIOD: &str = "30s";
+
+/// The key to mark the creation source of a pool in labels
+pub const OPENEBS_CREATED_BY_KEY: &str = "openebs.io/created-by";
+
+/// The value to mark the creation source of a pool to be msp-operator in labels
+pub const MSP_OPERATOR: &str = "openebs.io/created-by";

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -23,4 +23,4 @@ pub const CACHE_POLL_PERIOD: &str = "30s";
 pub const OPENEBS_CREATED_BY_KEY: &str = "openebs.io/created-by";
 
 /// The value to mark the creation source of a pool to be msp-operator in labels
-pub const MSP_OPERATOR: &str = "openebs.io/created-by";
+pub const MSP_OPERATOR: &str = "msp-operator";

--- a/common/src/types/v0/message_bus/pool.rs
+++ b/common/src/types/v0/message_bus/pool.rs
@@ -247,15 +247,23 @@ pub struct CreatePool {
     pub id: PoolId,
     /// disk device paths or URIs to be claimed by the pool
     pub disks: Vec<PoolDeviceUri>,
+    /// labels to be set on the pool
+    pub labels: Option<::std::collections::HashMap<String, String>>,
 }
 
 impl CreatePool {
     /// Create new `Self` from the given parameters
-    pub fn new(node: &NodeId, id: &PoolId, disks: &[PoolDeviceUri]) -> Self {
+    pub fn new(
+        node: &NodeId,
+        id: &PoolId,
+        disks: &[PoolDeviceUri],
+        labels: &Option<::std::collections::HashMap<String, String>>,
+    ) -> Self {
         Self {
             node: node.clone(),
             id: id.clone(),
             disks: disks.to_vec(),
+            labels: labels.clone(),
         }
     }
 }

--- a/common/src/types/v0/message_bus/pool.rs
+++ b/common/src/types/v0/message_bus/pool.rs
@@ -1,6 +1,9 @@
 use super::*;
 
-use crate::{types::v0::store::pool::PoolSpec, IntoOption};
+use crate::{
+    types::v0::store::pool::{PoolLabel, PoolSpec},
+    IntoOption,
+};
 use serde::{Deserialize, Serialize};
 use std::{cmp::Ordering, fmt::Debug, ops::Deref};
 use strum_macros::{EnumString, ToString};
@@ -236,9 +239,6 @@ impl From<PoolDeviceUri> for String {
         device.to_string()
     }
 }
-
-// PoolLabel is the type for the labels
-type PoolLabel = ::std::collections::HashMap<String, String>;
 
 /// Create Pool Request
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]

--- a/common/src/types/v0/message_bus/pool.rs
+++ b/common/src/types/v0/message_bus/pool.rs
@@ -237,6 +237,9 @@ impl From<PoolDeviceUri> for String {
     }
 }
 
+// PoolLabel is the type for the labels
+type PoolLabel = ::std::collections::HashMap<String, String>;
+
 /// Create Pool Request
 #[derive(Serialize, Deserialize, Default, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -248,7 +251,7 @@ pub struct CreatePool {
     /// disk device paths or URIs to be claimed by the pool
     pub disks: Vec<PoolDeviceUri>,
     /// labels to be set on the pool
-    pub labels: Option<::std::collections::HashMap<String, String>>,
+    pub labels: Option<PoolLabel>,
 }
 
 impl CreatePool {
@@ -257,7 +260,7 @@ impl CreatePool {
         node: &NodeId,
         id: &PoolId,
         disks: &[PoolDeviceUri],
-        labels: &Option<::std::collections::HashMap<String, String>>,
+        labels: &Option<PoolLabel>,
     ) -> Self {
         Self {
             node: node.clone(),

--- a/common/src/types/v0/store/pool.rs
+++ b/common/src/types/v0/store/pool.rs
@@ -67,6 +67,9 @@ impl PartialEq<CreatePool> for PoolSpec {
     }
 }
 
+// PoolLabel is the type for the labels
+type PoolLabel = ::std::collections::HashMap<String, String>;
+
 /// User specification of a pool.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct PoolSpec {
@@ -79,7 +82,7 @@ pub struct PoolSpec {
     /// status of the pool
     pub status: PoolSpecStatus,
     /// labels to be set on the pool
-    pub labels: Option<::std::collections::HashMap<String, String>>,
+    pub labels: Option<PoolLabel>,
     /// Update in progress
     #[serde(skip)]
     pub sequencer: OperationSequence,

--- a/common/src/types/v0/store/pool.rs
+++ b/common/src/types/v0/store/pool.rs
@@ -10,9 +10,7 @@ use crate::types::v0::{
 };
 
 use serde::{Deserialize, Serialize};
-use std::convert::From;
-
-type PoolLabel = String;
+use std::{convert::From, fmt::Debug};
 
 /// Pool data structure used by the persistent store.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
@@ -54,7 +52,7 @@ impl From<&CreatePool> for PoolSpec {
             id: request.id.clone(),
             disks: request.disks.clone(),
             status: PoolSpecStatus::Creating,
-            labels: vec![],
+            labels: request.labels.clone(),
             sequencer: OperationSequence::new(request.id.clone()),
             operation: None,
         }
@@ -80,8 +78,8 @@ pub struct PoolSpec {
     pub disks: Vec<PoolDeviceUri>,
     /// status of the pool
     pub status: PoolSpecStatus,
-    /// Pool labels.
-    pub labels: Vec<PoolLabel>,
+    /// labels to be set on the pool
+    pub labels: Option<::std::collections::HashMap<String, String>>,
     /// Update in progress
     #[serde(skip)]
     pub sequencer: OperationSequence,
@@ -123,7 +121,7 @@ impl ResourceUuid for PoolSpec {
 
 impl From<PoolSpec> for models::PoolSpec {
     fn from(src: PoolSpec) -> Self {
-        Self::new(src.disks, src.id, src.labels, src.node, src.status)
+        Self::new_all(src.disks, src.id, src.labels, src.node, src.status)
     }
 }
 

--- a/common/src/types/v0/store/pool.rs
+++ b/common/src/types/v0/store/pool.rs
@@ -9,9 +9,11 @@ use crate::types::v0::{
     },
 };
 
+// PoolLabel is the type for the labels
+pub type PoolLabel = ::std::collections::HashMap<String, String>;
+
 use serde::{Deserialize, Serialize};
 use std::{convert::From, fmt::Debug};
-
 /// Pool data structure used by the persistent store.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Pool {
@@ -66,9 +68,6 @@ impl PartialEq<CreatePool> for PoolSpec {
         &other == self
     }
 }
-
-// PoolLabel is the type for the labels
-type PoolLabel = ::std::collections::HashMap<String, String>;
 
 /// User specification of a pool.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]

--- a/control-plane/agents/core/src/core/reconciler/pool/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/pool/mod.rs
@@ -95,7 +95,7 @@ async fn missing_pool_state_reconciler(
 
         pool.warn_span(|| tracing::warn!("Attempting to recreate missing pool"));
 
-        let request = CreatePool::new(&pool.node, &pool.id, &pool.disks);
+        let request = CreatePool::new(&pool.node, &pool.id, &pool.disks, &pool.labels);
         match node.create_pool(&request).await {
             Ok(_) => {
                 pool.info_span(|| tracing::info!("Pool successfully recreated"));

--- a/control-plane/agents/core/src/pool/tests.rs
+++ b/control-plane/agents/core/src/pool/tests.rs
@@ -39,6 +39,7 @@ async fn pool() {
         node: mayastor.clone(),
         id: "pooloop".into(),
         disks: vec!["malloc:///disk0?size_mb=100".into()],
+        labels: None,
     }
     .request()
     .await

--- a/control-plane/agents/examples/pool-client/main.rs
+++ b/control-plane/agents/examples/pool-client/main.rs
@@ -48,6 +48,7 @@ async fn create_pool(node: &str, pool: &str) {
         node: node.into(),
         id: pool.into(),
         disks: vec!["malloc:///disk0?size_mb=100".into()],
+        labels: None,
     }
     .request()
     .await

--- a/control-plane/msp-operator/src/main.rs
+++ b/control-plane/msp-operator/src/main.rs
@@ -479,8 +479,16 @@ impl ResourceContext {
             });
         }
 
-        let mut body = HashMap::new();
-        body.insert("disks", self.spec.disks.clone());
+        let mut labels: HashMap<String, String> = HashMap::new();
+        labels.insert(
+            String::from("openebs.io/created-by"),
+            String::from("mayastor-control-plane"),
+        );
+
+        let body = json!({
+            "disks": self.spec.disks.clone(),
+            "labels": labels
+        });
 
         let res = self
             .put(UrlPath::Pool(self.name()))?

--- a/control-plane/msp-operator/src/main.rs
+++ b/control-plane/msp-operator/src/main.rs
@@ -481,8 +481,8 @@ impl ResourceContext {
 
         let mut labels: HashMap<String, String> = HashMap::new();
         labels.insert(
-            String::from("openebs.io/created-by"),
-            String::from("msp-operator"),
+            String::from(constants::OPENEBS_CREATED_BY_KEY),
+            String::from(constants::MSP_OPERATOR),
         );
 
         let body = json!({

--- a/control-plane/msp-operator/src/main.rs
+++ b/control-plane/msp-operator/src/main.rs
@@ -482,7 +482,7 @@ impl ResourceContext {
         let mut labels: HashMap<String, String> = HashMap::new();
         labels.insert(
             String::from("openebs.io/created-by"),
-            String::from("mayastor-control-plane"),
+            String::from("msp-operator"),
         );
 
         let body = json!({

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -1767,6 +1767,11 @@ components:
                Can be specified in the form of a file path or a URI
                eg: /dev/sda, aio:///dev/sda, malloc:///disk?size_mb=100
             type: string
+        labels:
+          description: labels to be set on the pools
+          type: object
+          additionalProperties:
+            type: string
       required:
         - disks
     CreateReplicaBody:
@@ -2359,9 +2364,9 @@ components:
         id:
           $ref: '#/components/schemas/PoolId'
         labels:
-          description: Pool labels.
-          type: array
-          items:
+          description: labels to be set on the pools
+          type: object
+          additionalProperties:
             type: string
         node:
           $ref: '#/components/schemas/NodeId'
@@ -2370,7 +2375,6 @@ components:
       required:
         - disks
         - id
-        - labels
         - node
         - status
     ReplicaSpec:

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -50,11 +50,14 @@ impl From<models::CreateReplicaBody> for CreateReplicaBody {
 pub struct CreatePoolBody {
     /// disk device paths or URIs to be claimed by the pool
     pub disks: Vec<PoolDeviceUri>,
+    /// labels to be set on the pool
+    pub labels: Option<::std::collections::HashMap<String, String>>,
 }
 impl From<models::CreatePoolBody> for CreatePoolBody {
     fn from(src: models::CreatePoolBody) -> Self {
         Self {
             disks: src.disks.iter().cloned().map(From::from).collect(),
+            labels: src.labels,
         }
     }
 }
@@ -62,6 +65,7 @@ impl From<CreatePool> for CreatePoolBody {
     fn from(create: CreatePool) -> Self {
         CreatePoolBody {
             disks: create.disks,
+            labels: create.labels,
         }
     }
 }
@@ -72,6 +76,7 @@ impl CreatePoolBody {
             node: node_id,
             id: pool_id,
             disks: self.disks.clone(),
+            labels: self.labels.clone(),
         }
     }
 }

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -13,6 +13,7 @@ pub use common_lib::{
             VolumeLabels, VolumePolicy, Watch, WatchCallback, WatchResourceId,
         },
         openapi::{apis, models},
+        store::pool::PoolLabel,
     },
 };
 
@@ -44,9 +45,6 @@ impl From<models::CreateReplicaBody> for CreateReplicaBody {
         }
     }
 }
-
-// PoolLabel is the type for the labels
-type PoolLabel = ::std::collections::HashMap<String, String>;
 
 /// Create Pool Body JSON
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]

--- a/control-plane/rest/src/versions/v0.rs
+++ b/control-plane/rest/src/versions/v0.rs
@@ -45,13 +45,16 @@ impl From<models::CreateReplicaBody> for CreateReplicaBody {
     }
 }
 
+// PoolLabel is the type for the labels
+type PoolLabel = ::std::collections::HashMap<String, String>;
+
 /// Create Pool Body JSON
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct CreatePoolBody {
     /// disk device paths or URIs to be claimed by the pool
     pub disks: Vec<PoolDeviceUri>,
     /// labels to be set on the pool
-    pub labels: Option<::std::collections::HashMap<String, String>>,
+    pub labels: Option<PoolLabel>,
 }
 impl From<models::CreatePoolBody> for CreatePoolBody {
     fn from(src: models::CreatePoolBody) -> Self {

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -114,7 +114,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
         pool,
         models::Pool::new_all(
             "pooloop",
-            models::PoolSpec::new(vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", Vec::<String>::new(), &mayastor1, models::SpecStatus::Created),
+            models::PoolSpec::new(vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &mayastor1, models::SpecStatus::Created),
             models::PoolState::new(100663296u64, vec!["malloc:///malloc0?blk_size=512&size_mb=100&uuid=b940f4f2-d45d-4404-8167-3b0366f9e2b0"], "pooloop", &mayastor1, models::PoolStatus::Online, 0u64)
         )
     );

--- a/openapi/docs/models/CreatePoolBody.md
+++ b/openapi/docs/models/CreatePoolBody.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **disks** | **Vec<String>** | disk device paths or URIs to be claimed by the pool | 
+**labels** | Option<**::std::collections::HashMap<String, String>**> | labels to be set on the pools | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/openapi/docs/models/PoolSpec.md
+++ b/openapi/docs/models/PoolSpec.md
@@ -6,7 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **disks** | **Vec<String>** | absolute disk paths claimed by the pool | 
 **id** | **String** | storage pool identifier | 
-**labels** | **Vec<String>** | Pool labels. | 
+**labels** | Option<**::std::collections::HashMap<String, String>**> | labels to be set on the pools | [optional]
 **node** | **String** | storage node identifier | 
 **status** | [**crate::models::SpecStatus**](SpecStatus.md) |  | 
 

--- a/openapi/src/models/create_pool_body.rs
+++ b/openapi/src/models/create_pool_body.rs
@@ -22,6 +22,9 @@ pub struct CreatePoolBody {
     /// disk device paths or URIs to be claimed by the pool
     #[serde(rename = "disks")]
     pub disks: Vec<String>,
+    /// labels to be set on the pools
+    #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
+    pub labels: Option<::std::collections::HashMap<String, String>>,
 }
 
 impl CreatePoolBody {
@@ -29,12 +32,17 @@ impl CreatePoolBody {
     pub fn new(disks: impl IntoVec<String>) -> CreatePoolBody {
         CreatePoolBody {
             disks: disks.into_vec(),
+            labels: None,
         }
     }
     /// CreatePoolBody using all fields
-    pub fn new_all(disks: impl IntoVec<String>) -> CreatePoolBody {
+    pub fn new_all(
+        disks: impl IntoVec<String>,
+        labels: impl Into<Option<::std::collections::HashMap<String, String>>>,
+    ) -> CreatePoolBody {
         CreatePoolBody {
             disks: disks.into_vec(),
+            labels: labels.into(),
         }
     }
 }

--- a/openapi/src/models/pool_spec.rs
+++ b/openapi/src/models/pool_spec.rs
@@ -25,9 +25,9 @@ pub struct PoolSpec {
     /// storage pool identifier
     #[serde(rename = "id")]
     pub id: String,
-    /// Pool labels.
-    #[serde(rename = "labels")]
-    pub labels: Vec<String>,
+    /// labels to be set on the pools
+    #[serde(rename = "labels", skip_serializing_if = "Option::is_none")]
+    pub labels: Option<::std::collections::HashMap<String, String>>,
     /// storage node identifier
     #[serde(rename = "node")]
     pub node: String,
@@ -40,14 +40,13 @@ impl PoolSpec {
     pub fn new(
         disks: impl IntoVec<String>,
         id: impl Into<String>,
-        labels: impl IntoVec<String>,
         node: impl Into<String>,
         status: impl Into<crate::models::SpecStatus>,
     ) -> PoolSpec {
         PoolSpec {
             disks: disks.into_vec(),
             id: id.into(),
-            labels: labels.into_vec(),
+            labels: None,
             node: node.into(),
             status: status.into(),
         }
@@ -56,14 +55,14 @@ impl PoolSpec {
     pub fn new_all(
         disks: impl IntoVec<String>,
         id: impl Into<String>,
-        labels: impl IntoVec<String>,
+        labels: impl Into<Option<::std::collections::HashMap<String, String>>>,
         node: impl Into<String>,
         status: impl Into<crate::models::SpecStatus>,
     ) -> PoolSpec {
         PoolSpec {
             disks: disks.into_vec(),
             id: id.into(),
-            labels: labels.into_vec(),
+            labels: labels.into(),
             node: node.into(),
             status: status.into(),
         }

--- a/tests/tests-mayastor/src/lib.rs
+++ b/tests/tests-mayastor/src/lib.rs
@@ -531,6 +531,7 @@ impl ClusterBuilder {
                 node: pool.node.clone().into(),
                 id: pool.id(),
                 disks: vec![pool.disk()],
+                labels: None,
             }
             .request()
             .await

--- a/tests/tests-mayastor/tests/pools.rs
+++ b/tests/tests-mayastor/tests/pools.rs
@@ -85,6 +85,7 @@ async fn create_pool_idempotent() {
         node: cluster.node(0),
         id: cluster.pool(0, 0),
         disks: vec!["malloc:///disk?size_mb=100".into()],
+        labels: None,
     }
     .request()
     .await
@@ -94,6 +95,7 @@ async fn create_pool_idempotent() {
         node: cluster.node(0),
         id: cluster.pool(0, 0),
         disks: vec!["malloc:///disk?size_mb=100".into()],
+        labels: None,
     }
     .request()
     .await
@@ -114,6 +116,7 @@ async fn create_pool_idempotent_same_disk_different_query() {
         node: cluster.node(0),
         id: cluster.pool(0, 0),
         disks: vec!["malloc:///disk?size_mb=100&blk_size=512".into()],
+        labels: None,
     }
     .request()
     .await
@@ -123,6 +126,7 @@ async fn create_pool_idempotent_same_disk_different_query() {
         node: cluster.node(0),
         id: cluster.pool(0, 0),
         disks: vec!["malloc:///disk?size_mb=200&blk_size=4096".into()],
+        labels: None,
     }
     .request()
     .await
@@ -141,6 +145,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
         node: cluster.node(1),
         id: cluster.pool(1, 0),
         disks: vec!["malloc:///disk?size_mb=100".into()],
+        labels: None,
     }
     .request()
     .await
@@ -150,6 +155,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
         node: cluster.node(2),
         id: cluster.pool(2, 0),
         disks: vec!["malloc:///disk?size_mb=100".into()],
+        labels: None,
     }
     .request()
     .await
@@ -159,6 +165,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
         node: cluster.node(2),
         id: cluster.pool(2, 0),
         disks: vec!["malloc:///disk?size_mb=100".into()],
+        labels: None,
     }
     .request()
     .await
@@ -168,6 +175,7 @@ async fn create_pool_idempotent_different_nvmf_host() {
         node: cluster.node(2),
         id: cluster.pool(2, 0),
         disks: vec!["malloc:///disk?size_mb=100".into()],
+        labels: None,
     }
     .request()
     .await


### PR DESCRIPTION
### What does this PR do?
- This PR changes the labels type to hashmap
- This adds changes to populate labels on request.
- This add changes in msp-operator, to add a unique label is the pool creation request comes to rest from msp-operator.

Signed-off-by: Abhinandan-Purkait <abhinandan.purkait@mayadata.io>