### PR TITLE
fix: jaegertracing sometimes fails and kubectl-plugin volume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,7 +1945,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "kubectl-mayastor"
+name = "kubectl-plugin"
 version = "0.1.0"
 dependencies = [
  "actix-rt",

--- a/composer/src/lib.rs
+++ b/composer/src/lib.rs
@@ -824,7 +824,7 @@ impl Drop for ComposeTest {
                     .output()
                     .unwrap();
                 std::process::Command::new("docker")
-                    .args(&["rm", c])
+                    .args(&["rm", "-v", c])
                     .output()
                     .unwrap();
             });

--- a/deploy/terraform/mod/jaeger/main.tf
+++ b/deploy/terraform/mod/jaeger/main.tf
@@ -1,21 +1,6 @@
-resource "null_resource" "before" {
-}
-
 resource "null_resource" "jaegertracing_repo" {
   provisioner "local-exec" {
     command = "helm repo add jaegertracing https://jaegertracing.github.io/helm-charts"
-  }
-  provisioner "local-exec" {
-    command = "kubectl replace -f ${path.module}/crd.yaml --force"
-  }
-  provisioner "local-exec" {
-    when       = destroy
-    command    = "kubectl delete crd jaegers.jaegertracing.io"
-    on_failure = continue
-  }
-
-  triggers = {
-    "before" = null_resource.before.id
   }
 }
 
@@ -49,11 +34,19 @@ resource "helm_release" "jaegertracing-operator" {
   }
 
   provisioner "local-exec" {
+    command = "kubectl replace -f ${path.module}/crd.yaml --force"
+  }
+  provisioner "local-exec" {
     command = "kubectl replace -f ${path.module}/jaeger.yaml --force"
   }
   provisioner "local-exec" {
     when       = destroy
     command    = "kubectl delete -f ${path.module}/jaeger.yaml"
+    on_failure = continue
+  }
+  provisioner "local-exec" {
+    when       = destroy
+    command    = "kubectl delete crd jaegers.jaegertracing.io"
     on_failure = continue
   }
 }

--- a/kubectl-plugin/Cargo.toml
+++ b/kubectl-plugin/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
-name = "kubectl-mayastor"
+name = "kubectl-plugin"
 version = "0.1.0"
 edition = "2018"
+
+[[bin]]
+name = "kubectl-mayastor"
+path = "src/main.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/kubectl-plugin/README.md
+++ b/kubectl-plugin/README.md
@@ -24,16 +24,16 @@ The plugin needs to be able to connect to the REST server in order to make the a
 1. Get Volumes
 ```
 ❯ kubectl mayastor get volumes
- ID                                    REPLICAS  PROTOCOL  STATUS  SIZE
- 18e30e83-b106-4e0d-9fb6-2b04e761e18a  4         none      Online  10485761
- 0c08667c-8b59-4d11-9192-b54e27e0ce0f  4         none      Online  10485761
+ ID                                    REPLICAS  STATUS  SIZE
+ 18e30e83-b106-4e0d-9fb6-2b04e761e18a  4         Online  10485761
+ 0c08667c-8b59-4d11-9192-b54e27e0ce0f  4         Online  10485761
 
 ```
 2. Get Volume by ID
 ```
 ❯ kubectl mayastor get volume 18e30e83-b106-4e0d-9fb6-2b04e761e18a
- ID                                    REPLICAS  PROTOCOL  STATUS  SIZE
- 18e30e83-b106-4e0d-9fb6-2b04e761e18a  4         none      Online  10485761
+ ID                                    REPLICAS  STATUS  SIZE
+ 18e30e83-b106-4e0d-9fb6-2b04e761e18a  4         Online  10485761
 
 ```
 3. Get Pools
@@ -73,7 +73,7 @@ Volume 0c08667c-8b59-4d11-9192-b54e27e0ce0f Scaled Successfully 🚀
 8. Get Volume(s)/Pool(s)/Node(s) to a specific Output Format
 ```
 ❯ kubectl mayastor -ojson get volumes
-[{"spec":{"labels":[],"num_paths":1,"num_replicas":4,"protocol":"none","size":10485761,"status":"Created","uuid":"18e30e83-b106-4e0d-9fb6-2b04e761e18a"},"state":{"children":[],"protocol":"none","size":10485761,"status":"Online","uuid":"18e30e83-b106-4e0d-9fb6-2b04e761e18a"}},{"spec":{"labels":[],"num_paths":1,"num_replicas":5,"protocol":"none","size":10485761,"status":"Created","uuid":"0c08667c-8b59-4d11-9192-b54e27e0ce0f"},"state":{"children":[],"protocol":"none","size":10485761,"status":"Online","uuid":"0c08667c-8b59-4d11-9192-b54e27e0ce0f"}}]
+[{"spec":{"num_replicas":2,"size":67108864,"status":"Created","target":{"node":"ksnode-2","protocol":"nvmf"},"uuid":"5703e66a-e5e5-4c84-9dbe-e5a9a5c805db","topology":{"explicit":{"allowed_nodes":["ksnode-1","ksnode-3","ksnode-2"],"preferred_nodes":["ksnode-2","ksnode-3","ksnode-1"]}},"policy":{"self_heal":true}},"state":{"target":{"children":[{"state":"Online","uri":"bdev:///ac02cf9e-8f25-45f0-ab51-d2e80bd462f1?uuid=ac02cf9e-8f25-45f0-ab51-d2e80bd462f1"},{"state":"Online","uri":"nvmf://192.168.122.6:8420/nqn.2019-05.io.openebs:7b0519cb-8864-4017-85b6-edd45f6172d8?uuid=7b0519cb-8864-4017-85b6-edd45f6172d8"}],"deviceUri":"nvmf://192.168.122.234:8420/nqn.2019-05.io.openebs:nexus-140a1eb1-62b5-43c1-acef-9cc9ebb29425","node":"ksnode-2","rebuilds":0,"protocol":"nvmf","size":67108864,"state":"Online","uuid":"140a1eb1-62b5-43c1-acef-9cc9ebb29425"},"size":67108864,"status":"Online","uuid":"5703e66a-e5e5-4c84-9dbe-e5a9a5c805db"}}]
 
 ```
 

--- a/kubectl-plugin/README.md
+++ b/kubectl-plugin/README.md
@@ -24,16 +24,16 @@ The plugin needs to be able to connect to the REST server in order to make the a
 1. Get Volumes
 ```
 ❯ kubectl mayastor get volumes
- ID                                    REPLICAS  STATUS  SIZE
- 18e30e83-b106-4e0d-9fb6-2b04e761e18a  4         Online  10485761
- 0c08667c-8b59-4d11-9192-b54e27e0ce0f  4         Online  10485761
+ ID                                    REPLICAS TARGET-NODE  ACCESSIBILITY STATUS  SIZE
+ 18e30e83-b106-4e0d-9fb6-2b04e761e18a  4        mayastor-1   nvmf          Online  10485761
+ 0c08667c-8b59-4d11-9192-b54e27e0ce0f  4        mayastor-2   <none>        Online  10485761
 
 ```
 2. Get Volume by ID
 ```
 ❯ kubectl mayastor get volume 18e30e83-b106-4e0d-9fb6-2b04e761e18a
- ID                                    REPLICAS  STATUS  SIZE
- 18e30e83-b106-4e0d-9fb6-2b04e761e18a  4         Online  10485761
+ ID                                    REPLICAS TARGET-NODE  ACCESSIBILITY STATUS  SIZE
+ 18e30e83-b106-4e0d-9fb6-2b04e761e18a  4        mayastor-1   nvmf          Online  10485761
 
 ```
 3. Get Pools

--- a/kubectl-plugin/src/resources/utils.rs
+++ b/kubectl-plugin/src/resources/utils.rs
@@ -1,13 +1,28 @@
 use prettytable::{format, Row, Table};
 use serde::ser;
 
-// Constant to specify the output formats, these should work irrespective of case.
+/// Constant to specify the output formats, these should work irrespective of case.
 pub const YAML_FORMAT: &str = "yaml";
 pub const JSON_FORMAT: &str = "json";
 
+const CELL_NO_CONTENT: &str = "<none>";
+/// Optional cells should display `CELL_NO_CONTENT` if Node
+pub fn optional_cell<T: ToString>(field: Option<T>) -> String {
+    field
+        .map(|f| f.to_string())
+        .unwrap_or_else(|| CELL_NO_CONTENT.to_string())
+}
+
 // Constants to store the table headers of the Tabular output formats.
 lazy_static! {
-    pub static ref VOLUME_HEADERS: Row = row!["ID", "REPLICAS", "STATUS", "SIZE"];
+    pub static ref VOLUME_HEADERS: Row = row![
+        "ID",
+        "REPLICAS",
+        "TARGET-NODE",
+        "ACCESSIBILITY",
+        "STATUS",
+        "SIZE"
+    ];
     pub static ref POOLS_HEADERS: Row = row![
         "ID",
         "TOTAL CAPACITY",

--- a/kubectl-plugin/src/resources/utils.rs
+++ b/kubectl-plugin/src/resources/utils.rs
@@ -7,7 +7,7 @@ pub const JSON_FORMAT: &str = "json";
 
 // Constants to store the table headers of the Tabular output formats.
 lazy_static! {
-    pub static ref VOLUME_HEADERS: Row = row!["ID", "REPLICAS", "PROTOCOL", "STATUS", "SIZE"];
+    pub static ref VOLUME_HEADERS: Row = row!["ID", "REPLICAS", "STATUS", "SIZE"];
     pub static ref POOLS_HEADERS: Row = row![
         "ID",
         "TOTAL CAPACITY",

--- a/kubectl-plugin/src/resources/volume.rs
+++ b/kubectl-plugin/src/resources/volume.rs
@@ -6,7 +6,7 @@ use crate::{
 use async_trait::async_trait;
 use structopt::StructOpt;
 
-use crate::resources::utils::{CreateRows, GetHeaderRow, OutputFormat};
+use crate::resources::utils::{optional_cell, CreateRows, GetHeaderRow, OutputFormat};
 use prettytable::Row;
 
 /// Volumes resource.
@@ -21,10 +21,20 @@ impl CreateRows for openapi::models::Volume {
         let rows = vec![row![
             state.uuid,
             self.spec.num_replicas,
+            optional_cell(state.target.clone().map(|t| t.node)),
+            optional_cell(state.target.as_ref().map(|t| target_protocol(t)).flatten()),
             state.status,
             state.size
         ]];
         rows
+    }
+}
+
+/// Retrieve the protocol from a volume target and return it as an option
+fn target_protocol(target: &openapi::models::Nexus) -> Option<openapi::models::Protocol> {
+    match &target.protocol {
+        openapi::models::Protocol::None => None,
+        protocol => Some(*protocol),
     }
 }
 


### PR DESCRIPTION
fix(terraform): jaegertracing sometimes fails

fix(plugin): remove protocol from volume

fix(kubectl-plugin): add target-node and accessibility

Add new target-node and accessibility columns to the volume's tabular output
Added a new EMPTY_FIELD (<none>) to signify that there's nothing to output.