### PR TITLE
feat(pstor-usage): take into account volume operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -933,6 +933,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.2.25",
+ "utils",
 ]
 
 [[package]]

--- a/tests/tests-mayastor/Cargo.toml
+++ b/tests/tests-mayastor/Cargo.toml
@@ -17,6 +17,7 @@ openapi = { path = "../../openapi", features = [ "tower-client", "tower-trace" ]
 composer = { git = "https://github.com/mayadata-io/composer", default-features = false, branch = "develop" }
 deployer = { path = "../../deployer" }
 rpc = { path = "../../rpc" }
+utils = { path = "../../utils/utils-lib" }
 anyhow = "1.0.44"
 common-lib = { path = "../../common" }
 structopt = "0.3.23"

--- a/utils/pstor-usage/README.md
+++ b/utils/pstor-usage/README.md
@@ -9,17 +9,17 @@ By default, it makes use of the `deployer` library to create a local cluster run
 
 ```textmate
 ❯ cargo run -q --bin pstor-usage -- --help
-pstor-usage version 0.1.0, git hash 4f40cf4681f7
+pstor-usage version 0.1.0, git hash 756e0175b34e
 
 USAGE:
     pstor-usage [FLAGS] [OPTIONS]
 
 FLAGS:
     -h, --help               Prints help information
-        --no-total-stats     Skip the output of the total storage usage after allocation of all resources and also after
-                             those resources have been deleted
         --pool-use-malloc    Use ram based pools instead of files (useful for debugging with small pool allocation).
                              When using files the /tmp/pool directory will be used
+        --no-total-stats     Skip the output of the total storage usage after allocation of all resources and also after
+                             those resources have been deleted
     -V, --version            Prints version information
 
 OPTIONS:
@@ -28,8 +28,12 @@ OPTIONS:
     -p, --pools <pools>                        Number of pools per sample [default: 10]
     -r, --rest-url <rest-url>                  The rest endpoint if reusing a cluster
         --vol-samples <vol-samples>            Number of volume samples [default: 10]
+        --volume-mods <volume-mods>            Modifies `N` volumes from each volume samples. In other words, we will
+                                               publish/unpublish each `N` volumes from each list of samples. Please note
+                                               that this can take quite some time; it's very slow to create nexuses with
+                                               remote replicas [default: 2]
         --volume-replicas <volume-replicas>    Number of volume replicas [default: 3]
-        --volume-size <volume-size>            Size of the volumes [default: 1MiB]
+        --volume-size <volume-size>            Size of the volumes [default: 5MiB]
     -v, --volumes <volumes>                    Number of volumes per sample [default: 20]
 ```
 
@@ -37,7 +41,7 @@ OPTIONS:
 
 ```textmate
 ❯ cargo run -q --bin pstor-usage
-pstor-usage version 0.1.0, git hash 4f40cf4681f7
+pstor-usage version 0.1.0, git hash 756e0175b34e
 ┌───────────────┬────────────┐
 │ Volumes ~Repl │ Disk Usage │
 ├───────────────┼────────────┤
@@ -45,19 +49,19 @@ pstor-usage version 0.1.0, git hash 4f40cf4681f7
 ├───────────────┼────────────┤
 │     40 ~3     │  172 KiB   │
 ├───────────────┼────────────┤
-│     60 ~3     │  248 KiB   │
+│     60 ~3     │  252 KiB   │
 ├───────────────┼────────────┤
 │     80 ~3     │  332 KiB   │
 ├───────────────┼────────────┤
-│    100 ~3     │  408 KiB   │
+│    100 ~3     │  412 KiB   │
 ├───────────────┼────────────┤
-│    120 ~3     │  492 KiB   │
+│    120 ~3     │  488 KiB   │
 ├───────────────┼────────────┤
-│    140 ~3     │  584 KiB   │
+│    140 ~3     │  580 KiB   │
 ├───────────────┼────────────┤
 │    160 ~3     │  664 KiB   │
 ├───────────────┼────────────┤
-│    180 ~3     │  744 KiB   │
+│    180 ~3     │  740 KiB   │
 ├───────────────┼────────────┤
 │    200 ~3     │  824 KiB   │
 └───────────────┴────────────┘
@@ -68,11 +72,11 @@ pstor-usage version 0.1.0, git hash 4f40cf4681f7
 ├───────┼────────────┤
 │  20   │   16 KiB   │
 ├───────┼────────────┤
-│  30   │   24 KiB   │
+│  30   │   28 KiB   │
 ├───────┼────────────┤
-│  40   │   32 KiB   │
+│  40   │   36 KiB   │
 ├───────┼────────────┤
-│  50   │   40 KiB   │
+│  50   │   44 KiB   │
 └───────┴────────────┘
 ┌───────────────┬───────┬────────────┐
 │ Volumes ~Repl │ Pools │ Disk Usage │
@@ -81,33 +85,56 @@ pstor-usage version 0.1.0, git hash 4f40cf4681f7
 ├───────────────┼───────┼────────────┤
 │     40 ~3     │  20   │  188 KiB   │
 ├───────────────┼───────┼────────────┤
-│     60 ~3     │  30   │  272 KiB   │
+│     60 ~3     │  30   │  280 KiB   │
 ├───────────────┼───────┼────────────┤
-│     80 ~3     │  40   │  364 KiB   │
+│     80 ~3     │  40   │  368 KiB   │
 ├───────────────┼───────┼────────────┤
-│    100 ~3     │  50   │  448 KiB   │
+│    100 ~3     │  50   │  456 KiB   │
 ├───────────────┼───────┼────────────┤
 │    120 ~3     │  50   │  532 KiB   │
 ├───────────────┼───────┼────────────┤
 │    140 ~3     │  50   │  624 KiB   │
 ├───────────────┼───────┼────────────┤
-│    160 ~3     │  50   │  704 KiB   │
+│    160 ~3     │  50   │  708 KiB   │
 ├───────────────┼───────┼────────────┤
 │    180 ~3     │  50   │  784 KiB   │
 ├───────────────┼───────┼────────────┤
-│    200 ~3     │  50   │  864 KiB   │
+│    200 ~3     │  50   │  868 KiB   │
 └───────────────┴───────┴────────────┘
-┌────────────────┬───────────────┐
-│ After Creation │ After Cleanup │
-├────────────────┼───────────────┤
-│ 864 KiB        │ 1 MiB 356 KiB │
-└────────────────┴───────────────┘
+┌──────────────────┬────────────┐
+│ Volume~Repl Mods │ Disk Usage │
+├──────────────────┼────────────┤
+│       2~3        │   20 KiB   │
+├──────────────────┼────────────┤
+│       4~3        │   44 KiB   │
+├──────────────────┼────────────┤
+│       6~3        │   68 KiB   │
+├──────────────────┼────────────┤
+│       8~3        │   96 KiB   │
+├──────────────────┼────────────┤
+│       10~3       │  120 KiB   │
+├──────────────────┼────────────┤
+│       12~3       │  144 KiB   │
+├──────────────────┼────────────┤
+│       14~3       │  168 KiB   │
+├──────────────────┼────────────┤
+│       16~3       │  192 KiB   │
+├──────────────────┼────────────┤
+│       18~3       │  216 KiB   │
+├──────────────────┼────────────┤
+│       20~3       │  240 KiB   │
+└──────────────────┴────────────┘
+┌──────────┬──────────────┬─────────┬───────────────┬───────────────┐
+│ Creation │ Modification │ Cleanup │ Total         │ Current       │
+├──────────┼──────────────┼─────────┼───────────────┼───────────────┤
+│ 868 KiB  │ 240 KiB      │ 532 KiB │ 1 MiB 616 KiB │ 1 MiB 636 KiB │
+└──────────┴──────────────┴─────────┴───────────────┴───────────────┘
 ```
 
 ***Sampling only single replica volumes:***
 
 ```textmate
-❯ cargo run -q --bin pstor-usage -- --pools 0 --volume-replicas 1 --no-total-stats
+❯ cargo run -q --bin pstor-usage -- --pools 0 --volume-replicas 1 --volume-mods 0 --no-total-stats
 ┌───────────────┬────────────┐
 │ Volumes ~Repl │ Disk Usage │
 ├───────────────┼────────────┤

--- a/utils/pstor-usage/src/etcd.rs
+++ b/utils/pstor-usage/src/etcd.rs
@@ -54,7 +54,7 @@ impl EtcdSampler {
 impl Sampler for EtcdSampler {
     async fn sample<T: ResourceMgr>(
         &self,
-        client: ApiClient,
+        client: &ApiClient,
         count: u32,
         resource_mgr: &T,
     ) -> anyhow::Result<(Vec<T::Output>, ResourceSamples)> {
@@ -69,7 +69,7 @@ impl Sampler for EtcdSampler {
         let base = self.etcd.db_size().await?;
         let mut acc = base;
         for _ in 1 ..= self.steps {
-            created.push(resource_mgr.create(client.clone(), count).await?);
+            created.push(resource_mgr.create(client, count).await?);
             let usage = self.etcd.db_size().await? - acc;
 
             count_vec.push(count as u64);

--- a/utils/pstor-usage/src/main.rs
+++ b/utils/pstor-usage/src/main.rs
@@ -71,7 +71,7 @@ async fn main() -> anyhow::Result<()> {
         None => {
             // cluster will be terminated on drop
             let cluster = testlib::ClusterBuilder::builder()
-                .with_default_tracing(false)
+                .with_silence_test_traces()
                 .with_build(false)
                 .with_build_all(false)
                 .with_mayastors(args.volume_replicas.into())

--- a/utils/pstor-usage/src/resources.rs
+++ b/utils/pstor-usage/src/resources.rs
@@ -2,20 +2,31 @@ use openapi::clients::tower::direct::ApiClient;
 
 /// Resource Manager that handles creating and deleting resources.
 #[async_trait::async_trait]
-pub(crate) trait ResourceMgr: Send + Sync {
-    type Output: ResourceDelete;
+pub(crate) trait ResourceMgr: Send + Sync + FormatSamples {
+    type Output: ResourceDelete + ResourceUpdates;
     /// Create `count` resources.
     async fn create(&self, client: &ApiClient, count: u32) -> anyhow::Result<Self::Output>;
     /// Delete the created resources.
     async fn delete(&self, client: &ApiClient, created: Self::Output) -> anyhow::Result<()>;
-    /// Prepare a sample from the given data points.
-    fn prepare_sample(&self, points: Vec<u64>) -> Box<dyn ResourceSample>;
+}
+
+/// Formats collected points into a ResourceSample.
+pub(crate) trait FormatSamples: Send + Sync {
+    /// Format a sample from the given data points.
+    fn format(&self, points: Vec<u64>) -> Box<dyn ResourceSample>;
 }
 
 /// Resources that are deletable and should be deleted.
 #[async_trait::async_trait]
 pub(crate) trait ResourceDelete: Send + Sync + Clone {
     async fn delete(&self, client: &ApiClient) -> anyhow::Result<()>;
+}
+
+/// Resource updates/modifications that can be performed by a user.
+#[async_trait::async_trait]
+pub(crate) trait ResourceUpdates: Send + Sync + FormatSamples + Default {
+    /// Update/Modify a resource `count` times
+    async fn modify(&self, client: &ApiClient, count: u32) -> anyhow::Result<()>;
 }
 
 #[async_trait::async_trait]
@@ -28,15 +39,32 @@ impl<T: ResourceDelete> ResourceDelete for Vec<T> {
     }
 }
 
+impl<T: FormatSamples + Default> FormatSamples for [T] {
+    fn format(&self, points: Vec<u64>) -> Box<dyn ResourceSample> {
+        match self.first() {
+            None => T::default().format(points),
+            Some(first) => first.format(points),
+        }
+    }
+}
+
 /// Sample `count` data points from a given `ResourceMgr`.
 #[async_trait::async_trait]
 pub(crate) trait Sampler {
+    /// Samples `count` resource allocations returning both the allocated resources and the samples.
     async fn sample<T: ResourceMgr>(
         &self,
         client: &ApiClient,
         count: u32,
         resource_mgr: &T,
     ) -> anyhow::Result<(Vec<T::Output>, ResourceSamples)>;
+    /// Samples `count` resource modifications returning the collected samples.
+    async fn sample_mods<T: ResourceUpdates>(
+        &self,
+        client: &ApiClient,
+        count: u32,
+        resources: &[T],
+    ) -> anyhow::Result<ResourceSamples>;
 }
 
 /// A sample of data points, if you will.

--- a/utils/pstor-usage/src/volumes.rs
+++ b/utils/pstor-usage/src/volumes.rs
@@ -21,7 +21,7 @@ impl VolMgr {
 #[async_trait::async_trait]
 impl ResourceMgr for VolMgr {
     type Output = Vec<models::Volume>;
-    async fn create(&self, client: ApiClient, count: u32) -> anyhow::Result<Self::Output> {
+    async fn create(&self, client: &ApiClient, count: u32) -> anyhow::Result<Self::Output> {
         let mut created_volumes = Vec::with_capacity(count as usize);
         for _ in 0 .. count {
             let volume = client
@@ -39,7 +39,7 @@ impl ResourceMgr for VolMgr {
         }
         Ok(created_volumes)
     }
-    async fn delete(&self, client: ApiClient, created: Self::Output) -> anyhow::Result<()> {
+    async fn delete(&self, client: &ApiClient, created: Self::Output) -> anyhow::Result<()> {
         created.delete(client).await
     }
 
@@ -51,7 +51,7 @@ impl ResourceMgr for VolMgr {
 
 #[async_trait::async_trait]
 impl ResourceDelete for Vec<models::Volume> {
-    async fn delete(&self, client: ApiClient) -> anyhow::Result<()> {
+    async fn delete(&self, client: &ApiClient) -> anyhow::Result<()> {
         for volume in self {
             client.volumes_api().del_volume(&volume.spec.uuid).await?;
         }

--- a/utils/pstor-usage/src/volumes.rs
+++ b/utils/pstor-usage/src/volumes.rs
@@ -1,7 +1,10 @@
-use crate::resources::{ResourceDelete, ResourceMgr, ResourceSample};
+use crate::resources::{
+    FormatSamples, ResourceDelete, ResourceMgr, ResourceSample, ResourceUpdates,
+};
 use openapi::{apis::Uuid, clients::tower::direct::ApiClient, models};
 
 /// Resource manager for volumes.
+#[derive(Default)]
 pub(crate) struct VolMgr {
     n_replicas: u8,
     size_bytes: u64,
@@ -42,8 +45,11 @@ impl ResourceMgr for VolMgr {
     async fn delete(&self, client: &ApiClient, created: Self::Output) -> anyhow::Result<()> {
         created.delete(client).await
     }
+}
 
-    fn prepare_sample(&self, points: Vec<u64>) -> Box<dyn ResourceSample> {
+#[async_trait::async_trait]
+impl FormatSamples for VolMgr {
+    fn format(&self, points: Vec<u64>) -> Box<dyn ResourceSample> {
         let replicas = self.n_replicas;
         Box::new(VolumeCount { points, replicas })
     }
@@ -56,6 +62,70 @@ impl ResourceDelete for Vec<models::Volume> {
             client.volumes_api().del_volume(&volume.spec.uuid).await?;
         }
         Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl ResourceUpdates for Vec<models::Volume> {
+    async fn modify(&self, client: &ApiClient, count: u32) -> anyhow::Result<()> {
+        let nodes = client.nodes_api().get_nodes().await?;
+        let node_ids = nodes.into_iter().map(|n| n.id).collect::<Vec<_>>();
+        let mut node_index = 0;
+
+        for (churns, volume) in self.iter().enumerate() {
+            if churns >= count as usize {
+                break;
+            }
+
+            let node_id = node_ids.get(node_index).expect("Should have nodes");
+            client
+                .volumes_api()
+                .put_volume_target(
+                    &volume.spec.uuid,
+                    node_id,
+                    models::VolumeShareProtocol::Nvmf,
+                )
+                .await?;
+            node_index = (node_index + 1) % node_ids.len();
+
+            client
+                .volumes_api()
+                .del_volume_target(&volume.spec.uuid, Some(true))
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl FormatSamples for Vec<models::Volume> {
+    fn format(&self, points: Vec<u64>) -> Box<dyn ResourceSample> {
+        let replicas = self
+            .first()
+            .map(|v| v.spec.num_replicas)
+            .unwrap_or_default();
+        Box::new(VolumeMod { points, replicas })
+    }
+}
+
+struct VolumeMod {
+    points: Vec<u64>,
+    replicas: u8,
+}
+impl ResourceSample for VolumeMod {
+    fn points(&self) -> &Vec<u64> {
+        &self.points
+    }
+    fn points_mut(&mut self) -> &mut Vec<u64> {
+        &mut self.points
+    }
+
+    fn name(&self) -> String {
+        "Volume~Repl Mods".to_string()
+    }
+
+    fn format_point(&self, point: u64) -> String {
+        format!("{}~{}", point, self.replicas)
     }
 }
 


### PR DESCRIPTION
refactor(pstor-usage): use client by reference

---------

fix(test): cluster tracing with a subscriber guard

Since the last tracing update we can no longer simply have a jaeger Tracer. We need to keep a
subscriber guard or alternatively set the subscriber as the global. We've opted to keep the guard
within the cluster since the test library is a library.

---------

feat(pstor-usage): modify volumes N number of times

In addition to create/delete now we also modify a volume - we publish/unpublish the volume as this
is equivalent to a user creating/deleting a pod that references a pvc.

NOTE: This is a slow operation as the nexus is created "very slowly" by mayastor.