### PR TITLE
fix(csi deployment): add image pull secret

### DIFF
--- a/chart/templates/csi-deployment.yaml
+++ b/chart/templates/csi-deployment.yaml
@@ -18,6 +18,8 @@ spec:
       hostNetwork: true
       serviceAccount: mayastor-service-account
       dnsPolicy: ClusterFirstWithHostNet
+      imagePullSecrets:
+        {{- include "base_pull_secrets" . }}
       containers:
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1
@@ -52,7 +54,6 @@ spec:
           args:
             - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"
             - "--rest-endpoint=http://$(REST_SERVICE_HOST):8081"
-            - "--log-level=debug"
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/

--- a/deploy/csi-deployment.yaml
+++ b/deploy/csi-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       hostNetwork: true
       serviceAccount: mayastor-service-account
       dnsPolicy: ClusterFirstWithHostNet
+      imagePullSecrets:
+        - name: regcred
       containers:
         - name: csi-provisioner
           image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.1


### PR DESCRIPTION
Add missing image pull secret for the CSI deployment.

Remove the "log-level" argument to bring the template in line with
the change to the deployment file in commit 75fa3c3e2a5c458b824fa1beef8e7959626e7a6e