### PR TITLE
refactor(replace nats): add support for pool and replica operations over grpc replacing nats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "ctrlp-tests",
  "dyn-clonable",
  "futures",
+ "grpc",
  "http",
  "humantime",
  "itertools",
@@ -262,7 +263,7 @@ dependencies = [
  "state",
  "structopt",
  "tokio",
- "tonic",
+ "tonic 0.5.2",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.2.25",
@@ -682,6 +683,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
+ "tonic 0.5.2",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.2.25",
@@ -700,15 +702,15 @@ dependencies = [
  "futures",
  "ipnetwork",
  "once_cell",
- "prost",
+ "prost 0.8.0",
  "prost-build",
- "prost-derive",
+ "prost-derive 0.8.0",
  "prost-types",
  "serde",
  "serde_derive",
  "serde_json",
  "tokio",
- "tonic",
+ "tonic 0.5.2",
  "tonic-build",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -875,7 +877,7 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.5.2",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.2.25",
@@ -924,12 +926,14 @@ dependencies = [
  "composer",
  "deployer",
  "etcd-client",
+ "grpc",
  "openapi",
  "opentelemetry",
  "opentelemetry-jaeger",
  "rpc",
  "structopt",
  "tokio",
+ "tonic 0.6.2",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.2.25",
@@ -1053,7 +1057,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "tokio",
- "tonic",
+ "tonic 0.5.2",
  "tower",
  "tracing",
  "tracing-subscriber 0.2.25",
@@ -1218,10 +1222,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76b9f5b0b4f53cf836bef05b22cd5239479700bc8d44a04c3c77f1ba6c2c73e9"
 dependencies = [
  "http",
- "prost",
+ "prost 0.8.0",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.5.2",
  "tonic-build",
  "tower-service",
 ]
@@ -1498,11 +1502,20 @@ dependencies = [
 name = "grpc"
 version = "0.1.0"
 dependencies = [
- "prost",
+ "common-lib",
+ "humantime",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "prost 0.8.0",
  "prost-build",
  "prost-types",
- "tonic",
+ "tokio",
+ "tonic 0.5.2",
  "tonic-build",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.2.25",
+ "utils",
 ]
 
 [[package]]
@@ -2639,7 +2652,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.8.0",
+]
+
+[[package]]
+name = "prost"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
+dependencies = [
+ "bytes",
+ "prost-derive 0.9.0",
 ]
 
 [[package]]
@@ -2654,7 +2677,7 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
+ "prost 0.8.0",
  "prost-types",
  "tempfile",
  "which",
@@ -2674,13 +2697,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.8.0",
 ]
 
 [[package]]
@@ -2909,9 +2945,12 @@ dependencies = [
  "composer",
  "ctrlp-tests",
  "futures",
+ "git-version",
+ "grpc",
  "http",
  "humantime",
  "jsonwebtoken",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
  "rustls 0.20.2",
@@ -2950,14 +2989,14 @@ name = "rpc"
 version = "1.0.0"
 dependencies = [
  "bytes",
- "prost",
+ "prost 0.8.0",
  "prost-build",
- "prost-derive",
+ "prost-derive 0.8.0",
  "prost-types",
  "serde",
  "serde_derive",
  "serde_json",
- "tonic",
+ "tonic 0.5.2",
  "tonic-build",
 ]
 
@@ -3725,8 +3764,39 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project 1.0.10",
- "prost",
- "prost-derive",
+ "prost 0.8.0",
+ "prost-derive 0.8.0",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "base64 0.13.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project 1.0.10",
+ "prost 0.9.0",
+ "prost-derive 0.9.0",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,6 +27,7 @@ openapi = { path = "../openapi", features = [ "actix-server", "tower-client", "t
 parking_lot = "0.11.2"
 rand = "0.8.4"
 utils = { path = "../utils/utils-lib" }
+tonic = "0.5.2"
 
 # Tracing
 tracing-subscriber = "0.2.24"

--- a/control-plane/agents/Cargo.toml
+++ b/control-plane/agents/Cargo.toml
@@ -36,6 +36,7 @@ utils = { path = "../../utils/utils-lib" }
 reqwest = "0.11.4"
 parking_lot = "0.11.2"
 itertools = "0.10.1"
+grpc = { path = "../grpc" }
 
 # Tracing
 opentelemetry-jaeger = { version = "0.15.0", features = ["rt-tokio-current-thread"] }

--- a/control-plane/agents/core/src/lib.rs
+++ b/control-plane/agents/core/src/lib.rs
@@ -1,0 +1,85 @@
+#![warn(missing_docs)]
+
+use common::ServiceError;
+use futures::{future::join_all, FutureExt};
+use grpc::{pool::server::PoolServer, replica::server::ReplicaServer};
+use http::Uri;
+use tracing::error;
+
+/// the gprc service that encapsulates the base_service and the server for rpc
+pub struct Service {
+    base_service: common::Service,
+    tonic_grpc_server: tonic::transport::Server,
+}
+
+impl Service {
+    /// creates a new Service with the base_service and tonic server builder
+    pub fn new(base_service: common::Service) -> Self {
+        Self {
+            base_service,
+            tonic_grpc_server: tonic::transport::Server::builder(),
+        }
+    }
+
+    /// launch each of the services and the grpc server
+    pub async fn run(mut self) {
+        let grpc_addr = self.base_service.get_shared_state::<Uri>().clone();
+        let pool_service = self.base_service.get_shared_state::<PoolServer>().clone();
+        let replica_service = self
+            .base_service
+            .get_shared_state::<ReplicaServer>()
+            .clone();
+
+        let tonic_router = self
+            .tonic_grpc_server
+            .add_service(pool_service.into_grpc_server())
+            .add_service(replica_service.into_grpc_server());
+
+        let mut threads = self.base_service.mbus_handles().await;
+
+        let tonic_thread = tokio::spawn(async move {
+            tonic_router
+                .serve_with_shutdown(
+                    grpc_addr.authority().unwrap().to_string().parse().unwrap(),
+                    Self::shutdown_signal().map(|_| ()),
+                )
+                .await
+                .map_err(|source| ServiceError::GrpcServer { source })
+        });
+
+        threads.push(tonic_thread);
+
+        join_all(threads)
+            .await
+            .iter()
+            .for_each(|result| match result {
+                Err(error) => error!("Failed to wait for thread: {:?}", error),
+                Ok(Err(error)) => {
+                    error!(error=?error, "Error running service thread");
+                }
+                _ => {}
+            });
+    }
+
+    /// Get a shutdown_signal as a oneshot channel when the process receives either TERM or INT.
+    /// When received the opentel traces are also immediately flushed.
+    fn shutdown_signal() -> tokio::sync::oneshot::Receiver<()> {
+        let mut signal_term =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
+        let mut signal_int =
+            tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt()).unwrap();
+        let (stop_sender, stop_receiver) = tokio::sync::oneshot::channel();
+        tokio::spawn(async move {
+            tokio::select! {
+                _term = signal_term.recv() => {tracing::info!("SIGTERM received")},
+                _int = signal_int.recv() => {tracing::info!("SIGINT received")},
+            }
+            opentelemetry::global::force_flush_tracer_provider();
+            if stop_sender.send(()).is_err() {
+                // should we panic here?
+                tracing::warn!("Failed to stop the tonic server");
+            }
+        });
+        stop_receiver
+    }
+}

--- a/control-plane/agents/core/src/pool/tests.rs
+++ b/control-plane/agents/core/src/pool/tests.rs
@@ -2,12 +2,12 @@
 
 use super::*;
 use common_lib::{
-    mbus_api,
     mbus_api::{ReplyError, ReplyErrorKind, ResourceKind, TimeoutOptions},
     types::v0::{
         message_bus::{
-            GetNodes, GetSpecs, Protocol, Replica, ReplicaId, ReplicaName, ReplicaShareProtocol,
-            ReplicaStatus, VolumeId,
+            CreatePool, CreateReplica, DestroyPool, DestroyReplica, Filter, GetNodes, GetSpecs,
+            Protocol, Replica, ReplicaId, ReplicaName, ReplicaShareProtocol, ReplicaStatus,
+            ShareReplica, UnshareReplica, VolumeId,
         },
         openapi::{
             apis::StatusCode,
@@ -17,6 +17,7 @@ use common_lib::{
         store::replica::ReplicaSpec,
     },
 };
+use grpc::{grpc_opts::Context, pool::traits::PoolOperations, replica::traits::ReplicaOperations};
 use itertools::Itertools;
 use std::{convert::TryFrom, time::Duration};
 use testlib::{Cluster, ClusterBuilder};
@@ -29,39 +30,51 @@ async fn pool() {
         .build()
         .await
         .unwrap();
-    let mayastor = cluster.node(0);
 
+    let mayastor = cluster.node(0);
     let nodes = GetNodes::default().request().await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
-    CreatePool {
-        node: mayastor.clone(),
-        id: "pooloop".into(),
-        disks: vec!["malloc:///disk0?size_mb=100".into()],
-        labels: None,
-    }
-    .request()
-    .await
-    .unwrap();
 
-    let pools = GetPools::default().request().await.unwrap();
+    let pool_client = cluster.grpc_client().pool();
+    let rep_client = cluster.grpc_client().replica();
+
+    let pool = pool_client
+        .create(
+            &CreatePool {
+                node: mayastor.clone(),
+                id: "pooloop".into(),
+                disks: vec!["malloc:///disk0?size_mb=100".into()],
+                labels: None,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    tracing::info!("Pools: {:?}", pool);
+
+    let pools = pool_client.get(Filter::None, None).await.unwrap();
     tracing::info!("Pools: {:?}", pools);
 
-    let replica = CreateReplica {
-        node: mayastor.clone(),
-        uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
-        pool: "pooloop".into(),
-        size: 12582912, /* actual size will be a multiple of 4MB so just
-                         * create it like so */
-        thin: true,
-        share: Protocol::None,
-        name: None,
-        ..Default::default()
-    }
-    .request()
-    .await
-    .unwrap();
+    let replica = rep_client
+        .create(
+            &CreateReplica {
+                node: mayastor.clone(),
+                uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
+                pool: "pooloop".into(),
+                size: 12582912, /* actual size will be a multiple of 4MB so just
+                                 * create it like so */
+                thin: true,
+                share: Protocol::None,
+                name: None,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+    tracing::info!("Replicas: {:?}", replica);
 
-    let replicas = GetReplicas::default().request().await.unwrap();
+    let replicas = rep_client.get(Filter::None, None).await.unwrap();
     tracing::info!("Replicas: {:?}", replicas);
 
     let uri = replica.uri.clone();
@@ -80,64 +93,84 @@ async fn pool() {
         }
     );
 
-    let uri = ShareReplica {
-        node: mayastor.clone(),
-        uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
-        pool: "pooloop".into(),
-        protocol: ReplicaShareProtocol::Nvmf,
-        name: None,
-    }
-    .request()
-    .await
-    .unwrap();
+    let uri = rep_client
+        .share(
+            &ShareReplica {
+                node: mayastor.clone(),
+                uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
+                pool: "pooloop".into(),
+                protocol: ReplicaShareProtocol::Nvmf,
+                name: None,
+            },
+            None,
+        )
+        .await
+        .unwrap();
 
     let mut replica_updated = replica;
     replica_updated.uri = uri;
     replica_updated.share = Protocol::Nvmf;
-    let replica = GetReplicas::default().request().await.unwrap();
+    let replica = rep_client.get(Filter::None, None).await.unwrap();
     let replica = replica.0.first().unwrap();
     assert_eq!(replica, &replica_updated);
 
-    let error = DestroyPool {
-        node: mayastor.clone(),
-        id: "pooloop".into(),
-    }
-    .request()
-    .await
-    .expect_err("Should fail to destroy a pool that is in use.");
+    let error = pool_client
+        .destroy(
+            &DestroyPool {
+                node: mayastor.clone(),
+                id: "pooloop".into(),
+            },
+            None,
+        )
+        .await
+        .expect_err("Should fail to destroy a pool that is in use.");
+
     assert!(matches!(
         error,
-        mbus_api::Error::ReplyWithError {
-            source: ReplyError {
-                kind: ReplyErrorKind::InUse,
-                resource: ResourceKind::Pool,
-                ..
-            }
+        ReplyError {
+            kind: ReplyErrorKind::InUse,
+            resource: ResourceKind::Pool,
+            ..
         }
     ));
+    rep_client
+        .destroy(
+            &DestroyReplica {
+                node: mayastor.clone(),
+                uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
+                pool: "pooloop".into(),
+                name: None,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
 
-    DestroyReplica {
-        node: mayastor.clone(),
-        uuid: ReplicaId::try_from("cf36a440-74c6-4042-b16c-4f7eddfc24da").unwrap(),
-        pool: "pooloop".into(),
-        name: None,
-        ..Default::default()
-    }
-    .request()
-    .await
-    .unwrap();
+    assert!(rep_client
+        .get(Filter::None, None)
+        .await
+        .unwrap()
+        .0
+        .is_empty());
 
-    assert!(GetReplicas::default().request().await.unwrap().0.is_empty());
+    pool_client
+        .destroy(
+            &DestroyPool {
+                node: mayastor.clone(),
+                id: "pooloop".into(),
+            },
+            None,
+        )
+        .await
+        .unwrap();
 
-    DestroyPool {
-        node: mayastor.clone(),
-        id: "pooloop".into(),
-    }
-    .request()
-    .await
-    .unwrap();
-
-    assert!(GetPools::default().request().await.unwrap().0.is_empty());
+    assert!(pool_client
+        .get(Filter::None, None)
+        .await
+        .unwrap()
+        .0
+        .is_empty());
 }
 
 /// The tests below revolve around transactions and are dependent on the core agent's command line
@@ -177,24 +210,30 @@ async fn replica_transaction() {
         .unwrap();
     let mayastor = cluster.node(0);
 
+    let pool_client = cluster.grpc_client().pool();
+    let rep_client = cluster.grpc_client().replica();
+
     let nodes = GetNodes::default().request().await.unwrap();
     tracing::info!("Nodes: {:?}", nodes);
 
-    let pools = GetPools::default().request().await.unwrap();
+    let pools = pool_client.get(Filter::None, None).await.unwrap();
     tracing::info!("Pools: {:?}", pools);
 
-    let replica = CreateReplica {
-        node: mayastor.clone(),
-        uuid: ReplicaId::new(),
-        pool: cluster.pool(0, 0),
-        size: 12582912,
-        thin: false,
-        share: Protocol::None,
-        ..Default::default()
-    }
-    .request()
-    .await
-    .unwrap();
+    let replica = rep_client
+        .create(
+            &CreateReplica {
+                node: mayastor.clone(),
+                uuid: ReplicaId::new(),
+                pool: cluster.pool(0, 0),
+                size: 12582912,
+                thin: false,
+                share: Protocol::None,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
 
     async fn check_operation(replica: &Replica, protocol: Protocol) {
         // operation in progress
@@ -208,8 +247,11 @@ async fn replica_transaction() {
     // pause mayastor
     cluster.composer().pause(mayastor.as_str()).await.unwrap();
 
-    ShareReplica::from(&replica)
-        .request_ext(bus_timeout_opts())
+    let _ = rep_client
+        .share(
+            &ShareReplica::from(&replica),
+            Some(Context::new(bus_timeout_opts())),
+        )
         .await
         .expect_err("mayastor down");
 
@@ -219,13 +261,19 @@ async fn replica_transaction() {
     cluster.composer().thaw(mayastor.as_str()).await.unwrap();
 
     // now it should be shared successfully
-    let uri = ShareReplica::from(&replica).request().await.unwrap();
+    let uri = rep_client
+        .share(&ShareReplica::from(&replica), None)
+        .await
+        .unwrap();
     println!("Share uri: {}", uri);
 
     cluster.composer().pause(mayastor.as_str()).await.unwrap();
 
-    UnshareReplica::from(&replica)
-        .request_ext(bus_timeout_opts())
+    let _ = rep_client
+        .unshare(
+            &UnshareReplica::from(&replica),
+            Some(Context::new(bus_timeout_opts())),
+        )
         .await
         .expect_err("mayastor down");
 
@@ -233,7 +281,10 @@ async fn replica_transaction() {
 
     cluster.composer().thaw(mayastor.as_str()).await.unwrap();
 
-    UnshareReplica::from(&replica).request().await.unwrap();
+    let _ = rep_client
+        .unshare(&UnshareReplica::from(&replica), None)
+        .await
+        .unwrap();
 
     assert_eq!(replica_spec(&replica).await.unwrap().share, Protocol::None);
 }
@@ -241,24 +292,33 @@ async fn replica_transaction() {
 /// Tests Store Write Failures for Replica Operations
 /// As it stands, the tests expects the operation to not be undone, and
 /// a reconcile thread should eventually sync the specs when the store reappears
-async fn replica_op_transaction_store<R>(
+async fn replica_op_transaction_store(
     replica: &Replica,
     cluster: &Cluster,
     (store_timeout, reconcile_period, grpc_timeout): (Duration, Duration, Duration),
-    (request, protocol): (R, Protocol),
-) where
-    R: Message,
-    R::Reply: std::fmt::Debug,
-{
+    protocol: Protocol,
+    share: Option<ShareReplica>,
+    unshare: Option<UnshareReplica>,
+) {
     let mayastor = cluster.node(0);
 
     // pause mayastor
     cluster.composer().pause(mayastor.as_str()).await.unwrap();
 
-    request
-        .request_ext(bus_timeout_opts())
-        .await
-        .expect_err("mayastor down");
+    let rep_client = cluster.grpc_client().replica();
+
+    if share.clone().is_some() {
+        rep_client
+            .share(&share.as_ref().unwrap().clone(), None)
+            .await
+            .expect_err("mayastor down");
+    }
+    if unshare.clone().is_some() {
+        rep_client
+            .unshare(&unshare.as_ref().unwrap().clone(), None)
+            .await
+            .expect_err("mayastor down");
+    }
 
     // ensure the share will succeed but etcd store will fail
     // by pausing etcd and releasing mayastor
@@ -287,10 +347,18 @@ async fn replica_op_transaction_store<R>(
     let spec = replica_spec(replica).await.unwrap();
     assert!(spec.operation.is_none() && spec.share == protocol);
 
-    request
-        .request_ext(bus_timeout_opts())
-        .await
-        .expect_err("already done");
+    if share.clone().is_some() {
+        rep_client
+            .share(&share.as_ref().unwrap().clone(), None)
+            .await
+            .expect_err("already done");
+    }
+    if unshare.clone().is_some() {
+        rep_client
+            .unshare(&unshare.as_ref().unwrap().clone(), None)
+            .await
+            .expect_err("already done");
+    }
 }
 
 /// Tests replica share and unshare operations when the store is temporarily down
@@ -310,26 +378,32 @@ async fn replica_transaction_store() {
         .build()
         .await
         .unwrap();
+    let rep_client = cluster.grpc_client().replica();
     let mayastor = cluster.node(0);
 
-    let replica = CreateReplica {
-        node: mayastor.clone(),
-        uuid: ReplicaId::new(),
-        pool: cluster.pool(0, 0),
-        size: 12582912,
-        thin: false,
-        share: Protocol::None,
-        ..Default::default()
-    }
-    .request()
-    .await
-    .unwrap();
+    let replica = rep_client
+        .create(
+            &CreateReplica {
+                node: mayastor.clone(),
+                uuid: ReplicaId::new(),
+                pool: cluster.pool(0, 0),
+                size: 12582912,
+                thin: false,
+                share: Protocol::None,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
 
     replica_op_transaction_store(
         &replica,
         &cluster,
         (store_timeout, reconcile_period, grpc_timeout),
-        (ShareReplica::from(&replica), Protocol::Nvmf),
+        Protocol::Nvmf,
+        Some(ShareReplica::from(&replica)),
+        None,
     )
     .await;
 
@@ -337,7 +411,9 @@ async fn replica_transaction_store() {
         &replica,
         &cluster,
         (store_timeout, reconcile_period, grpc_timeout),
-        (UnshareReplica::from(&replica), Protocol::None),
+        Protocol::None,
+        None,
+        Some(UnshareReplica::from(&replica)),
     )
     .await;
 }

--- a/control-plane/agents/core/src/server.rs
+++ b/control-plane/agents/core/src/server.rs
@@ -1,4 +1,6 @@
 pub mod core;
+/// Services to launch the grpc server
+pub mod lib;
 pub mod nexus;
 pub mod node;
 pub mod pool;
@@ -6,14 +8,14 @@ pub mod volume;
 pub mod watcher;
 
 use crate::core::registry;
-use common::Service;
 use common_lib::types::v0::message_bus::ChannelVs;
+use http::Uri;
 
 use common_lib::{mbus_api::BusClient, opentelemetry::default_tracing_tags};
 use opentelemetry::{global, sdk::propagation::TraceContextPropagator, KeyValue};
 use structopt::StructOpt;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Registry};
-use utils::package_info;
+use utils::{package_info, DEFAULT_GRPC_SERVER_ADDR};
 
 #[derive(Debug, StructOpt)]
 #[structopt(version = package_info!())]
@@ -75,6 +77,10 @@ pub(crate) struct CliArgs {
     /// Trace rest requests to the Jaeger endpoint agent
     #[structopt(long, short)]
     jaeger: Option<String>,
+    /// The GRPC Server URLs to connect to
+    /// (supports the http/https schema)
+    #[structopt(long, short, default_value = DEFAULT_GRPC_SERVER_ADDR)]
+    pub(crate) grpc_server_addr: Uri,
 }
 impl CliArgs {
     fn args() -> Self {
@@ -151,7 +157,7 @@ async fn server(cli_args: CliArgs) {
     )
     .await;
 
-    let service = Service::builder(cli_args.nats.clone(), ChannelVs::Core)
+    let base_service = common::Service::builder(cli_args.nats.clone(), ChannelVs::Core)
         .with_shared_state(global::tracer_with_version(
             "core-agent",
             env!("CARGO_PKG_VERSION"),
@@ -160,13 +166,16 @@ async fn server(cli_args: CliArgs) {
         .connect_message_bus(cli_args.no_min_timeouts, BusClient::CoreAgent)
         .await
         .with_shared_state(registry.clone())
+        .with_shared_state(cli_args.grpc_server_addr.clone())
         .configure_async(node::configure)
         .await
-        .configure(pool::configure)
+        .configure_async(pool::configure)
+        .await
         .configure(nexus::configure)
         .configure(volume::configure)
         .configure(watcher::configure);
 
+    let service = lib::Service::new(base_service);
     registry.start().await;
     service.run().await;
     registry.stop().await;

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -10,6 +10,17 @@ authors = ["Abhinandan Purkait <abhinandan.purkait@mayadata.io>"]
 tonic = "0.5.2"
 prost = "0.8.0"
 prost-types = "0.8.0"
+tokio = { version = "1.12.0", features = ["full"] }
+common-lib = { path = "../../common" }
+humantime = "2.1.0"
+utils = { path = "../../utils/utils-lib" }
+
+# Tracing
+tracing-subscriber = "0.2.24"
+tracing-opentelemetry = "0.15.0"
+opentelemetry = { version = "0.16.0", features = ["rt-tokio-current-thread"] }
+opentelemetry-semantic-conventions = "0.8.0"
+tracing = "0.1.28"
 
 [build-dependencies]
 tonic-build = "0.5.2"

--- a/control-plane/grpc/src/client.rs
+++ b/control-plane/grpc/src/client.rs
@@ -1,0 +1,34 @@
+use crate::{
+    pool::{client::PoolClient, traits::PoolOperations},
+    replica::{client::ReplicaClient, traits::ReplicaOperations},
+};
+use common_lib::mbus_api::TimeoutOptions;
+use tonic::transport::Uri;
+
+/// CoreClient encapsulates all the individual clients needed for gRPC transport
+pub struct CoreClient {
+    pool: PoolClient,
+    replica: ReplicaClient,
+}
+
+/// implement the CoreClient
+impl CoreClient {
+    /// generates a new CoreClient to get the individual clients
+    pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
+        let timeout_opts = opts.into();
+        let pool_client = PoolClient::new(addr.clone(), timeout_opts.clone()).await;
+        let replica_client = ReplicaClient::new(addr, timeout_opts).await;
+        Self {
+            pool: pool_client,
+            replica: replica_client,
+        }
+    }
+    /// retrieve the corresponding pool client
+    pub fn pool(&self) -> impl PoolOperations {
+        self.pool.clone()
+    }
+    /// retrieve the corresponding replica client
+    pub fn replica(&self) -> impl ReplicaOperations {
+        self.replica.clone()
+    }
+}

--- a/control-plane/grpc/src/grpc_opts/mod.rs
+++ b/control-plane/grpc/src/grpc_opts/mod.rs
@@ -1,0 +1,67 @@
+use common_lib::{mbus_api::TimeoutOptions, types::v0::message_bus::MessageIdVs};
+use std::time::Duration;
+
+/// Request specific minimum timeouts
+/// zeroing replicas on create/destroy takes some time (observed up to 7seconds)
+/// nexus creation by itself can take up to 4 seconds... it can take even longer if etcd is not up
+#[derive(Debug, Clone)]
+pub struct RequestMinTimeout {
+    replica: Duration,
+    nexus: Duration,
+}
+
+impl Default for RequestMinTimeout {
+    fn default() -> Self {
+        Self {
+            replica: Duration::from_secs(10),
+            nexus: Duration::from_secs(30),
+        }
+    }
+}
+impl RequestMinTimeout {
+    /// minimum timeout for a replica operation
+    pub fn replica(&self) -> Duration {
+        self.replica
+    }
+    /// minimum timeout for a nexus operation
+    pub fn nexus(&self) -> Duration {
+        self.nexus
+    }
+}
+
+/// get the default timeout for each type of request if a timeout is not specified.
+/// timeouts vary with different types of requests
+pub fn timeout_grpc(op_id: MessageIdVs, min_timeout: Duration) -> Duration {
+    let base_timeout = RequestMinTimeout::default();
+    let timeout = match op_id {
+        MessageIdVs::CreateVolume => base_timeout.replica() * 3 + base_timeout.nexus(),
+        MessageIdVs::DestroyVolume => base_timeout.replica() * 3 + base_timeout.nexus(),
+        MessageIdVs::PublishVolume => base_timeout.nexus(),
+        MessageIdVs::UnpublishVolume => base_timeout.nexus(),
+
+        MessageIdVs::CreateNexus => base_timeout.nexus(),
+        MessageIdVs::DestroyNexus => base_timeout.nexus(),
+
+        MessageIdVs::CreateReplica => base_timeout.replica(),
+        MessageIdVs::DestroyReplica => base_timeout.replica(),
+        _ => min_timeout,
+    };
+    timeout.max(min_timeout).min(Duration::from_secs(59))
+}
+
+/// context to be sent along with each request encapsulating the extra add ons that changes the
+/// behaviour of each request.
+pub struct Context {
+    timeout_opts: Option<TimeoutOptions>,
+}
+impl Context {
+    /// generate a new context with the provided timeout options
+    pub fn new(timeout_opts: impl Into<Option<TimeoutOptions>>) -> Self {
+        Self {
+            timeout_opts: timeout_opts.into(),
+        }
+    }
+    pub fn timeout_opts(&self) -> Option<TimeoutOptions> {
+        self.timeout_opts.clone()
+    }
+}

--- a/control-plane/grpc/src/lib.rs
+++ b/control-plane/grpc/src/lib.rs
@@ -1,3 +1,9 @@
+pub mod client;
+pub mod grpc_opts;
+pub mod misc;
+pub mod pool;
+pub mod replica;
+
 // Common module for all the misc operations
 // TODO: move this to its respective directory structure
 pub(crate) mod common {

--- a/control-plane/grpc/src/misc/mod.rs
+++ b/control-plane/grpc/src/misc/mod.rs
@@ -1,0 +1,2 @@
+// Common traits for the transport
+pub mod traits;

--- a/control-plane/grpc/src/misc/traits.rs
+++ b/control-plane/grpc/src/misc/traits.rs
@@ -1,0 +1,142 @@
+use crate::common;
+use common_lib::mbus_api::{ReplyError, ReplyErrorKind, ResourceKind};
+
+impl From<ResourceKind> for common::ResourceKind {
+    fn from(kind: ResourceKind) -> Self {
+        match kind {
+            ResourceKind::Unknown => Self::Unknown,
+            ResourceKind::Node => Self::Node,
+            ResourceKind::Pool => Self::Pool,
+            ResourceKind::Replica => Self::Replica,
+            ResourceKind::ReplicaState => Self::ReplicaState,
+            ResourceKind::ReplicaSpec => Self::ReplicaSpec,
+            ResourceKind::Nexus => Self::Nexus,
+            ResourceKind::Child => Self::Child,
+            ResourceKind::Volume => Self::Volume,
+            ResourceKind::JsonGrpc => Self::JsonGrpc,
+            ResourceKind::Block => Self::Block,
+            ResourceKind::Watch => Self::Watch,
+        }
+    }
+}
+
+impl From<common::ResourceKind> for ResourceKind {
+    fn from(kind: common::ResourceKind) -> Self {
+        match kind {
+            common::ResourceKind::Unknown => Self::Unknown,
+            common::ResourceKind::Node => Self::Node,
+            common::ResourceKind::Pool => Self::Pool,
+            common::ResourceKind::Replica => Self::Replica,
+            common::ResourceKind::ReplicaState => Self::ReplicaState,
+            common::ResourceKind::ReplicaSpec => Self::ReplicaSpec,
+            common::ResourceKind::Nexus => Self::Nexus,
+            common::ResourceKind::Child => Self::Child,
+            common::ResourceKind::Volume => Self::Volume,
+            common::ResourceKind::JsonGrpc => Self::JsonGrpc,
+            common::ResourceKind::Block => Self::Block,
+            common::ResourceKind::Watch => Self::Watch,
+        }
+    }
+}
+
+impl From<ReplyErrorKind> for common::ReplyErrorKind {
+    fn from(kind: ReplyErrorKind) -> Self {
+        match kind {
+            ReplyErrorKind::WithMessage => Self::WithMessage,
+            ReplyErrorKind::DeserializeReq => Self::DeserializeReq,
+            ReplyErrorKind::Internal => Self::Internal,
+            ReplyErrorKind::Timeout => Self::Timeout,
+            ReplyErrorKind::InvalidArgument => Self::InvalidArgument,
+            ReplyErrorKind::DeadlineExceeded => Self::DeadlineExceeded,
+            ReplyErrorKind::NotFound => Self::NotFound,
+            ReplyErrorKind::AlreadyExists => Self::AlreadyExists,
+            ReplyErrorKind::PermissionDenied => Self::PermissionDenied,
+            ReplyErrorKind::ResourceExhausted => Self::ResourceExhausted,
+            ReplyErrorKind::FailedPrecondition => Self::FailedPrecondition,
+            ReplyErrorKind::Aborted => Self::Aborted,
+            ReplyErrorKind::OutOfRange => Self::OutOfRange,
+            ReplyErrorKind::Unimplemented => Self::Unimplemented,
+            ReplyErrorKind::Unavailable => Self::Unavailable,
+            ReplyErrorKind::Unauthenticated => Self::Unauthenticated,
+            ReplyErrorKind::Unauthorized => Self::Unauthorized,
+            ReplyErrorKind::Conflict => Self::Conflict,
+            ReplyErrorKind::FailedPersist => Self::FailedPersist,
+            ReplyErrorKind::NotShared => Self::NotShared,
+            ReplyErrorKind::AlreadyShared => Self::AlreadyShared,
+            ReplyErrorKind::NotPublished => Self::NotPublished,
+            ReplyErrorKind::AlreadyPublished => Self::AlreadyPublished,
+            ReplyErrorKind::Deleting => Self::IsDeleting,
+            ReplyErrorKind::ReplicaCountAchieved => Self::ReplicaCountAchieved,
+            ReplyErrorKind::ReplicaChangeCount => Self::ReplicaChangeCount,
+            ReplyErrorKind::ReplicaIncrease => Self::ReplicaIncrease,
+            ReplyErrorKind::ReplicaCreateNumber => Self::ReplicaCreateNumber,
+            ReplyErrorKind::VolumeNoReplicas => Self::VolumeNoReplicas,
+            ReplyErrorKind::InUse => Self::InUse,
+        }
+    }
+}
+
+impl From<common::ReplyErrorKind> for ReplyErrorKind {
+    fn from(kind: common::ReplyErrorKind) -> Self {
+        match kind {
+            common::ReplyErrorKind::WithMessage => Self::WithMessage,
+            common::ReplyErrorKind::DeserializeReq => Self::DeserializeReq,
+            common::ReplyErrorKind::Internal => Self::Internal,
+            common::ReplyErrorKind::Timeout => Self::Timeout,
+            common::ReplyErrorKind::InvalidArgument => Self::InvalidArgument,
+            common::ReplyErrorKind::DeadlineExceeded => Self::DeadlineExceeded,
+            common::ReplyErrorKind::NotFound => Self::NotFound,
+            common::ReplyErrorKind::AlreadyExists => Self::AlreadyExists,
+            common::ReplyErrorKind::PermissionDenied => Self::PermissionDenied,
+            common::ReplyErrorKind::ResourceExhausted => Self::ResourceExhausted,
+            common::ReplyErrorKind::FailedPrecondition => Self::FailedPrecondition,
+            common::ReplyErrorKind::Aborted => Self::Aborted,
+            common::ReplyErrorKind::OutOfRange => Self::OutOfRange,
+            common::ReplyErrorKind::Unimplemented => Self::Unimplemented,
+            common::ReplyErrorKind::Unavailable => Self::Unavailable,
+            common::ReplyErrorKind::Unauthenticated => Self::Unauthenticated,
+            common::ReplyErrorKind::Unauthorized => Self::Unauthorized,
+            common::ReplyErrorKind::Conflict => Self::Conflict,
+            common::ReplyErrorKind::FailedPersist => Self::FailedPersist,
+            common::ReplyErrorKind::NotShared => Self::NotShared,
+            common::ReplyErrorKind::AlreadyShared => Self::AlreadyShared,
+            common::ReplyErrorKind::NotPublished => Self::NotPublished,
+            common::ReplyErrorKind::AlreadyPublished => Self::AlreadyPublished,
+            common::ReplyErrorKind::IsDeleting => Self::Deleting,
+            common::ReplyErrorKind::ReplicaCountAchieved => Self::ReplicaCountAchieved,
+            common::ReplyErrorKind::ReplicaChangeCount => Self::ReplicaChangeCount,
+            common::ReplyErrorKind::ReplicaIncrease => Self::ReplicaIncrease,
+            common::ReplyErrorKind::ReplicaCreateNumber => Self::ReplicaCreateNumber,
+            common::ReplyErrorKind::VolumeNoReplicas => Self::VolumeNoReplicas,
+            common::ReplyErrorKind::InUse => Self::InUse,
+        }
+    }
+}
+
+impl From<ReplyError> for crate::common::ReplyError {
+    fn from(err: ReplyError) -> Self {
+        let kind: common::ReplyErrorKind = err.clone().kind.into();
+        let resource: common::ResourceKind = err.clone().resource.into();
+        crate::common::ReplyError {
+            kind: kind as i32,
+            resource: resource as i32,
+            source: err.clone().source,
+            extra: err.extra,
+        }
+    }
+}
+
+impl From<crate::common::ReplyError> for ReplyError {
+    fn from(err: crate::common::ReplyError) -> Self {
+        ReplyError {
+            kind: common::ReplyErrorKind::from_i32(err.clone().kind)
+                .unwrap_or(common::ReplyErrorKind::Aborted)
+                .into(),
+            resource: common::ResourceKind::from_i32(err.clone().resource)
+                .unwrap_or(common::ResourceKind::Unknown)
+                .into(),
+            source: err.clone().source,
+            extra: err.extra,
+        }
+    }
+}

--- a/control-plane/grpc/src/pool/client.rs
+++ b/control-plane/grpc/src/pool/client.rs
@@ -1,0 +1,139 @@
+use crate::{
+    common::{NodeFilter, NodePoolFilter, PoolFilter},
+    grpc_opts::{timeout_grpc, Context},
+    pool::traits::{CreatePoolInfo, DestroyPoolInfo, PoolOperations},
+    pool_grpc::{
+        create_pool_reply, get_pools_reply, get_pools_request, pool_grpc_client::PoolGrpcClient,
+        CreatePoolRequest, DestroyPoolRequest, GetPoolsRequest,
+    },
+};
+use common_lib::{
+    mbus_api::{v0::Pools, ReplyError, ResourceKind, TimeoutOptions},
+    types::v0::message_bus::{Filter, MessageIdVs, Pool},
+};
+use std::{convert::TryFrom, time::Duration};
+use tonic::transport::{Channel, Endpoint, Uri};
+use utils::DEFAULT_REQ_TIMEOUT;
+
+// RPC Pool Client
+#[derive(Clone)]
+pub struct PoolClient {
+    base_timeout: Duration,
+    endpoint: Endpoint,
+}
+
+impl PoolClient {
+    /// creates a new base tonic endpoint with the timeout options and the address
+    pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
+        let timeout_opts = opts.into();
+        let timeout = timeout_opts
+            .map(|opt| opt.base_timeout())
+            .unwrap_or_else(|| humantime::parse_duration(DEFAULT_REQ_TIMEOUT).unwrap());
+        let endpoint = tonic::transport::Endpoint::from(addr)
+            .connect_timeout(timeout)
+            .timeout(timeout);
+        Self {
+            base_timeout: timeout,
+            endpoint,
+        }
+    }
+    /// creates a new pool grpc client on a new endpoint after altering the properties of the
+    /// base endpoint according to the provided context
+    pub async fn reconnect(
+        &self,
+        ctx: Option<Context>,
+        op_id: MessageIdVs,
+    ) -> Result<PoolGrpcClient<Channel>, tonic::transport::Error> {
+        let ctx_timeout = ctx.map(|ctx| ctx.timeout_opts()).flatten();
+        match ctx_timeout {
+            None => {
+                let timeout = timeout_grpc(op_id, self.base_timeout);
+                let endpoint = self
+                    .endpoint
+                    .clone()
+                    .connect_timeout(timeout)
+                    .timeout(timeout);
+                let client = PoolGrpcClient::connect(endpoint.clone()).await?;
+                Ok(client)
+            }
+            Some(timeout) => {
+                let timeout = timeout.base_timeout();
+                let endpoint = self
+                    .endpoint
+                    .clone()
+                    .connect_timeout(timeout)
+                    .timeout(timeout);
+                let client = PoolGrpcClient::connect(endpoint.clone()).await?;
+                Ok(client)
+            }
+        }
+    }
+}
+
+/// Implement pool operations supported by the Pool RPC client.
+/// This converts the client side data into a RPC request.
+#[tonic::async_trait]
+impl PoolOperations for PoolClient {
+    async fn create(
+        &self,
+        create_pool_req: &dyn CreatePoolInfo,
+        ctx: Option<Context>,
+    ) -> Result<Pool, ReplyError> {
+        let client = self.reconnect(ctx, MessageIdVs::CreatePool).await?;
+        let req: CreatePoolRequest = create_pool_req.into();
+        let response = client.clone().create_pool(req).await?.into_inner();
+        match response.reply {
+            Some(create_pool_reply) => match create_pool_reply {
+                create_pool_reply::Reply::Pool(pool) => Ok(Pool::try_from(pool)?),
+                create_pool_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Replica)),
+        }
+    }
+
+    /// Issue the pool destroy operation over RPC.
+    async fn destroy(
+        &self,
+        destroy_pool_req: &dyn DestroyPoolInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError> {
+        let client = self.reconnect(ctx, MessageIdVs::DestroyPool).await?;
+        let req: DestroyPoolRequest = destroy_pool_req.into();
+        let response = client.clone().destroy_pool(req).await?.into_inner();
+        match response.error {
+            None => Ok(()),
+            Some(err) => Err(err.into()),
+        }
+    }
+
+    async fn get(&self, filter: Filter, ctx: Option<Context>) -> Result<Pools, ReplyError> {
+        let client = self.reconnect(ctx, MessageIdVs::GetPools).await?;
+        let req: GetPoolsRequest = match filter {
+            Filter::Node(id) => GetPoolsRequest {
+                filter: Some(get_pools_request::Filter::Node(NodeFilter {
+                    node_id: id.into(),
+                })),
+            },
+            Filter::Pool(id) => GetPoolsRequest {
+                filter: Some(get_pools_request::Filter::Pool(PoolFilter {
+                    pool_id: id.into(),
+                })),
+            },
+            Filter::NodePool(node_id, pool_id) => GetPoolsRequest {
+                filter: Some(get_pools_request::Filter::NodePool(NodePoolFilter {
+                    node_id: node_id.into(),
+                    pool_id: pool_id.into(),
+                })),
+            },
+            _ => GetPoolsRequest { filter: None },
+        };
+        let response = client.clone().get_pools(req).await?.into_inner();
+        match response.reply {
+            Some(get_pools_reply) => match get_pools_reply {
+                get_pools_reply::Reply::Pools(pools) => Ok(Pools::try_from(pools)?),
+                get_pools_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Replica)),
+        }
+    }
+}

--- a/control-plane/grpc/src/pool/mod.rs
+++ b/control-plane/grpc/src/pool/mod.rs
@@ -1,0 +1,8 @@
+// Pool grpc Client related code
+pub mod client;
+
+// Pool grpc Server related code
+pub mod server;
+
+// Pool traits for the transport
+pub mod traits;

--- a/control-plane/grpc/src/pool/server.rs
+++ b/control-plane/grpc/src/pool/server.rs
@@ -1,0 +1,111 @@
+use crate::{
+    pool::traits::PoolOperations,
+    pool_grpc,
+    pool_grpc::{
+        create_pool_reply, get_pools_reply,
+        pool_grpc_server::{PoolGrpc, PoolGrpcServer},
+        CreatePoolReply, CreatePoolRequest, DestroyPoolReply, DestroyPoolRequest, GetPoolsReply,
+        GetPoolsRequest,
+    },
+};
+use common_lib::mbus_api::{ErrorChain, ReplyError};
+use std::sync::Arc;
+use tonic::{Request, Response};
+
+/// RPC Pool Server
+#[derive(Clone)]
+pub struct PoolServer {
+    /// Service which executes the operations.
+    service: Arc<dyn PoolOperations>,
+}
+
+impl PoolServer {
+    /// returns a new poolserver with the service implementing pool operations
+    pub fn new(service: Arc<dyn PoolOperations>) -> Self {
+        Self { service }
+    }
+    /// coverts the poolserver to its corresponding grpc server type
+    pub fn into_grpc_server(self) -> PoolGrpcServer<PoolServer> {
+        PoolGrpcServer::new(self)
+    }
+}
+
+// Implementation of the RPC methods.
+#[tonic::async_trait]
+impl PoolGrpc for PoolServer {
+    async fn destroy_pool(
+        &self,
+        request: Request<DestroyPoolRequest>,
+    ) -> Result<tonic::Response<DestroyPoolReply>, tonic::Status> {
+        let req = request.into_inner();
+        // Dispatch the destroy call to the registered service.
+        let service = self.service.clone();
+        tokio::spawn(async move {
+            match service.destroy(&req, None).await {
+                Ok(()) => Ok(Response::new(DestroyPoolReply { error: None })),
+                Err(e) => Ok(Response::new(DestroyPoolReply {
+                    error: Some(e.into()),
+                })),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Ok(Response::new(DestroyPoolReply {
+                error: Some(ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into()),
+            }))
+        })
+    }
+
+    async fn create_pool(
+        &self,
+        request: Request<CreatePoolRequest>,
+    ) -> Result<tonic::Response<pool_grpc::CreatePoolReply>, tonic::Status> {
+        let req: CreatePoolRequest = request.into_inner();
+        let service = self.service.clone();
+        tokio::spawn(async move {
+            match service.create(&req, None).await {
+                Ok(pool) => Ok(Response::new(CreatePoolReply {
+                    reply: Some(create_pool_reply::Reply::Pool(pool.into())),
+                })),
+                Err(err) => Ok(Response::new(CreatePoolReply {
+                    reply: Some(create_pool_reply::Reply::Error(err.into())),
+                })),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Ok(Response::new(CreatePoolReply {
+                reply: Some(create_pool_reply::Reply::Error(
+                    ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into(),
+                )),
+            }))
+        })
+    }
+
+    async fn get_pools(
+        &self,
+        request: Request<GetPoolsRequest>,
+    ) -> Result<tonic::Response<pool_grpc::GetPoolsReply>, tonic::Status> {
+        let req: GetPoolsRequest = request.into_inner();
+        let filter = req.filter.map(Into::into).unwrap_or_default();
+        let service = self.service.clone();
+        tokio::spawn(async move {
+            match service.get(filter, None).await {
+                Ok(pools) => Ok(Response::new(GetPoolsReply {
+                    reply: Some(get_pools_reply::Reply::Pools(pools.into())),
+                })),
+                Err(err) => Ok(Response::new(GetPoolsReply {
+                    reply: Some(get_pools_reply::Reply::Error(err.into())),
+                })),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Ok(Response::new(GetPoolsReply {
+                reply: Some(get_pools_reply::Reply::Error(
+                    ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into(),
+                )),
+            }))
+        })
+    }
+}

--- a/control-plane/grpc/src/pool/traits.rs
+++ b/control-plane/grpc/src/pool/traits.rs
@@ -1,0 +1,336 @@
+use crate::{
+    common,
+    grpc_opts::Context,
+    pool_grpc,
+    pool_grpc::{get_pools_request, CreatePoolRequest, DestroyPoolRequest},
+};
+use common_lib::{
+    mbus_api::{v0::Pools, ReplyError, ResourceKind},
+    types::v0::{
+        message_bus,
+        message_bus::{
+            CreatePool, DestroyPool, Filter, NodeId, Pool, PoolDeviceUri, PoolId, PoolState,
+        },
+        store::pool::{PoolLabel, PoolSpec, PoolSpecStatus},
+    },
+};
+use std::convert::TryFrom;
+
+/// Trait implemented by services which support pool operations.
+#[tonic::async_trait]
+pub trait PoolOperations: Send + Sync {
+    async fn create(
+        &self,
+        pool: &dyn CreatePoolInfo,
+        ctx: Option<Context>,
+    ) -> Result<Pool, ReplyError>;
+    async fn destroy(
+        &self,
+        pool: &dyn DestroyPoolInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError>;
+    async fn get(&self, filter: Filter, ctx: Option<Context>) -> Result<Pools, ReplyError>;
+}
+
+impl TryFrom<pool_grpc::Pool> for Pool {
+    type Error = ReplyError;
+    fn try_from(pool: pool_grpc::Pool) -> Result<Self, Self::Error> {
+        let pool_state = match pool.state {
+            None => None,
+            Some(pool_state) => Some(PoolState {
+                node: pool_state.node_id.into(),
+                id: pool_state.pool_id.into(),
+                disks: pool_state.disks_uri.iter().map(|i| i.into()).collect(),
+                status: match pool_grpc::PoolStatus::from_i32(pool_state.status) {
+                    Some(status) => status.into(),
+                    None => return Err(ReplyError::unwrap_err(ResourceKind::Pool)),
+                },
+                capacity: pool_state.capacity,
+                used: pool_state.used,
+            }),
+        };
+        let pool_spec = match pool.definition {
+            None => None,
+            Some(pool_definition) => {
+                let pool_spec = match pool_definition.spec {
+                    Some(spec) => spec,
+                    None => return Err(ReplyError::unwrap_err(ResourceKind::Pool)),
+                };
+                let pool_meta = match pool_definition.metadata {
+                    Some(meta) => meta,
+                    None => return Err(ReplyError::unwrap_err(ResourceKind::Pool)),
+                };
+                let pool_spec_status = match common::SpecStatus::from_i32(pool_meta.status) {
+                    Some(status) => match status {
+                        common::SpecStatus::Created => match pool_state {
+                            None => PoolSpecStatus::Created(message_bus::PoolStatus::Unknown),
+                            Some(ref state) => PoolSpecStatus::Created(state.status.clone()),
+                        },
+                        _ => match common::SpecStatus::from_i32(pool_meta.status) {
+                            Some(status) => status.into(),
+                            None => return Err(ReplyError::unwrap_err(ResourceKind::Pool)),
+                        },
+                    },
+                    None => return Err(ReplyError::unwrap_err(ResourceKind::Pool)),
+                };
+                Some(PoolSpec {
+                    node: pool_spec.node_id.into(),
+                    id: pool_spec.pool_id.into(),
+                    disks: pool_spec.disks.iter().map(|i| i.into()).collect(),
+                    status: pool_spec_status,
+                    labels: match pool_spec.labels {
+                        Some(labels) => Some(labels.value),
+                        None => None,
+                    },
+                    sequencer: Default::default(),
+                    operation: None,
+                })
+            }
+        };
+        match Pool::try_new(pool_spec, pool_state) {
+            Some(pool) => Ok(pool),
+            None => Err(ReplyError::unwrap_err(ResourceKind::Pool)),
+        }
+    }
+}
+
+impl From<Pool> for pool_grpc::Pool {
+    fn from(pool: Pool) -> Self {
+        let pool_definition = match pool.spec() {
+            None => None,
+            Some(pool_spec) => {
+                let status: common::SpecStatus = pool_spec.status.into();
+                Some(pool_grpc::PoolDefinition {
+                    spec: Some(pool_grpc::PoolSpec {
+                        node_id: pool_spec.node.to_string(),
+                        pool_id: pool_spec.id.to_string(),
+                        disks: pool_spec.disks.iter().map(|i| i.to_string()).collect(),
+                        labels: pool_spec
+                            .labels
+                            .map(|labels| crate::common::StringMapValue { value: labels }),
+                    }),
+                    metadata: Some(pool_grpc::Metadata {
+                        uuid: None,
+                        status: status as i32,
+                    }),
+                })
+            }
+        };
+        let pool_state = match pool.state() {
+            None => None,
+            Some(pool_state) => Some(pool_grpc::PoolState {
+                node_id: pool_state.node.to_string(),
+                pool_id: pool_state.id.to_string(),
+                disks_uri: pool_state.disks.iter().map(|i| i.to_string()).collect(),
+                status: pool_state.status as i32,
+                capacity: pool_state.capacity,
+                used: pool_state.used,
+            }),
+        };
+        pool_grpc::Pool {
+            definition: pool_definition,
+            state: pool_state,
+        }
+    }
+}
+
+impl TryFrom<pool_grpc::Pools> for Pools {
+    type Error = ReplyError;
+    fn try_from(grpc_pool_type: pool_grpc::Pools) -> Result<Self, Self::Error> {
+        let mut pools: Vec<Pool> = vec![];
+        for pool in grpc_pool_type.pools {
+            pools.push(Pool::try_from(pool.clone())?)
+        }
+        Ok(Pools(pools))
+    }
+}
+
+impl From<Pools> for pool_grpc::Pools {
+    fn from(pools: Pools) -> Self {
+        pool_grpc::Pools {
+            pools: pools
+                .into_inner()
+                .iter()
+                .map(|pool| pool.clone().into())
+                .collect(),
+        }
+    }
+}
+
+impl From<get_pools_request::Filter> for Filter {
+    fn from(filter: get_pools_request::Filter) -> Self {
+        match filter {
+            get_pools_request::Filter::Node(node_filter) => {
+                Filter::Node(node_filter.node_id.into())
+            }
+            get_pools_request::Filter::NodePool(node_pool_filter) => Filter::NodePool(
+                node_pool_filter.node_id.into(),
+                node_pool_filter.pool_id.into(),
+            ),
+            get_pools_request::Filter::Pool(pool_filter) => {
+                Filter::Pool(pool_filter.pool_id.into())
+            }
+        }
+    }
+}
+
+/// CreatePoolInfo trait for the pool creation to be implemented by entities which want to avail
+/// this operation
+pub trait CreatePoolInfo: Send + Sync {
+    fn pool_id(&self) -> PoolId;
+    fn node_id(&self) -> NodeId;
+    fn disks(&self) -> Vec<PoolDeviceUri>;
+    fn labels(&self) -> Option<PoolLabel>;
+}
+
+/// DestroyPoolInfo trait for the pool deletion to be implemented by entities which want to avail
+/// this operation
+pub trait DestroyPoolInfo: Sync + Send {
+    fn pool_id(&self) -> PoolId;
+    fn node_id(&self) -> NodeId;
+}
+
+impl CreatePoolInfo for CreatePool {
+    fn pool_id(&self) -> PoolId {
+        self.id.clone()
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.node.clone()
+    }
+
+    fn disks(&self) -> Vec<PoolDeviceUri> {
+        self.disks.clone()
+    }
+
+    fn labels(&self) -> Option<PoolLabel> {
+        self.labels.clone()
+    }
+}
+
+impl CreatePoolInfo for CreatePoolRequest {
+    fn pool_id(&self) -> PoolId {
+        self.pool_id.clone().into()
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.node_id.clone().into()
+    }
+
+    fn disks(&self) -> Vec<PoolDeviceUri> {
+        self.disks.iter().map(|disk| disk.into()).collect()
+    }
+
+    fn labels(&self) -> Option<PoolLabel> {
+        match self.labels.clone() {
+            None => None,
+            Some(labels) => Some(labels.value),
+        }
+    }
+}
+
+impl From<&dyn CreatePoolInfo> for CreatePoolRequest {
+    fn from(data: &dyn CreatePoolInfo) -> Self {
+        Self {
+            pool_id: data.pool_id().to_string(),
+            node_id: data.node_id().to_string(),
+            disks: data.disks().iter().map(|disk| disk.to_string()).collect(),
+            labels: data
+                .labels()
+                .map(|labels| crate::common::StringMapValue { value: labels }),
+        }
+    }
+}
+
+impl From<&dyn CreatePoolInfo> for CreatePool {
+    fn from(data: &dyn CreatePoolInfo) -> Self {
+        Self {
+            node: data.node_id(),
+            id: data.pool_id(),
+            disks: data.disks(),
+            labels: data.labels(),
+        }
+    }
+}
+
+impl DestroyPoolInfo for DestroyPool {
+    fn pool_id(&self) -> PoolId {
+        self.id.clone()
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.node.clone()
+    }
+}
+
+impl DestroyPoolInfo for DestroyPoolRequest {
+    fn pool_id(&self) -> PoolId {
+        self.pool_id.clone().into()
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.node_id.clone().into()
+    }
+}
+
+impl From<&dyn DestroyPoolInfo> for DestroyPoolRequest {
+    fn from(data: &dyn DestroyPoolInfo) -> Self {
+        Self {
+            pool_id: data.pool_id().to_string(),
+            node_id: data.node_id().to_string(),
+        }
+    }
+}
+
+impl From<&dyn DestroyPoolInfo> for DestroyPool {
+    fn from(data: &dyn DestroyPoolInfo) -> Self {
+        Self {
+            node: data.node_id(),
+            id: data.pool_id(),
+        }
+    }
+}
+
+impl From<pool_grpc::PoolStatus> for message_bus::PoolStatus {
+    fn from(src: pool_grpc::PoolStatus) -> Self {
+        match src {
+            pool_grpc::PoolStatus::Online => Self::Online,
+            pool_grpc::PoolStatus::Degraded => Self::Degraded,
+            pool_grpc::PoolStatus::Faulted => Self::Faulted,
+            pool_grpc::PoolStatus::Unknown => Self::Unknown,
+        }
+    }
+}
+
+impl From<message_bus::PoolStatus> for pool_grpc::PoolStatus {
+    fn from(pool_status: message_bus::PoolStatus) -> Self {
+        match pool_status {
+            message_bus::PoolStatus::Unknown => Self::Unknown,
+            message_bus::PoolStatus::Online => Self::Online,
+            message_bus::PoolStatus::Degraded => Self::Degraded,
+            message_bus::PoolStatus::Faulted => Self::Faulted,
+        }
+    }
+}
+
+impl From<common::SpecStatus> for PoolSpecStatus {
+    fn from(src: common::SpecStatus) -> Self {
+        match src {
+            common::SpecStatus::Created => Self::Created(Default::default()),
+            common::SpecStatus::Creating => Self::Creating,
+            common::SpecStatus::Deleted => Self::Deleted,
+            common::SpecStatus::Deleting => Self::Deleting,
+        }
+    }
+}
+
+impl From<PoolSpecStatus> for common::SpecStatus {
+    fn from(src: PoolSpecStatus) -> Self {
+        match src {
+            PoolSpecStatus::Creating => Self::Creating,
+            PoolSpecStatus::Created(_) => Self::Created,
+            PoolSpecStatus::Deleting => Self::Deleting,
+            PoolSpecStatus::Deleted => Self::Deleted,
+        }
+    }
+}

--- a/control-plane/grpc/src/replica/client.rs
+++ b/control-plane/grpc/src/replica/client.rs
@@ -1,0 +1,212 @@
+use crate::{
+    common::{
+        NodeFilter, NodePoolFilter, NodePoolReplicaFilter, NodeReplicaFilter, PoolFilter,
+        PoolReplicaFilter, ReplicaFilter, VolumeFilter,
+    },
+    replica::traits::ReplicaOperations,
+    replica_grpc::{
+        create_replica_reply, get_replicas_reply, get_replicas_request,
+        replica_grpc_client::ReplicaGrpcClient, share_replica_reply, CreateReplicaRequest,
+        DestroyReplicaRequest, GetReplicasRequest, ShareReplicaRequest, UnshareReplicaRequest,
+    },
+};
+use std::time::Duration;
+use tonic::transport::{Channel, Endpoint, Uri};
+
+use crate::{
+    grpc_opts::{timeout_grpc, Context},
+    replica::traits::{
+        CreateReplicaInfo, DestroyReplicaInfo, ShareReplicaInfo, UnshareReplicaInfo,
+    },
+};
+use common_lib::{
+    mbus_api::{v0::Replicas, ReplyError, ResourceKind, TimeoutOptions},
+    types::v0::message_bus::{Filter, MessageIdVs, Replica},
+};
+use utils::DEFAULT_REQ_TIMEOUT;
+
+// RPC Replica Client
+#[derive(Clone)]
+pub struct ReplicaClient {
+    base_timeout: Duration,
+    endpoint: Endpoint,
+}
+
+impl ReplicaClient {
+    /// creates a new base tonic endpoint with the timeout options and the address
+    pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
+        let opts = opts.into();
+        let timeout = opts
+            .map(|opt| opt.base_timeout())
+            .unwrap_or_else(|| humantime::parse_duration(DEFAULT_REQ_TIMEOUT).unwrap());
+        let endpoint = tonic::transport::Endpoint::from(addr)
+            .connect_timeout(timeout)
+            .timeout(timeout);
+        Self {
+            base_timeout: timeout,
+            endpoint,
+        }
+    }
+    /// creates a new replica grpc client on a new endpoint after altering the properties of the
+    /// base endpoint according to the provided context
+    pub async fn reconnect(
+        &self,
+        ctx: Option<Context>,
+        op_id: MessageIdVs,
+    ) -> Result<ReplicaGrpcClient<Channel>, tonic::transport::Error> {
+        let ctx_timeout = ctx.map(|ctx| ctx.timeout_opts()).flatten();
+        match ctx_timeout {
+            None => {
+                let timeout = timeout_grpc(op_id, self.base_timeout);
+                let endpoint = self
+                    .endpoint
+                    .clone()
+                    .connect_timeout(timeout)
+                    .timeout(timeout);
+                let client = ReplicaGrpcClient::connect(endpoint.clone()).await?;
+                Ok(client)
+            }
+            Some(timeout_opts) => {
+                let timeout = timeout_opts.base_timeout();
+                let endpoint = self
+                    .endpoint
+                    .clone()
+                    .connect_timeout(timeout)
+                    .timeout(timeout);
+                let client = ReplicaGrpcClient::connect(endpoint.clone()).await?;
+                Ok(client)
+            }
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl ReplicaOperations for ReplicaClient {
+    async fn create(
+        &self,
+        req: &dyn CreateReplicaInfo,
+        ctx: Option<Context>,
+    ) -> Result<Replica, ReplyError> {
+        let client = self.reconnect(ctx, MessageIdVs::CreateReplica).await?;
+        let req: CreateReplicaRequest = req.into();
+        let response = client.clone().create_replica(req).await?.into_inner();
+        match response.reply {
+            Some(create_replica_reply) => match create_replica_reply {
+                create_replica_reply::Reply::Replica(replica) => Ok(replica.into()),
+                create_replica_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Replica)),
+        }
+    }
+
+    async fn get(&self, filter: Filter, ctx: Option<Context>) -> Result<Replicas, ReplyError> {
+        let client = self.reconnect(ctx, MessageIdVs::GetReplicas).await?;
+        let req: GetReplicasRequest = match filter {
+            Filter::Node(id) => GetReplicasRequest {
+                filter: Some(get_replicas_request::Filter::Node(NodeFilter {
+                    node_id: id.into(),
+                })),
+            },
+            Filter::Pool(id) => GetReplicasRequest {
+                filter: Some(get_replicas_request::Filter::Pool(PoolFilter {
+                    pool_id: id.into(),
+                })),
+            },
+            Filter::NodePool(node_id, pool_id) => GetReplicasRequest {
+                filter: Some(get_replicas_request::Filter::NodePool(NodePoolFilter {
+                    node_id: node_id.into(),
+                    pool_id: pool_id.into(),
+                })),
+            },
+            Filter::NodePoolReplica(node_id, pool_id, replica_id) => GetReplicasRequest {
+                filter: Some(get_replicas_request::Filter::NodePoolReplica(
+                    NodePoolReplicaFilter {
+                        node_id: node_id.into(),
+                        pool_id: pool_id.into(),
+                        replica_id: replica_id.to_string(),
+                    },
+                )),
+            },
+            Filter::NodeReplica(node_id, replica_id) => GetReplicasRequest {
+                filter: Some(get_replicas_request::Filter::NodeReplica(
+                    NodeReplicaFilter {
+                        node_id: node_id.into(),
+                        replica_id: replica_id.to_string(),
+                    },
+                )),
+            },
+            Filter::PoolReplica(pool_id, replica_id) => GetReplicasRequest {
+                filter: Some(get_replicas_request::Filter::PoolReplica(
+                    PoolReplicaFilter {
+                        pool_id: pool_id.into(),
+                        replica_id: replica_id.to_string(),
+                    },
+                )),
+            },
+            Filter::Replica(replica_id) => GetReplicasRequest {
+                filter: Some(get_replicas_request::Filter::Replica(ReplicaFilter {
+                    replica_id: replica_id.to_string(),
+                })),
+            },
+            Filter::Volume(volume_id) => GetReplicasRequest {
+                filter: Some(get_replicas_request::Filter::Volume(VolumeFilter {
+                    volume_id: volume_id.to_string(),
+                })),
+            },
+            _ => GetReplicasRequest { filter: None },
+        };
+        let response = client.clone().get_replicas(req).await?.into_inner();
+        match response.reply {
+            Some(get_replicas_reply) => match get_replicas_reply {
+                get_replicas_reply::Reply::Replicas(replicas) => Ok(replicas.into()),
+                get_replicas_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Replica)),
+        }
+    }
+
+    async fn destroy(
+        &self,
+        req: &dyn DestroyReplicaInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError> {
+        let client = self.reconnect(ctx, MessageIdVs::DestroyReplica).await?;
+        let req: DestroyReplicaRequest = req.into();
+        let response = client.clone().destroy_replica(req).await?.into_inner();
+        match response.error {
+            None => Ok(()),
+            Some(err) => Err(err.into()),
+        }
+    }
+
+    async fn share(
+        &self,
+        req: &dyn ShareReplicaInfo,
+        ctx: Option<Context>,
+    ) -> Result<String, ReplyError> {
+        let client = self.reconnect(ctx, MessageIdVs::ShareReplica).await?;
+        let req: ShareReplicaRequest = req.into();
+        let response = client.clone().share_replica(req).await?.into_inner();
+        match response.reply {
+            Some(share_replica_reply) => match share_replica_reply {
+                share_replica_reply::Reply::Response(message) => Ok(message),
+                share_replica_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Replica)),
+        }
+    }
+
+    async fn unshare(
+        &self,
+        req: &dyn UnshareReplicaInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError> {
+        let client = self.reconnect(ctx, MessageIdVs::UnshareReplica).await?;
+        let req: UnshareReplicaRequest = req.into();
+        let response = client.clone().unshare_replica(req).await?.into_inner();
+        match response.error {
+            None => Ok(()),
+            Some(err) => Err(err.into()),
+        }
+    }
+}

--- a/control-plane/grpc/src/replica/mod.rs
+++ b/control-plane/grpc/src/replica/mod.rs
@@ -1,0 +1,8 @@
+// Replica grpc Client related code
+pub mod client;
+
+// Replica grpc Server related code
+pub mod server;
+
+// Replica traits for the transport
+pub mod traits;

--- a/control-plane/grpc/src/replica/server.rs
+++ b/control-plane/grpc/src/replica/server.rs
@@ -1,0 +1,161 @@
+use crate::{
+    replica::traits::ReplicaOperations,
+    replica_grpc::{
+        create_replica_reply, get_replicas_reply,
+        replica_grpc_server::{ReplicaGrpc, ReplicaGrpcServer},
+        share_replica_reply, CreateReplicaReply, CreateReplicaRequest, DestroyReplicaReply,
+        DestroyReplicaRequest, GetReplicasReply, GetReplicasRequest, ShareReplicaReply,
+        ShareReplicaRequest, UnshareReplicaReply, UnshareReplicaRequest,
+    },
+};
+use common_lib::{
+    mbus_api::{ErrorChain, ReplyError},
+    types::v0::message_bus::Filter,
+};
+use std::sync::Arc;
+use tonic::Response;
+
+/// RPC Replica Server
+#[derive(Clone)]
+pub struct ReplicaServer {
+    /// Service which executes the operations.
+    service: Arc<dyn ReplicaOperations>,
+}
+
+impl ReplicaServer {
+    /// returns a new replicaserver with the service implementing replica operations
+    pub fn new(service: Arc<dyn ReplicaOperations>) -> Self {
+        Self { service }
+    }
+    /// coverts the replicaserver to its corresponding grpc server type
+    pub fn into_grpc_server(self) -> ReplicaGrpcServer<ReplicaServer> {
+        ReplicaGrpcServer::new(self)
+    }
+}
+
+/// Implementation of the RPC methods.
+#[tonic::async_trait]
+impl ReplicaGrpc for ReplicaServer {
+    async fn create_replica(
+        &self,
+        request: tonic::Request<CreateReplicaRequest>,
+    ) -> Result<tonic::Response<CreateReplicaReply>, tonic::Status> {
+        let req = request.into_inner();
+        let service = self.service.clone();
+        tokio::spawn(async move {
+            match service.create(&req, None).await {
+                Ok(replica) => Ok(Response::new(CreateReplicaReply {
+                    reply: Some(create_replica_reply::Reply::Replica(replica.into())),
+                })),
+                Err(err) => Ok(Response::new(CreateReplicaReply {
+                    reply: Some(create_replica_reply::Reply::Error(err.into())),
+                })),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Ok(Response::new(CreateReplicaReply {
+                reply: Some(create_replica_reply::Reply::Error(
+                    ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into(),
+                )),
+            }))
+        })
+    }
+    async fn destroy_replica(
+        &self,
+        request: tonic::Request<DestroyReplicaRequest>,
+    ) -> Result<tonic::Response<DestroyReplicaReply>, tonic::Status> {
+        let req = request.into_inner();
+        let service = self.service.clone();
+        tokio::spawn(async move {
+            match service.destroy(&req, None).await {
+                Ok(()) => Ok(Response::new(DestroyReplicaReply { error: None })),
+                Err(e) => Ok(Response::new(DestroyReplicaReply {
+                    error: Some(e.into()),
+                })),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Ok(Response::new(DestroyReplicaReply {
+                error: Some(ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into()),
+            }))
+        })
+    }
+    async fn get_replicas(
+        &self,
+        request: tonic::Request<GetReplicasRequest>,
+    ) -> Result<tonic::Response<GetReplicasReply>, tonic::Status> {
+        let req: GetReplicasRequest = request.into_inner();
+        let filter: Filter = if req.filter.is_none() {
+            Filter::None
+        } else {
+            req.filter.unwrap().into()
+        };
+        let service = self.service.clone();
+        tokio::spawn(async move {
+            match service.get(filter, None).await {
+                Ok(replicas) => Ok(Response::new(GetReplicasReply {
+                    reply: Some(get_replicas_reply::Reply::Replicas(replicas.into())),
+                })),
+                Err(err) => Ok(Response::new(GetReplicasReply {
+                    reply: Some(get_replicas_reply::Reply::Error(err.into())),
+                })),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Ok(Response::new(GetReplicasReply {
+                reply: Some(get_replicas_reply::Reply::Error(
+                    ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into(),
+                )),
+            }))
+        })
+    }
+    async fn share_replica(
+        &self,
+        request: tonic::Request<ShareReplicaRequest>,
+    ) -> Result<tonic::Response<ShareReplicaReply>, tonic::Status> {
+        let req = request.into_inner();
+        let service = self.service.clone();
+        tokio::spawn(async move {
+            match service.share(&req, None).await {
+                Ok(message) => Ok(Response::new(ShareReplicaReply {
+                    reply: Some(share_replica_reply::Reply::Response(message)),
+                })),
+                Err(err) => Ok(Response::new(ShareReplicaReply {
+                    reply: Some(share_replica_reply::Reply::Error(err.into())),
+                })),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Ok(Response::new(ShareReplicaReply {
+                reply: Some(share_replica_reply::Reply::Error(
+                    ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into(),
+                )),
+            }))
+        })
+    }
+    async fn unshare_replica(
+        &self,
+        request: tonic::Request<UnshareReplicaRequest>,
+    ) -> Result<tonic::Response<UnshareReplicaReply>, tonic::Status> {
+        let req = request.into_inner();
+        let service = self.service.clone();
+        tokio::spawn(async move {
+            match service.unshare(&req, None).await {
+                Ok(()) => Ok(Response::new(UnshareReplicaReply { error: None })),
+                Err(e) => Ok(Response::new(UnshareReplicaReply {
+                    error: Some(e.into()),
+                })),
+            }
+        })
+        .await
+        .unwrap_or_else(|e| {
+            Ok(Response::new(UnshareReplicaReply {
+                error: Some(ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into()),
+            }))
+        })
+    }
+}

--- a/control-plane/grpc/src/replica/traits.rs
+++ b/control-plane/grpc/src/replica/traits.rs
@@ -1,0 +1,596 @@
+use crate::{
+    grpc_opts::Context,
+    replica_grpc,
+    replica_grpc::{
+        get_replicas_request, CreateReplicaRequest, DestroyReplicaRequest, ShareReplicaRequest,
+        UnshareReplicaRequest,
+    },
+};
+use common_lib::{
+    mbus_api::{v0::Replicas, ReplyError},
+    types::v0::{
+        message_bus,
+        message_bus::{
+            CreateReplica, DestroyReplica, Filter, NexusId, NodeId, PoolId, Replica, ReplicaId,
+            ReplicaName, ReplicaOwners, ShareReplica, UnshareReplica, VolumeId,
+        },
+    },
+};
+use std::convert::TryFrom;
+
+/// all replica operations to be a part of the ReplicaOperations trait
+#[tonic::async_trait]
+pub trait ReplicaOperations: Send + Sync {
+    async fn create(
+        &self,
+        req: &dyn CreateReplicaInfo,
+        ctx: Option<Context>,
+    ) -> Result<Replica, ReplyError>;
+    async fn get(&self, filter: Filter, ctx: Option<Context>) -> Result<Replicas, ReplyError>;
+    async fn destroy(
+        &self,
+        req: &dyn DestroyReplicaInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError>;
+    async fn share(
+        &self,
+        req: &dyn ShareReplicaInfo,
+        ctx: Option<Context>,
+    ) -> Result<String, ReplyError>;
+    async fn unshare(
+        &self,
+        req: &dyn UnshareReplicaInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError>;
+}
+
+impl From<Replica> for replica_grpc::Replica {
+    fn from(replica: Replica) -> Self {
+        let share: replica_grpc::Protocol = replica.share.into();
+        let status: replica_grpc::ReplicaStatus = replica.status.into();
+        replica_grpc::Replica {
+            node_id: replica.node.into(),
+            name: replica.name.into(),
+            replica_id: Some(replica.uuid.into()),
+            pool_id: replica.pool.into(),
+            thin: replica.thin,
+            size: replica.size,
+            share: share as i32,
+            uri: replica.uri,
+            status: status as i32,
+        }
+    }
+}
+
+impl From<replica_grpc::Replica> for Replica {
+    fn from(replica: replica_grpc::Replica) -> Self {
+        Replica {
+            node: replica.node_id.into(),
+            name: replica.name.into(),
+            uuid: ReplicaId::try_from(replica.replica_id.unwrap()).unwrap(),
+            pool: replica.pool_id.into(),
+            thin: replica.thin,
+            size: replica.size,
+            share: replica_grpc::Protocol::from_i32(replica.share)
+                .unwrap()
+                .into(),
+            uri: replica.uri,
+            status: replica_grpc::ReplicaStatus::from_i32(replica.status)
+                .unwrap()
+                .into(),
+        }
+    }
+}
+
+impl From<get_replicas_request::Filter> for Filter {
+    fn from(filter: get_replicas_request::Filter) -> Self {
+        match filter {
+            get_replicas_request::Filter::Node(node_filter) => {
+                Filter::Node(node_filter.node_id.into())
+            }
+            get_replicas_request::Filter::NodePool(node_pool_filter) => Filter::NodePool(
+                node_pool_filter.node_id.into(),
+                node_pool_filter.pool_id.into(),
+            ),
+            get_replicas_request::Filter::Pool(pool_filter) => {
+                Filter::Pool(pool_filter.pool_id.into())
+            }
+            get_replicas_request::Filter::NodePoolReplica(node_pool_replica_filter) => {
+                Filter::NodePoolReplica(
+                    node_pool_replica_filter.node_id.into(),
+                    node_pool_replica_filter.pool_id.into(),
+                    ReplicaId::try_from(node_pool_replica_filter.replica_id).unwrap(),
+                )
+            }
+            get_replicas_request::Filter::NodeReplica(node_replica_filter) => Filter::NodeReplica(
+                node_replica_filter.node_id.into(),
+                ReplicaId::try_from(node_replica_filter.replica_id).unwrap(),
+            ),
+            get_replicas_request::Filter::PoolReplica(pool_replica_filter) => Filter::PoolReplica(
+                pool_replica_filter.pool_id.into(),
+                ReplicaId::try_from(pool_replica_filter.replica_id).unwrap(),
+            ),
+            get_replicas_request::Filter::Replica(replica_filter) => {
+                Filter::Replica(ReplicaId::try_from(replica_filter.replica_id).unwrap())
+            }
+            get_replicas_request::Filter::Volume(volume_filter) => {
+                Filter::Volume(VolumeId::try_from(volume_filter.volume_id).unwrap())
+            }
+        }
+    }
+}
+
+impl From<replica_grpc::Replicas> for Replicas {
+    fn from(replicas: replica_grpc::Replicas) -> Self {
+        Replicas(
+            replicas
+                .replicas
+                .iter()
+                .map(|replica| replica.clone().into())
+                .collect(),
+        )
+    }
+}
+
+impl From<Replicas> for replica_grpc::Replicas {
+    fn from(replicas: Replicas) -> Self {
+        replica_grpc::Replicas {
+            replicas: replicas
+                .into_inner()
+                .iter()
+                .map(|replicas| replicas.clone().into())
+                .collect(),
+        }
+    }
+}
+
+/// CreateReplicaInfo trait for the replica creation to be implemented by entities which want to
+/// avail this operation
+pub trait CreateReplicaInfo: Send + Sync {
+    fn node(&self) -> NodeId;
+    fn name(&self) -> Option<ReplicaName>;
+    fn uuid(&self) -> ReplicaId;
+    fn pool(&self) -> PoolId;
+    fn size(&self) -> u64;
+    fn thin(&self) -> bool;
+    fn share(&self) -> message_bus::Protocol;
+    fn managed(&self) -> bool;
+    fn owners(&self) -> ReplicaOwners;
+}
+
+impl CreateReplicaInfo for CreateReplica {
+    fn node(&self) -> NodeId {
+        self.node.clone()
+    }
+
+    fn name(&self) -> Option<ReplicaName> {
+        self.name.clone()
+    }
+
+    fn uuid(&self) -> ReplicaId {
+        self.uuid.clone()
+    }
+
+    fn pool(&self) -> PoolId {
+        self.pool.clone()
+    }
+
+    fn size(&self) -> u64 {
+        self.size
+    }
+
+    fn thin(&self) -> bool {
+        self.thin
+    }
+
+    fn share(&self) -> message_bus::Protocol {
+        self.share
+    }
+
+    fn managed(&self) -> bool {
+        self.managed
+    }
+
+    fn owners(&self) -> ReplicaOwners {
+        self.owners.clone()
+    }
+}
+
+impl CreateReplicaInfo for CreateReplicaRequest {
+    fn node(&self) -> NodeId {
+        self.node_id.clone().into()
+    }
+
+    fn name(&self) -> Option<ReplicaName> {
+        self.name.clone().map(|e| e.into())
+    }
+
+    fn uuid(&self) -> ReplicaId {
+        ReplicaId::try_from(self.replica_id.clone().unwrap()).unwrap()
+    }
+
+    fn pool(&self) -> PoolId {
+        self.pool_id.clone().into()
+    }
+
+    fn size(&self) -> u64 {
+        self.size
+    }
+
+    fn thin(&self) -> bool {
+        self.thin
+    }
+
+    fn share(&self) -> message_bus::Protocol {
+        replica_grpc::Protocol::from_i32(self.share).unwrap().into()
+    }
+
+    fn managed(&self) -> bool {
+        self.managed
+    }
+
+    fn owners(&self) -> ReplicaOwners {
+        ReplicaOwners::new(
+            self.owners
+                .clone()
+                .unwrap()
+                .volume
+                .map(|id| VolumeId::try_from(id).unwrap()),
+            self.owners
+                .clone()
+                .unwrap()
+                .nexuses
+                .iter()
+                .map(|id| NexusId::try_from(id.clone()).unwrap())
+                .collect(),
+        )
+    }
+}
+
+/// DestroyReplicaInfo trait for the replica deletion to be implemented by entities which want to
+/// avail this operation
+pub trait DestroyReplicaInfo: Send + Sync {
+    fn node(&self) -> NodeId;
+    fn pool(&self) -> PoolId;
+    fn name(&self) -> Option<ReplicaName>;
+    fn uuid(&self) -> ReplicaId;
+    fn disowners(&self) -> ReplicaOwners;
+}
+
+impl DestroyReplicaInfo for DestroyReplica {
+    fn node(&self) -> NodeId {
+        self.node.clone()
+    }
+
+    fn pool(&self) -> PoolId {
+        self.pool.clone()
+    }
+
+    fn name(&self) -> Option<ReplicaName> {
+        self.name.clone()
+    }
+
+    fn uuid(&self) -> ReplicaId {
+        self.uuid.clone()
+    }
+
+    fn disowners(&self) -> ReplicaOwners {
+        self.disowners.clone()
+    }
+}
+
+impl DestroyReplicaInfo for DestroyReplicaRequest {
+    fn node(&self) -> NodeId {
+        self.node_id.clone().into()
+    }
+
+    fn pool(&self) -> PoolId {
+        self.pool_id.clone().into()
+    }
+
+    fn name(&self) -> Option<ReplicaName> {
+        self.name.clone().map(|e| e.into())
+    }
+
+    fn uuid(&self) -> ReplicaId {
+        ReplicaId::try_from(self.replica_id.clone().unwrap()).unwrap()
+    }
+
+    fn disowners(&self) -> ReplicaOwners {
+        ReplicaOwners::new(
+            self.disowners
+                .clone()
+                .unwrap()
+                .volume
+                .map(|id| VolumeId::try_from(id).unwrap()),
+            self.disowners
+                .clone()
+                .unwrap()
+                .nexuses
+                .iter()
+                .map(|id| NexusId::try_from(id.clone()).unwrap())
+                .collect(),
+        )
+    }
+}
+
+/// ShareReplicaInfo trait for the replica sharing to be implemented by entities which want to avail
+/// this operation
+pub trait ShareReplicaInfo: Send + Sync {
+    fn node(&self) -> NodeId;
+    fn pool(&self) -> PoolId;
+    fn name(&self) -> Option<ReplicaName>;
+    fn uuid(&self) -> ReplicaId;
+    fn protocol(&self) -> message_bus::ReplicaShareProtocol;
+}
+
+impl ShareReplicaInfo for ShareReplica {
+    fn node(&self) -> NodeId {
+        self.node.clone()
+    }
+
+    fn pool(&self) -> PoolId {
+        self.pool.clone()
+    }
+
+    fn name(&self) -> Option<ReplicaName> {
+        self.name.clone()
+    }
+
+    fn uuid(&self) -> ReplicaId {
+        self.uuid.clone()
+    }
+
+    fn protocol(&self) -> message_bus::ReplicaShareProtocol {
+        self.protocol
+    }
+}
+
+impl ShareReplicaInfo for ShareReplicaRequest {
+    fn node(&self) -> NodeId {
+        self.node_id.clone().into()
+    }
+
+    fn pool(&self) -> PoolId {
+        self.pool_id.clone().into()
+    }
+
+    fn name(&self) -> Option<ReplicaName> {
+        self.name.clone().map(|e| e.into())
+    }
+
+    fn uuid(&self) -> ReplicaId {
+        ReplicaId::try_from(self.replica_id.clone().unwrap()).unwrap()
+    }
+
+    fn protocol(&self) -> message_bus::ReplicaShareProtocol {
+        replica_grpc::ReplicaShareProtocol::from_i32(self.protocol)
+            .unwrap()
+            .into()
+    }
+}
+
+/// UnshareReplicaInfo trait for the replica sharing to be implemented by entities which want to
+/// avail this operation
+pub trait UnshareReplicaInfo: Send + Sync {
+    fn node(&self) -> NodeId;
+    fn pool(&self) -> PoolId;
+    fn name(&self) -> Option<ReplicaName>;
+    fn uuid(&self) -> ReplicaId;
+}
+
+impl UnshareReplicaInfo for UnshareReplica {
+    fn node(&self) -> NodeId {
+        self.node.clone()
+    }
+
+    fn pool(&self) -> PoolId {
+        self.pool.clone()
+    }
+
+    fn name(&self) -> Option<ReplicaName> {
+        self.name.clone()
+    }
+
+    fn uuid(&self) -> ReplicaId {
+        self.uuid.clone()
+    }
+}
+
+impl UnshareReplicaInfo for UnshareReplicaRequest {
+    fn node(&self) -> NodeId {
+        self.node_id.clone().into()
+    }
+
+    fn pool(&self) -> PoolId {
+        self.pool_id.clone().into()
+    }
+
+    fn name(&self) -> Option<ReplicaName> {
+        self.name.clone().map(|e| e.into())
+    }
+
+    fn uuid(&self) -> ReplicaId {
+        ReplicaId::try_from(self.replica_id.clone().unwrap()).unwrap()
+    }
+}
+
+impl From<&dyn CreateReplicaInfo> for CreateReplicaRequest {
+    fn from(data: &dyn CreateReplicaInfo) -> Self {
+        let share: replica_grpc::Protocol = data.share().into();
+        Self {
+            node_id: data.node().to_string(),
+            pool_id: data.pool().to_string(),
+            name: data.name().map(|name| name.to_string()),
+            replica_id: Some(data.uuid().to_string()),
+            thin: data.thin(),
+            size: data.size(),
+            share: share as i32,
+            managed: data.managed(),
+            owners: Some(replica_grpc::ReplicaOwners {
+                volume: data.owners().volume().map(|id| id.to_string()),
+                nexuses: data
+                    .owners()
+                    .nexuses()
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect(),
+            }),
+        }
+    }
+}
+
+impl From<&dyn CreateReplicaInfo> for CreateReplica {
+    fn from(data: &dyn CreateReplicaInfo) -> Self {
+        Self {
+            node: data.node(),
+            name: data.name(),
+            uuid: data.uuid(),
+            pool: data.pool(),
+            size: data.size(),
+            thin: data.thin(),
+            share: data.share(),
+            managed: data.managed(),
+            owners: data.owners(),
+        }
+    }
+}
+
+impl From<&dyn DestroyReplicaInfo> for DestroyReplicaRequest {
+    fn from(data: &dyn DestroyReplicaInfo) -> Self {
+        Self {
+            node_id: data.node().to_string(),
+            pool_id: data.pool().to_string(),
+            name: data.name().map(|name| name.to_string()),
+            replica_id: Some(data.uuid().to_string()),
+            disowners: Some(replica_grpc::ReplicaOwners {
+                volume: data.disowners().volume().map(|id| id.to_string()),
+                nexuses: data
+                    .disowners()
+                    .nexuses()
+                    .iter()
+                    .map(|id| id.to_string())
+                    .collect(),
+            }),
+        }
+    }
+}
+
+impl From<&dyn DestroyReplicaInfo> for DestroyReplica {
+    fn from(data: &dyn DestroyReplicaInfo) -> Self {
+        Self {
+            node: data.node(),
+            pool: data.pool(),
+            uuid: data.uuid(),
+            name: data.name(),
+            disowners: data.disowners(),
+        }
+    }
+}
+
+impl From<&dyn ShareReplicaInfo> for ShareReplicaRequest {
+    fn from(data: &dyn ShareReplicaInfo) -> Self {
+        let protocol: replica_grpc::ReplicaShareProtocol = data.protocol().into();
+        Self {
+            node_id: data.node().to_string(),
+            pool_id: data.pool().to_string(),
+            name: data.name().map(|name| name.to_string()),
+            replica_id: Some(data.uuid().to_string()),
+            protocol: protocol as i32,
+        }
+    }
+}
+
+impl From<&dyn ShareReplicaInfo> for ShareReplica {
+    fn from(data: &dyn ShareReplicaInfo) -> Self {
+        Self {
+            node: data.node(),
+            pool: data.pool(),
+            uuid: data.uuid(),
+            name: data.name(),
+            protocol: data.protocol(),
+        }
+    }
+}
+
+impl From<&dyn UnshareReplicaInfo> for UnshareReplicaRequest {
+    fn from(data: &dyn UnshareReplicaInfo) -> Self {
+        Self {
+            node_id: data.node().to_string(),
+            pool_id: data.pool().to_string(),
+            name: data.name().map(|name| name.to_string()),
+            replica_id: Some(data.uuid().to_string()),
+        }
+    }
+}
+
+impl From<&dyn UnshareReplicaInfo> for UnshareReplica {
+    fn from(data: &dyn UnshareReplicaInfo) -> Self {
+        Self {
+            node: data.node(),
+            pool: data.pool(),
+            uuid: data.uuid(),
+            name: data.name(),
+        }
+    }
+}
+
+impl From<replica_grpc::Protocol> for message_bus::Protocol {
+    fn from(src: replica_grpc::Protocol) -> Self {
+        match src {
+            replica_grpc::Protocol::None => Self::None,
+            replica_grpc::Protocol::Nvmf => Self::Nvmf,
+            replica_grpc::Protocol::Iscsi => Self::Iscsi,
+            replica_grpc::Protocol::Nbd => Self::Nbd,
+        }
+    }
+}
+
+impl From<message_bus::Protocol> for replica_grpc::Protocol {
+    fn from(src: message_bus::Protocol) -> Self {
+        match src {
+            message_bus::Protocol::None => Self::None,
+            message_bus::Protocol::Nvmf => Self::Nvmf,
+            message_bus::Protocol::Iscsi => Self::Iscsi,
+            message_bus::Protocol::Nbd => Self::Nbd,
+        }
+    }
+}
+
+impl From<replica_grpc::ReplicaStatus> for message_bus::ReplicaStatus {
+    fn from(src: replica_grpc::ReplicaStatus) -> Self {
+        match src {
+            replica_grpc::ReplicaStatus::Unknown => Self::Unknown,
+            replica_grpc::ReplicaStatus::Online => Self::Online,
+            replica_grpc::ReplicaStatus::Degraded => Self::Degraded,
+            replica_grpc::ReplicaStatus::Faulted => Self::Faulted,
+        }
+    }
+}
+
+impl From<message_bus::ReplicaStatus> for replica_grpc::ReplicaStatus {
+    fn from(src: message_bus::ReplicaStatus) -> Self {
+        match src {
+            message_bus::ReplicaStatus::Unknown => Self::Unknown,
+            message_bus::ReplicaStatus::Online => Self::Online,
+            message_bus::ReplicaStatus::Degraded => Self::Degraded,
+            message_bus::ReplicaStatus::Faulted => Self::Faulted,
+        }
+    }
+}
+
+impl From<replica_grpc::ReplicaShareProtocol> for message_bus::ReplicaShareProtocol {
+    fn from(src: replica_grpc::ReplicaShareProtocol) -> Self {
+        match src {
+            replica_grpc::ReplicaShareProtocol::NvmfProtocol => Self::Nvmf,
+        }
+    }
+}
+
+impl From<message_bus::ReplicaShareProtocol> for replica_grpc::ReplicaShareProtocol {
+    fn from(src: message_bus::ReplicaShareProtocol) -> Self {
+        match src {
+            message_bus::ReplicaShareProtocol::Nvmf => Self::NvmfProtocol,
+        }
+    }
+}

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -26,7 +26,7 @@ opentelemetry = { version = "0.16.0", features = ["rt-tokio-current-thread"] }
 actix-web-opentelemetry = "0.11.0-beta.5"
 tracing = "0.1.28"
 tracing-subscriber = "0.2.24"
-
+once_cell = "1.9.0"
 async-trait = "0.1.51"
 serde_json = { version = "1.0.68", features = ["preserve_order"] }
 serde_yaml = "0.8.21"
@@ -41,6 +41,8 @@ jsonwebtoken = "7.2.0"
 common-lib = { path = "../../common" }
 utils = { path = "../../utils/utils-lib" }
 humantime = "2.1.0"
+git-version = "0.3.5"
+grpc = { path = "../grpc" }
 
 [dev-dependencies]
 tokio = { version = "1.12.0", features = ["full"] }

--- a/control-plane/rest/service/src/v0/mod.rs
+++ b/control-plane/rest/service/src/v0/mod.rs
@@ -15,16 +15,13 @@ pub mod swagger_ui;
 pub mod volumes;
 pub mod watches;
 
+use crate::authentication::authenticate;
 use actix_service::ServiceFactory;
 use actix_web::{
     body::MessageBody,
     dev::{ServiceRequest, ServiceResponse},
     web, FromRequest, HttpRequest,
 };
-use futures::future::Ready;
-use serde::Deserialize;
-
-use crate::authentication::authenticate;
 pub use common_lib::{
     types::v0::openapi::{
         apis::actix_server::{Body, Path, Query, RestError},
@@ -32,8 +29,16 @@ pub use common_lib::{
     },
     IntoVec,
 };
+use futures::future::Ready;
+use grpc::client::CoreClient;
 use mbus_api::{ReplyError, ReplyErrorKind, ResourceKind};
+use once_cell::sync::OnceCell;
 use rest_client::versions::v0::*;
+use serde::Deserialize;
+
+/// once cell static variable to store the grpc client and initialise
+/// once at startup
+pub static CORE_CLIENT: OnceCell<CoreClient> = OnceCell::new();
 
 fn version() -> String {
     "v0".into()

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -274,6 +274,10 @@ impl Components {
     pub fn nats_enabled(&self) -> bool {
         !self.1.no_nats
     }
+    /// to check whether core agent is being deployed or not
+    pub fn core_enabled(&self) -> bool {
+        self.0.contains(&Component::Core(Default::default()))
+    }
 }
 
 #[macro_export]

--- a/deployer/src/infra/rest.rs
+++ b/deployer/src/infra/rest.rs
@@ -34,6 +34,12 @@ impl ComponentAction for Rest {
                 binary = binary.with_arg("--no-min-timeouts");
             }
 
+            if let Some(env) = &options.rest_env {
+                for kv in env {
+                    binary = binary.with_env(kv.key.as_str(), kv.value.as_str().as_ref());
+                }
+            }
+
             if cfg.container_exists("jaeger") {
                 let jaeger_config = format!("jaeger.{}:6831", cfg.get_name());
                 binary = binary.with_args(vec!["--jaeger", &jaeger_config])

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -149,6 +149,10 @@ pub struct StartOptions {
     #[structopt(long, env = "AGENTS_ENV", value_delimiter=",", parse(try_from_str = common_lib::opentelemetry::parse_key_value))]
     pub agents_env: Option<Vec<KeyValue>>,
 
+    /// Add the following environment variables to the rest container
+    #[structopt(long, env = "REST_ENV", value_delimiter=",", parse(try_from_str = common_lib::opentelemetry::parse_key_value))]
+    pub rest_env: Option<Vec<KeyValue>>,
+
     /// Cargo Build each component before deploying
     #[structopt(short, long)]
     pub build: bool,

--- a/tests/tests-mayastor/Cargo.toml
+++ b/tests/tests-mayastor/Cargo.toml
@@ -23,7 +23,8 @@ common-lib = { path = "../../common" }
 structopt = "0.3.23"
 backtrace = "0.3.61"
 etcd-client = "0.7.2"
-
+grpc = { path = "../../control-plane/grpc" }
+tonic = "0.6.2"
 # Tracing
 tracing = "0.1.28"
 tracing-subscriber = "0.2.24"

--- a/tests/tests-mayastor/tests/nexus.rs
+++ b/tests/tests-mayastor/tests/nexus.rs
@@ -153,16 +153,16 @@ async fn create_nexus_replicas() {
         .get_replica(&Cluster::replica(0, 0, 0))
         .await
         .unwrap();
-    let remote = v0::ShareReplica {
-        node: cluster.node(1),
-        pool: cluster.pool(1, 0),
-        uuid: Cluster::replica(1, 0, 0),
-        name: None,
-        protocol: v0::ReplicaShareProtocol::Nvmf,
-    }
-    .request()
-    .await
-    .unwrap();
+    let remote = cluster
+        .rest_v00()
+        .replicas_api()
+        .put_node_pool_replica_share(
+            cluster.node(1).as_str(),
+            cluster.pool(1, 0).as_str(),
+            &(Cluster::replica(1, 0, 0).into()),
+        )
+        .await
+        .unwrap();
 
     v0::CreateNexus {
         node: cluster.node(0),

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -29,3 +29,9 @@ pub const OPENEBS_CREATED_BY_KEY: &str = "openebs.io/created-by";
 
 /// The value to mark the creation source of a pool to be msp-operator in labels
 pub const MSP_OPERATOR: &str = "msp-operator";
+
+/// The default value to be assigned as GRPC server addr if not overridden
+pub const DEFAULT_GRPC_SERVER_ADDR: &str = "https://0.0.0.0:50051";
+
+/// The default value to be assigned as GRPC client addr if not overridden
+pub const DEFAULT_GRPC_CLIENT_ADDR: &str = "https://core:50051";


### PR DESCRIPTION
### Changes
1. Removed the NATS subscription handlers for the pool and replica operations.
2. Add pool and replica operations over grpc.
3. Change tests to remove message bus usage for pool and replica operations.
4. Changes to cluster builder to use grpc.
5. Changes to the deployer to accept env-variable to rest containers.

Signed-off-by: Abhinandan-Purkait <abhinandan.purkait@mayadata.io>