### PR TITLE
fix(rust test): fix occasional CI test failures

### DIFF
--- a/common/src/types/v0/message_bus/volume.rs
+++ b/common/src/types/v0/message_bus/volume.rs
@@ -529,8 +529,19 @@ pub struct ReplicaTopology {
 }
 
 impl ReplicaTopology {
+    /// Create a new instance of ReplicaTopology.
     pub fn new(node: Option<NodeId>, pool: Option<PoolId>, status: ReplicaStatus) -> Self {
         Self { node, pool, status }
+    }
+
+    /// Get the ReplicaTopology node ID.
+    pub fn node(&self) -> &Option<NodeId> {
+        &self.node
+    }
+
+    /// Get the ReplicaTopology pool ID.
+    pub fn pool(&self) -> &Option<PoolId> {
+        &self.pool
     }
 }
 


### PR DESCRIPTION
CI occasionally shows the "hotspare" test failing; specifically in the
"hotspare_replica_count_spread" function.

The problem appears to be in the "wait_till_volume" function where we
were waiting for the number of replicas to be correct. However, we were
checking the replica count in the spec, which defines the desired number
of replicas rather than the actual number of replicas in the system.

This function has been enhanced to check the replica topology field in
the volume state which will give the number of actual replicas.