### PR TITLE
fix: sending node online event should not block

### DIFF
--- a/common/src/opentelemetry.rs
+++ b/common/src/opentelemetry.rs
@@ -19,3 +19,18 @@ pub fn default_tracing_tags(git_commit: &str, cargo_version: &str) -> Vec<KeyVal
         KeyValue::new("crate.version", cargo_version.to_string()),
     ]
 }
+
+/// Name of the OTEL_BSP_MAX_EXPORT_BATCH_SIZE variable
+pub const OTEL_BSP_MAX_EXPORT_BATCH_SIZE_NAME: &str = "OTEL_BSP_MAX_EXPORT_BATCH_SIZE";
+/// The value of OTEL_BSP_MAX_EXPORT_BATCH_SIZE to be used with JAEGER
+pub const OTEL_BSP_MAX_EXPORT_BATCH_SIZE_JAEGER: &str = "64";
+/// Set the OTEL variables for a jaeger configuration
+pub fn set_jaeger_env() {
+    // if not set, default it to our jaeger value
+    if std::env::var(OTEL_BSP_MAX_EXPORT_BATCH_SIZE_NAME).is_err() {
+        std::env::set_var(
+            OTEL_BSP_MAX_EXPORT_BATCH_SIZE_NAME,
+            OTEL_BSP_MAX_EXPORT_BATCH_SIZE_JAEGER,
+        );
+    }
+}

--- a/control-plane/agents/core/src/core/reconciler/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/mod.rs
@@ -48,7 +48,10 @@ impl ReconcilerControl {
     }
 
     /// Send an event signal to the poller's main loop
+    /// todo: don't requeque duplicate events
     pub(crate) async fn notify(&self, event: PollEvent) {
-        self.event_channel.send(event).await.ok();
+        if let Err(error) = self.event_channel.try_send(event) {
+            tracing::warn!(error=?error, "Failed to send event to reconcile worker");
+        }
     }
 }

--- a/control-plane/agents/core/src/core/reconciler/poller.rs
+++ b/control-plane/agents/core/src/core/reconciler/poller.rs
@@ -34,7 +34,9 @@ impl ReconcilerWorker {
             Box::new(replica::ReplicaReconciler::new()),
         ];
 
-        let event_channel = tokio::sync::mpsc::channel(poll_targets.len());
+        // if events are sent before the worker is started they may fill up the buffer
+        // from which point messages will be dropped
+        let event_channel = tokio::sync::mpsc::channel(poll_targets.len() * 2);
         let shutdown_channel = tokio::sync::mpsc::channel(1);
         Self {
             poll_targets,

--- a/control-plane/agents/core/src/core/scheduling/volume.rs
+++ b/control-plane/agents/core/src/core/scheduling/volume.rs
@@ -169,13 +169,23 @@ impl GetChildForRemoval {
 
 /// Used to filter nexus children in order to choose the best candidates for removal
 /// when the volume's replica count is being reduced.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct GetChildForRemovalContext {
     registry: Registry,
     spec: VolumeSpec,
     state: VolumeState,
     nexus_info: Option<NexusInfo>,
     unused_only: bool,
+}
+impl std::fmt::Debug for GetChildForRemovalContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GetChildForRemovalContext")
+            .field("spec", &self.spec)
+            .field("state", &self.state)
+            .field("nexus_info", &self.nexus_info)
+            .field("unused_only", &self.unused_only)
+            .finish()
+    }
 }
 
 impl GetChildForRemovalContext {

--- a/control-plane/agents/core/src/server.rs
+++ b/control-plane/agents/core/src/server.rs
@@ -115,6 +115,8 @@ fn init_tracing() {
             tracing_tags.dedup();
             println!("Using the following tracing tags: {:?}", tracing_tags);
 
+            common_lib::opentelemetry::set_jaeger_env();
+
             global::set_text_map_propagator(TraceContextPropagator::new());
             let tracer = opentelemetry_jaeger::new_pipeline()
                 .with_agent_endpoint(jaeger)

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -139,7 +139,10 @@ pub(crate) async fn get_volume_replica_candidates(
         });
     }
 
-    request.trace(&format!("Creation pool candidates for volume: {:?}", pools));
+    request.trace(&format!(
+        "Creation pool candidates for volume: {:?}",
+        pools.iter().map(|p| p.state()).collect::<Vec<_>>()
+    ));
 
     Ok(pools
         .iter()

--- a/control-plane/msp-operator/src/main.rs
+++ b/control-plane/msp-operator/src/main.rs
@@ -1029,6 +1029,7 @@ async fn main() -> anyhow::Result<()> {
             env!("CARGO_PKG_VERSION"),
         );
         global::set_text_map_propagator(TraceContextPropagator::new());
+        constants::set_jaeger_env();
         let tracer = opentelemetry_jaeger::new_pipeline()
             .with_agent_endpoint(jaeger)
             .with_service_name("msp-operator")

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -109,6 +109,7 @@ fn init_tracing() -> Option<Tracer> {
         tracing::info!("Starting jaeger trace pipeline at {}...", agent);
         // Start a new jaeger trace pipeline
         global::set_text_map_propagator(TraceContextPropagator::new());
+        common_lib::opentelemetry::set_jaeger_env();
         let tracer = opentelemetry_jaeger::new_pipeline()
             .with_agent_endpoint(agent)
             .with_service_name("rest-server")
@@ -220,12 +221,16 @@ async fn main() -> anyhow::Result<()> {
     )
     .await;
     let server = HttpServer::new(app).bind_rustls(CliArgs::args().https, get_certificates()?)?;
-    if let Some(http) = CliArgs::args().http {
+    let result = if let Some(http) = CliArgs::args().http {
         server.bind(http).map_err(anyhow::Error::from)?
     } else {
         server
     }
     .run()
     .await
-    .map_err(|e| e.into())
+    .map_err(|e| e.into());
+
+    global::shutdown_tracer_provider();
+
+    result
 }

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -107,6 +107,7 @@ macro_rules! impl_ctrlp_agents {
                         binary = binary.with_env(kv.key.as_str(), kv.value.as_str().as_ref());
                     }
                 }
+
                 if name == "core" {
                     let etcd = format!("etcd.{}:2379", options.cluster_label.name());
                     binary = binary.with_args(vec!["--store", &etcd]);
@@ -141,6 +142,9 @@ macro_rules! impl_ctrlp_agents {
                         let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
                         binary = binary.with_args(vec!["--jaeger", &jaeger_config]);
                     }
+                }
+                if let Some(size) = &options.otel_max_batch_size {
+                    binary = binary.with_env("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", size);
                 }
                 Ok(cfg.add_container_bin(&name, binary))
             }

--- a/deployer/src/infra/rest.rs
+++ b/deployer/src/infra/rest.rs
@@ -39,6 +39,10 @@ impl ComponentAction for Rest {
                 binary = binary.with_args(vec!["--jaeger", &jaeger_config])
             };
 
+            if let Some(size) = &options.otel_max_batch_size {
+                binary = binary.with_env("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", size);
+            }
+
             cfg.add_container_spec(
                 ContainerSpec::from_binary("rest", binary)
                     .with_portmap("8080", "8080")

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -216,6 +216,10 @@ pub struct StartOptions {
     #[structopt(long)]
     pub reconcile_idle_period: Option<humantime::Duration>,
 
+    /// Override the core agent's reconcile idle period
+    #[structopt(long, env = "OTEL_BSP_MAX_EXPORT_BATCH_SIZE")]
+    pub otel_max_batch_size: Option<String>,
+
     /// Amount of time to wait for all containers to start.
     #[structopt(short, long)]
     pub wait_timeout: Option<humantime::Duration>,

--- a/tests/bdd/test_replicas_garbage_collection.py
+++ b/tests/bdd/test_replicas_garbage_collection.py
@@ -28,9 +28,9 @@ NUM_VOLUME_REPLICAS = 2
 MAYASTOR_1 = "mayastor-1"
 MAYASTOR_2 = "mayastor-2"
 
-POOL_DISK1 = "disk1.img"
+POOL_DISK1 = "cdisk1.img"
 POOL1_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
-POOL_DISK2 = "disk2.img"
+POOL_DISK2 = "cdisk2.img"
 POOL2_UUID = "4cc6ee64-7232-497d-a26f-38284a444990"
 
 


### PR DESCRIPTION
On startup if the cluster had more than 5 Nodes the send event notification per node would block.
This is because the queue has only 5 elements.
Simply increasing the queue size would not necessarily improve things so instead we drop the
notification if the queue is full which is acceptable as at the moment we have no way of
"flattening" the events or to avoid running the reconcilers too often so we probably don't want
a huge queue of notifications to be built. Losing one is not a problem, just may mean we'd be a
little slower.