### PR TITLE
fix: use dns name to reach rest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,10 +53,3 @@ repos:
         args: [ "--changes" ]
         pass_filenames: false
         language: system
-    -   id: helm-develop-deploy
-        name: Helm Generator
-        description: Ensures the deploy is updated with the develop yamls
-        entry: ./scripts/generate-deploy-yamls.sh
-        args: [ "-c", "develop" ]
-        pass_filenames: false
-        language: system

--- a/chart/templates/csi-deployment.yaml
+++ b/chart/templates/csi-deployment.yaml
@@ -57,7 +57,7 @@ spec:
           imagePullPolicy: {{ .Values.mayastorCP.pullPolicy }}
           args:
             - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"
-            - "--rest-endpoint=http://$(REST_SERVICE_HOST):8081"{{ if .Values.base.jaeger.enabled }}
+            - "--rest-endpoint=http://rest:8081"{{ if .Values.base.jaeger.enabled }}
             - "--jaeger={{ .Values.base.jaeger.agent.name }}:{{ .Values.base.jaeger.agent.port }}"{{ end }}
           env:
             - name: RUST_LOG

--- a/chart/templates/msp-deployment.yaml
+++ b/chart/templates/msp-deployment.yaml
@@ -26,7 +26,7 @@ spec:
           image: {{ .Values.mayastorCP.registry }}mayadata/mcp-msp-operator:{{ .Values.mayastorCP.tag }}
           imagePullPolicy: {{ .Values.mayastorCP.pullPolicy }}
           args:
-            - "-e http://$(REST_SERVICE_HOST):8081"
+            - "-e http://rest:8081"
             - "--interval={{ .Values.base.cache_poll_period }}"{{ if .Values.base.jaeger.enabled }}
             - "--jaeger={{ .Values.base.jaeger.agent.name }}:{{ .Values.base.jaeger.agent.port }}"{{ end }}
           env:

--- a/deploy/core-agents-deployment.yaml
+++ b/deploy/core-agents-deployment.yaml
@@ -23,13 +23,15 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep
+            1; done;
           image: busybox:latest
           name: nats-probe
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
+            sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:

--- a/deploy/csi-deployment.yaml
+++ b/deploy/csi-deployment.yaml
@@ -26,7 +26,8 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz rest 8081; do echo "Waiting for REST API endpoint to become available"; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz rest 8081; do echo "Waiting for REST API endpoint
+            to become available"; sleep 1; done;
           image: busybox:latest
           name: rest-probe
       containers:
@@ -69,7 +70,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock"
-            - "--rest-endpoint=http://$(REST_SERVICE_HOST):8081"
+            - "--rest-endpoint=http://rest:8081"
           env:
             - name: RUST_LOG
               value: info

--- a/deploy/jaeger-operator/deployment.yaml
+++ b/deploy/jaeger-operator/deployment.yaml
@@ -45,14 +45,3 @@ spec:
               value: "mayastor-jaeger-operator"
           resources:
             {}
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: In
-                values:
-                - ""
-      tolerations:
-        - key: node-role.kubernetes.io/master

--- a/deploy/jaeger-operator/jaeger.yaml
+++ b/deploy/jaeger-operator/jaeger.yaml
@@ -9,17 +9,6 @@ spec:
   strategy: allInOne
   ingress:
     enabled: false
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: node-role.kubernetes.io/master
-            operator: In
-            values:
-            - ""
-  tolerations:
-    - key: node-role.kubernetes.io/master
   query:
     serviceType: NodePort
     nodePort: 30012

--- a/deploy/msp-deployment.yaml
+++ b/deploy/msp-deployment.yaml
@@ -24,13 +24,15 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep
+            1; done;
           image: busybox:latest
           name: nats-probe
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
+            sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:
@@ -45,7 +47,7 @@ spec:
           image: mayadata/mcp-msp-operator:v1.0.0
           imagePullPolicy: IfNotPresent
           args:
-            - "-e http://$(REST_SERVICE_HOST):8081"
+            - "-e http://rest:8081"
             - "--interval=30s"
           env:
             - name: RUST_LOG

--- a/deploy/rest-deployment.yaml
+++ b/deploy/rest-deployment.yaml
@@ -23,13 +23,15 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz nats 4222; do echo "Waiting for nats..."; sleep
+            1; done;
           image: busybox:latest
           name: nats-probe
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
+            sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:

--- a/deploy/terraform/mod/csi-controller/main.tf
+++ b/deploy/terraform/mod/csi-controller/main.tf
@@ -87,7 +87,7 @@ resource "kubernetes_deployment" "deployment_csi_controller" {
 
           args = concat([
             "--csi-socket=/var/lib/csi/sockets/pluginproxy/csi.sock",
-            "--rest-endpoint=http://$(REST_SERVICE_HOST):8081",
+            "--rest-endpoint=http://rest:8081",
           ], var.jaeger_agent_argument)
           env {
             name  = "RUST_LOG"

--- a/deploy/terraform/mod/k8s-operator/main.tf
+++ b/deploy/terraform/mod/k8s-operator/main.tf
@@ -33,7 +33,7 @@ resource "kubernetes_deployment" "deployment_msp_operator" {
         service_account_name = "mayastor-service-account"
         container {
           args = concat([
-            "-e http://$(REST_SERVICE_HOST):8081",
+            "-e http://rest:8081",
             "--interval=${var.cache_period}"
             ],
             var.jaeger_agent_argument


### PR DESCRIPTION
chore: remove helm generation from precommit

--------------

fix: use dns name to reach rest

Using the host name creates a race as rest's node port must start ahead of its consumers.
Instead, simply use the dns name, which will be updated whenever rest is ready.
Resolves: openebs/mayastor#1076
Resolves: CAS-1288