### PR TITLE
chore(helm): add namespace value

### DIFF
--- a/chart/templates/core-agents-deployment.yaml
+++ b/chart/templates/core-agents-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: core-agents
-  namespace: mayastor
+  namespace: {{ .Release.Namespace }}
   labels:
     app: core-agents
 spec:

--- a/chart/templates/csi-deployment.yaml
+++ b/chart/templates/csi-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: csi-controller
-  namespace: mayastor
+  namespace: {{ .Release.Namespace }}
   labels:
     app: csi-controller
 spec:

--- a/chart/templates/jaeger-operator/jaeger.yaml
+++ b/chart/templates/jaeger-operator/jaeger.yaml
@@ -2,7 +2,7 @@ apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: jaeger
-  namespace: mayastor
+  namespace: {{ .Release.Namespace }}
 spec:
   strategy: allInOne
   ingress:

--- a/chart/templates/msp-deployment.yaml
+++ b/chart/templates/msp-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: msp-operator
-  namespace: mayastor
+  namespace: {{ .Release.Namespace }}
   labels:
     app: msp-operator
 spec:

--- a/chart/templates/operator-rbac.yaml
+++ b/chart/templates/operator-rbac.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: mayastor-service-account
-  namespace: mayastor
+  namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -70,7 +70,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: mayastor-service-account
-  namespace: mayastor
+  namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: mayastor-cluster-role

--- a/chart/templates/rest-deployment.yaml
+++ b/chart/templates/rest-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rest
-  namespace: mayastor
+  namespace: {{ .Release.Namespace }}
   labels:
     app: rest
 spec:

--- a/chart/templates/rest-service.yaml
+++ b/chart/templates/rest-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rest
-  namespace: mayastor
+  namespace: {{ .Release.Namespace }}
   labels:
     app: rest
 spec:

--- a/scripts/deploy/generate-yamls.sh
+++ b/scripts/deploy/generate-yamls.sh
@@ -21,6 +21,7 @@ tag=
 helm_string=
 helm_file=
 helm_flags=
+namespace="mayastor"
 
 help() {
   cat <<EOF
@@ -36,6 +37,7 @@ Common options:
   -f <file>        Specify values in a YAML file or a URL (can specify multiple)
   -d               Debug the helm command by specifying --debug
   -c               Run this script only if the helm template directory has changes
+  -n               Namespace of the generated YAML files
 
 Profiles:
   develop:   Used by developers of mayastor.
@@ -79,6 +81,10 @@ while [ "$#" -gt 0 ]; do
     -t)
       shift
       tag=$1
+      ;;
+    -n)
+      shift
+      namespace=$1
       ;;
     -d)
       helm_flags="$helm_flags --debug"
@@ -157,7 +163,7 @@ fi
 # update helm dependencies
 ( cd "$CHARTDIR" && helm dependency update )
 # generate the yaml
-helm template --set "$template_params" mayastor "$CHARTDIR" --output-dir="$tmpd" --namespace mayastor \
+helm template --set "$template_params" mayastor "$CHARTDIR" --output-dir="$tmpd" --namespace $namespace \
   -f "$CHARTDIR/$profile/values.yaml" -f "$CHARTDIR/constants.yaml" -f "$helm_file" \
   --set "$helm_string" $helm_flags
 


### PR DESCRIPTION
Add a namespace value which is used by the templates.

Update generate-yamls.sh to take a namespace argument. This defaults to
mayastor and is used when generating the YAML files using Helm.