### PR TITLE
feat(kubectl-mayastor): add support for listing mayastor nodes using plugin

### DIFF
--- a/kubectl-plugin/README.md
+++ b/kubectl-plugin/README.md
@@ -50,13 +50,27 @@ The plugin needs to be able to connect to the REST server in order to make the a
  ID               TOTAL CAPACITY  USED CAPACITY  DISKS                                                     NODE      STATUS  MANAGED
  mayastor-pool-1  5360320512      1111490560     aio:///dev/vdb?uuid=d8a36b4b-0435-4fee-bf76-f2aef980b833  kworker1  Online  true
 ```
-5. Scale Volume by ID
+5. Get Nodes
+```
+❯ kubectl mayastor get nodes
+ ID          GRPC ENDPOINT   STATUS
+ mayastor-2  10.1.0.7:10124  Online
+ mayastor-1  10.1.0.6:10124  Online
+ mayastor-3  10.1.0.8:10124  Online
+```
+6. Get Node by ID
+```
+❯ kubectl mayastor get node mayastor-2
+ ID          GRPC ENDPOINT   STATUS
+ mayastor-2  10.1.0.7:10124  Online
+```
+7. Scale Volume by ID
 ```
 ❯ kubectl mayastor scale volume 0c08667c-8b59-4d11-9192-b54e27e0ce0f 5
 Volume 0c08667c-8b59-4d11-9192-b54e27e0ce0f Scaled Successfully 🚀
 
 ```
-6. Get Volume(s)/Pool(s) to a specific Output Format
+8. Get Volume(s)/Pool(s)/Node(s) to a specific Output Format
 ```
 ❯ kubectl mayastor -ojson get volumes
 [{"spec":{"labels":[],"num_paths":1,"num_replicas":4,"protocol":"none","size":10485761,"status":"Created","uuid":"18e30e83-b106-4e0d-9fb6-2b04e761e18a"},"state":{"children":[],"protocol":"none","size":10485761,"status":"Online","uuid":"18e30e83-b106-4e0d-9fb6-2b04e761e18a"}},{"spec":{"labels":[],"num_paths":1,"num_replicas":5,"protocol":"none","size":10485761,"status":"Created","uuid":"0c08667c-8b59-4d11-9192-b54e27e0ce0f"},"state":{"children":[],"protocol":"none","size":10485761,"status":"Online","uuid":"0c08667c-8b59-4d11-9192-b54e27e0ce0f"}}]

--- a/kubectl-plugin/src/main.rs
+++ b/kubectl-plugin/src/main.rs
@@ -9,7 +9,7 @@ mod rest_wrapper;
 
 use crate::{
     operations::{Get, List, Scale},
-    resources::{pool, utils, volume, GetResources, ScaleResources},
+    resources::{node, pool, utils, volume, GetResources, ScaleResources},
     rest_wrapper::RestClient,
 };
 use anyhow::Result;
@@ -57,6 +57,8 @@ async fn main() {
             GetResources::Volume { id } => volume::Volume::get(id, &cli_args.output).await,
             GetResources::Pools => pool::Pools::list(&cli_args.output).await,
             GetResources::Pool { id } => pool::Pool::get(id, &cli_args.output).await,
+            GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
+            GetResources::Node { id } => node::Node::get(id, &cli_args.output).await,
         },
         Operations::Scale(resource) => match resource {
             ScaleResources::Volume { id, replica_count } => {

--- a/kubectl-plugin/src/resources/mod.rs
+++ b/kubectl-plugin/src/resources/mod.rs
@@ -1,3 +1,4 @@
+pub mod node;
 pub mod pool;
 pub mod utils;
 pub mod volume;
@@ -7,6 +8,7 @@ use structopt::StructOpt;
 pub(crate) type VolumeId = openapi::apis::Uuid;
 pub(crate) type ReplicaCount = u8;
 pub(crate) type PoolId = String;
+pub(crate) type NodeId = String;
 
 /// The types of resources that support the 'list' operation.
 #[derive(StructOpt, Debug)]
@@ -19,6 +21,10 @@ pub(crate) enum GetResources {
     Pools,
     /// Get pool with the given ID.
     Pool { id: PoolId },
+    /// Get all nodes.
+    Nodes,
+    /// Get node with the given ID.
+    Node { id: NodeId },
 }
 
 /// The types of resources that support the 'scale' operation.

--- a/kubectl-plugin/src/resources/node.rs
+++ b/kubectl-plugin/src/resources/node.rs
@@ -1,0 +1,79 @@
+use crate::{
+    operations::{Get, List},
+    resources::{
+        utils,
+        utils::{CreateRows, GetHeaderRow},
+        NodeId,
+    },
+    rest_wrapper::RestClient,
+};
+use async_trait::async_trait;
+use prettytable::Row;
+use structopt::StructOpt;
+
+/// Nodes resource.
+#[derive(StructOpt, Debug)]
+pub struct Nodes {}
+
+// CreateRows being trait for Node would create the rows from the list of
+// Nodes returned from REST call.
+impl CreateRows for openapi::models::Node {
+    fn create_rows(&self) -> Vec<Row> {
+        let spec = self.spec.clone().unwrap_or_default();
+        // In case the state is not coming as filled, either due to node offline, fill in
+        // spec data and mark the status as Unknown.
+        let state = self.state.clone().unwrap_or(openapi::models::NodeState {
+            id: spec.id,
+            grpc_endpoint: spec.grpc_endpoint,
+            status: openapi::models::NodeStatus::Unknown,
+        });
+        let rows = vec![row![self.id, state.grpc_endpoint, state.status,]];
+        rows
+    }
+}
+
+// GetHeaderRow being trait for Node would return the Header Row for
+// Node.
+impl GetHeaderRow for openapi::models::Node {
+    fn get_header_row(&self) -> Row {
+        (&*utils::NODE_HEADERS).clone()
+    }
+}
+
+#[async_trait(?Send)]
+impl List for Nodes {
+    async fn list(output: &utils::OutputFormat) {
+        match RestClient::client().nodes_api().get_nodes().await {
+            Ok(nodes) => {
+                // Print table, json or yaml based on output format.
+                utils::print_table(output, nodes);
+            }
+            Err(e) => {
+                println!("Failed to list nodes. Error {}", e)
+            }
+        }
+    }
+}
+
+/// Node resource.
+#[derive(StructOpt, Debug)]
+pub(crate) struct Node {
+    /// ID of the node.
+    id: NodeId,
+}
+
+#[async_trait(?Send)]
+impl Get for Node {
+    type ID = NodeId;
+    async fn get(id: &Self::ID, output: &utils::OutputFormat) {
+        match RestClient::client().nodes_api().get_node(id).await {
+            Ok(node) => {
+                // Print table, json or yaml based on output format.
+                utils::print_table(output, node);
+            }
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+}

--- a/kubectl-plugin/src/resources/utils.rs
+++ b/kubectl-plugin/src/resources/utils.rs
@@ -17,6 +17,7 @@ lazy_static! {
         "STATUS",
         "MANAGED"
     ];
+    pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS",];
 }
 
 // table_printer takes the above defined headers and the rows created at execution,


### PR DESCRIPTION
### What does this PR do?
- This PR adds the feature in kubectl-mayastor to list and get mayastor nodes.