### PR TITLE
fix: don't disown replicas from faulted volumes and recreate faulted nexuses

### DIFF
--- a/common/src/store/etcd_keep_alive.rs
+++ b/common/src/store/etcd_keep_alive.rs
@@ -507,7 +507,7 @@ impl LeaseLockKeeperClocking<Locked> for EtcdSingletonLock {
 
 #[async_trait::async_trait]
 impl LeaseLockKeeperClocking<KeepAlive> for EtcdSingletonLock {
-    #[tracing::instrument(skip(self, state), err)]
+    #[tracing::instrument(level = "trace", skip(self, state), err)]
     async fn clock(&mut self, mut state: KeepAlive) -> LockStatesResult {
         state
             .keeper

--- a/common/src/types/v0/message_bus/replica.rs
+++ b/common/src/types/v0/message_bus/replica.rs
@@ -158,6 +158,7 @@ pub struct CreateReplica {
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 pub struct ReplicaOwners {
     volume: Option<VolumeId>,
+    #[serde(skip)]
     nexuses: Vec<NexusId>,
 }
 impl ReplicaOwners {

--- a/common/src/types/v0/store/nexus_persistence.rs
+++ b/common/src/types/v0/store/nexus_persistence.rs
@@ -26,6 +26,10 @@ impl NexusInfo {
             None => false,
         }
     }
+    /// Check if no replica is healthy
+    pub fn no_healthy_replicas(&self) -> bool {
+        self.children.iter().all(|c| !c.healthy) || self.children.is_empty()
+    }
 }
 
 /// Definition of the child information that gets saved in the persistent

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -186,6 +186,8 @@ pub enum SvcError {
     ReplicaCreateNumber { id: String },
     #[snafu(display("No online replicas are available for Volume '{}'", id))]
     NoOnlineReplicas { id: String },
+    #[snafu(display("No healthy replicas are available for Volume '{}'", id))]
+    NoHealthyReplicas { id: String },
     #[snafu(display("Entry with key '{}' not found in the persistent store.", key))]
     StoreMissingEntry { key: String },
     #[snafu(display("The uuid '{}' for kind '{}' is not valid.", uuid, kind.to_string()))]
@@ -509,6 +511,12 @@ impl From<SvcError> for ReplyError {
                 extra: error.full_string(),
             },
             SvcError::NoOnlineReplicas { .. } => ReplyError {
+                kind: ReplyErrorKind::VolumeNoReplicas,
+                resource: ResourceKind::Volume,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+            SvcError::NoHealthyReplicas { .. } => ReplyError {
                 kind: ReplyErrorKind::VolumeNoReplicas,
                 resource: ResourceKind::Volume,
                 source: desc.to_string(),

--- a/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/mod.rs
@@ -25,8 +25,10 @@ use common_lib::{
 };
 use garbage_collector::GarbageCollector;
 
+use common_lib::types::v0::message_bus::NexusStatus;
 use parking_lot::Mutex;
 use std::{convert::TryFrom, sync::Arc};
+use tracing::Instrument;
 
 /// Nexus Reconciler loop
 #[derive(Debug)]
@@ -98,7 +100,7 @@ async fn nexus_reconciler(
 
 /// Find and removes faulted children from the given nexus
 /// If the child is a replica it also disowns and destroys it
-#[tracing::instrument(skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid))]
+#[tracing::instrument(skip(nexus_spec, context, mode), level = "trace", fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
 pub(super) async fn faulted_children_remover(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
@@ -107,25 +109,37 @@ pub(super) async fn faulted_children_remover(
     let nexus_spec_clone = nexus_spec.lock().clone();
     let nexus_uuid = nexus_spec_clone.uuid.clone();
     let nexus_state = context.registry().get_nexus(&nexus_uuid).await?;
-    for child in nexus_state.children.iter().filter(|c| c.state.faulted()) {
-        nexus_spec_clone
-            .warn_span(|| tracing::warn!("Attempting to remove faulted child '{}'", child.uri));
-        if let Err(error) = context
-            .specs()
-            .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, true, mode)
-            .await
-        {
-            nexus_spec_clone.error(&format!(
-                "Failed to remove faulted child '{}', error: '{}'",
-                child.uri,
-                error.full_string(),
-            ));
-        } else {
-            nexus_spec_clone.info(&format!(
-                "Successfully removed faulted child '{}'",
-                child.uri,
-            ));
+    let child_count = nexus_state.children.len();
+
+    if child_count > 1 {
+        async {
+            for child in nexus_state.children.iter().filter(|c| c.state.faulted()) {
+                nexus_spec_clone
+                    .warn_span(|| tracing::warn!("Attempting to remove faulted child '{}'", child.uri));
+                if let Err(error) = context
+                    .specs()
+                    .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, true, mode)
+                    .await
+                {
+                    nexus_spec_clone.error_span(|| {
+                        tracing::error!(
+                        error = %error.full_string().as_str(),
+                        child.uri = %child.uri.as_str(),
+                        "Failed to remove faulted child"
+                    )
+                    });
+                } else {
+                    nexus_spec_clone.info_span(|| {
+                        tracing::info!(
+                        child.uri = %child.uri.as_str(),
+                        "Successfully removed faulted child",
+                    )
+                    });
+                }
+            }
         }
+        .instrument(tracing::info_span!("faulted_children_remover", nexus.uuid = %nexus_uuid, request.reconcile = true))
+        .await
     }
 
     PollResult::Ok(PollerState::Idle)
@@ -133,7 +147,7 @@ pub(super) async fn faulted_children_remover(
 
 /// Find and removes unknown children from the given nexus
 /// If the child is a replica it also disowns and destroys it
-#[tracing::instrument(skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid))]
+#[tracing::instrument(skip(nexus_spec, context, mode), level = "trace", fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
 pub(super) async fn unknown_children_remover(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
@@ -145,25 +159,42 @@ pub(super) async fn unknown_children_remover(
     let state_children = nexus_state.children.iter();
     let spec_children = nexus_spec.lock().children.clone();
 
-    for child in state_children.filter(|c| !spec_children.iter().any(|spec| spec.uri() == c.uri)) {
-        nexus_spec_clone
-            .warn_span(|| tracing::warn!("Attempting to remove unknown child '{}'", child.uri));
-        if let Err(error) = context
-            .specs()
-            .remove_nexus_child_by_uri(context.registry(), &nexus_state, &child.uri, false, mode)
-            .await
-        {
-            nexus_spec_clone.error(&format!(
-                "Failed to remove unknown child '{}', error: '{}'",
-                child.uri,
-                error.full_string(),
-            ));
-        } else {
-            nexus_spec_clone.info(&format!(
-                "Successfully removed unknown child '{}'",
-                child.uri,
-            ));
+    let unknown_children = state_children
+        .filter(|c| !spec_children.iter().any(|spec| spec.uri() == c.uri))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    if !unknown_children.is_empty() {
+        async move {
+            for child in unknown_children {
+                nexus_spec_clone
+                    .warn_span(|| tracing::warn!("Attempting to remove unknown child '{}'", child.uri));
+                if let Err(error) = context
+                    .specs()
+                    .remove_nexus_child_by_uri(
+                        context.registry(),
+                        &nexus_state,
+                        &child.uri,
+                        false,
+                        mode,
+                    )
+                    .await
+                {
+                    nexus_spec_clone.error(&format!(
+                        "Failed to remove unknown child '{}', error: '{}'",
+                        child.uri,
+                        error.full_string(),
+                    ));
+                } else {
+                    nexus_spec_clone.info(&format!(
+                        "Successfully removed unknown child '{}'",
+                        child.uri,
+                    ));
+                }
+            }
         }
+        .instrument(tracing::info_span!("unknown_children_remover", nexus.uuid = %nexus_uuid, request.reconcile = true))
+        .await
     }
 
     PollResult::Ok(PollerState::Idle)
@@ -172,7 +203,7 @@ pub(super) async fn unknown_children_remover(
 /// Find missing children from the given nexus
 /// They are removed from the spec as we don't know why they got removed, so it's safer
 /// to just disown and destroy them.
-#[tracing::instrument(skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid))]
+#[tracing::instrument(skip(nexus_spec, context, mode), level = "trace", fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
 pub(super) async fn missing_children_remover(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
@@ -220,94 +251,113 @@ pub(super) async fn missing_children_remover(
 
 /// Recreate the given nexus on its associated node
 /// Only healthy and online replicas are reused in the nexus recreate request
-#[tracing::instrument(skip(nexus_spec, context), fields(nexus.uuid = %nexus_spec.lock().uuid))]
 pub(super) async fn missing_nexus_recreate(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
     mode: OperationMode,
 ) -> PollResult {
-    let mut nexus = nexus_spec.lock().clone();
+    let nexus = nexus_spec.lock().clone();
     let nexus_uuid = nexus.uuid.clone();
 
     if context.registry().get_nexus(&nexus_uuid).await.is_ok() {
         return PollResult::Ok(PollerState::Idle);
     }
 
-    let warn_missing = |nexus_spec: &NexusSpec, node_status: NodeStatus| {
-        nexus_spec.debug_span(|| {
-            tracing::debug!(
-                node.uuid = %nexus_spec.node,
-                node.status = %node_status.to_string(),
-                "Attempted to recreate missing nexus, but the node is not online"
-            )
-        });
-    };
+    #[tracing::instrument(skip(nexus, context, mode), fields(nexus.uuid = %nexus.uuid, request.reconcile = true))]
+    async fn missing_nexus_recreate(
+        mut nexus: NexusSpec,
+        context: &PollContext,
+        mode: OperationMode,
+    ) -> PollResult {
+        let warn_missing = |nexus_spec: &NexusSpec, node_status: NodeStatus| {
+            nexus_spec.debug_span(|| {
+                tracing::debug!(
+                    node.uuid = %nexus_spec.node,
+                    node.status = %node_status.to_string(),
+                    "Attempted to recreate missing nexus, but the node is not online"
+                )
+            });
+        };
 
-    let node = match context.registry().get_node_wrapper(&nexus.node).await {
-        Ok(node) if !node.read().await.is_online() => {
-            let node_status = node.read().await.status();
-            warn_missing(&nexus, node_status);
+        let node = match context.registry().get_node_wrapper(&nexus.node).await {
+            Ok(node) if !node.read().await.is_online() => {
+                let node_status = node.read().await.status();
+                warn_missing(&nexus, node_status);
+                return PollResult::Ok(PollerState::Idle);
+            }
+            Err(_) => {
+                warn_missing(&nexus, NodeStatus::Unknown);
+                return PollResult::Ok(PollerState::Idle);
+            }
+            Ok(node) => node,
+        };
+
+        nexus.warn_span(|| tracing::warn!("Attempting to recreate missing nexus"));
+
+        let children = get_healthy_nexus_children(&nexus, context.registry()).await?;
+
+        let mut nexus_replicas = vec![];
+        for item in children.candidates() {
+            // just in case the replica gets somehow shared/unshared?
+            match context
+                .specs()
+                .make_replica_accessible(context.registry(), item.state(), &nexus.node, mode)
+                .await
+            {
+                Ok(uri) => {
+                    nexus_replicas.push(NexusChild::Replica(ReplicaUri::new(
+                        &item.spec().uuid,
+                        &uri,
+                    )));
+                }
+                Err(error) => {
+                    nexus.error_span(|| {
+                        tracing::error!(nexus.node=%nexus.node, replica.uuid = %item.spec().uuid, error=%error, "Failed to make the replica available on the nexus node");
+                    });
+                }
+            }
+        }
+
+        nexus.children = match children {
+            HealthyChildItems::One(_, _) => nexus_replicas.first().into_iter().cloned().collect(),
+            HealthyChildItems::All(_, _) => nexus_replicas,
+        };
+
+        if nexus.children.is_empty() {
+            if let Some(info) = children.nexus_info() {
+                if info.no_healthy_replicas() {
+                    nexus.error_span(|| {
+                        tracing::error!("No healthy replicas found - manual intervention required")
+                    });
+                    return PollResult::Ok(PollerState::Idle);
+                }
+            }
+
+            nexus.warn_span(|| {
+                tracing::warn!("No nexus children are available. Will retry later...")
+            });
             return PollResult::Ok(PollerState::Idle);
         }
-        Err(_) => {
-            warn_missing(&nexus, NodeStatus::Unknown);
-            return PollResult::Ok(PollerState::Idle);
-        }
-        Ok(node) => node,
-    };
 
-    nexus.warn_span(|| tracing::warn!("Attempting to recreate missing nexus"));
-
-    let children = get_healthy_nexus_children(&nexus, context.registry()).await?;
-
-    let mut nexus_replicas = vec![];
-    for item in children.candidates() {
-        // just in case the replica gets somehow shared/unshared?
-        match context
-            .specs()
-            .make_replica_accessible(context.registry(), item.state(), &nexus.node, mode)
-            .await
-        {
-            Ok(uri) => {
-                nexus_replicas.push(NexusChild::Replica(ReplicaUri::new(
-                    &item.spec().uuid,
-                    &uri,
-                )));
+        match node.create_nexus(&CreateNexus::from(&nexus)).await {
+            Ok(_) => {
+                nexus.info_span(|| tracing::info!("Nexus successfully recreated"));
+                PollResult::Ok(PollerState::Idle)
             }
             Err(error) => {
-                nexus.error_span(|| {
-                    tracing::error!(nexus.node=%nexus.node, replica.uuid = %item.spec().uuid, error=%error, "Failed to make the replica available on the nexus node");
-                });
+                nexus.error_span(|| tracing::error!(error=%error, "Failed to recreate the nexus"));
+                Err(error)
             }
         }
     }
 
-    nexus.children = match children {
-        HealthyChildItems::One(_) => nexus_replicas.first().into_iter().cloned().collect(),
-        HealthyChildItems::All(_) => nexus_replicas,
-    };
-
-    if nexus.children.is_empty() {
-        nexus.warn_span(|| tracing::warn!("No nexus children are available. Will retry later..."));
-        return PollResult::Ok(PollerState::Idle);
-    }
-
-    match node.create_nexus(&CreateNexus::from(&nexus)).await {
-        Ok(_) => {
-            nexus.info_span(|| tracing::info!("Nexus successfully recreated"));
-            PollResult::Ok(PollerState::Idle)
-        }
-        Err(error) => {
-            nexus.error_span(|| tracing::error!(error=%error, "Failed to recreate the nexus"));
-            Err(error)
-        }
-    }
+    missing_nexus_recreate(nexus, context, mode).await
 }
 
 /// Fixup the nexus share protocol if it does not match what the specs says
 /// If the nexus is shared but the protocol is not the same as the spec, then we must first
 /// unshare the nexus, and then share it via the correct protocol
-#[tracing::instrument(skip(nexus_spec, context), fields(nexus.uuid = %nexus_spec.lock().uuid))]
+#[tracing::instrument(skip(nexus_spec, context), level = "debug", fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
 pub(super) async fn fixup_nexus_protocol(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,

--- a/control-plane/agents/core/src/core/reconciler/volume/nexus.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/nexus.rs
@@ -9,6 +9,7 @@ use crate::core::{
 
 use common_lib::types::v0::store::{volume::VolumeSpec, OperationMode};
 
+use common_lib::types::v0::message_bus::VolumeStatus;
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -36,7 +37,7 @@ impl TaskPoller for VolumeNexusReconciler {
     }
 }
 
-#[tracing::instrument(level = "debug", skip(context, volume_spec), fields(volume.uuid = %volume_spec.lock().uuid, request.reconcile = true))]
+#[tracing::instrument(level = "trace", skip(context, volume_spec), fields(volume.uuid = %volume_spec.lock().uuid, request.reconcile = true))]
 async fn volume_nexus_reconcile(
     volume_spec: &Arc<Mutex<VolumeSpec>>,
     context: &PollContext,

--- a/control-plane/agents/core/src/core/scheduling/resources/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/resources/mod.rs
@@ -4,7 +4,11 @@ use crate::core::{
 };
 use common_lib::types::v0::{
     message_bus::{Child, ChildUri, Replica},
-    store::{nexus_child::NexusChild, nexus_persistence::ChildInfo, replica::ReplicaSpec},
+    store::{
+        nexus_child::NexusChild,
+        nexus_persistence::{ChildInfo, NexusInfo},
+        replica::ReplicaSpec,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -119,23 +123,30 @@ pub(crate) struct ChildItem {
 #[derive(Debug, Clone)]
 pub(crate) enum HealthyChildItems {
     /// One with multiple healthy candidates
-    One(Vec<ChildItem>),
+    One(Option<NexusInfo>, Vec<ChildItem>),
     /// All the healthy replicas can be used
-    All(Vec<ChildItem>),
+    All(Option<NexusInfo>, Vec<ChildItem>),
 }
 impl HealthyChildItems {
     /// Check if there are no healthy children
     pub(crate) fn is_empty(&self) -> bool {
         match self {
-            HealthyChildItems::One(items) => items.is_empty(),
-            HealthyChildItems::All(items) => items.is_empty(),
+            HealthyChildItems::One(_, items) => items.is_empty(),
+            HealthyChildItems::All(_, items) => items.is_empty(),
         }
     }
     /// Get a reference to the list of candidates
     pub(crate) fn candidates(&self) -> &Vec<ChildItem> {
         match self {
-            HealthyChildItems::One(items) => items,
-            HealthyChildItems::All(items) => items,
+            HealthyChildItems::One(_, items) => items,
+            HealthyChildItems::All(_, items) => items,
+        }
+    }
+    /// Get a reference to the list of candidates
+    pub(crate) fn nexus_info(&self) -> &Option<NexusInfo> {
+        match self {
+            HealthyChildItems::One(info, _) => info,
+            HealthyChildItems::All(info, _) => info,
         }
     }
 }

--- a/control-plane/agents/core/src/core/specs.rs
+++ b/control-plane/agents/core/src/core/specs.rs
@@ -667,6 +667,17 @@ impl ResourceSpecsLocked {
                 );
             }
         }
+
+        // patch up the missing replica nexus owners
+        let nexuses = self.get_nexuses();
+        for replica in self.get_replicas() {
+            let replica_uuid = replica.lock().uuid.clone();
+
+            nexuses
+                .iter()
+                .filter(|n| n.lock().contains_replica(&replica_uuid))
+                .for_each(|n| replica.lock().owners.add_owner(&n.lock().uuid));
+        }
     }
 
     /// Deserialise a vector of serde_json values into specific spec types.

--- a/control-plane/agents/core/src/nexus/scheduling.rs
+++ b/control-plane/agents/core/src/nexus/scheduling.rs
@@ -15,15 +15,14 @@ async fn get_healthy_children(
     registry: &Registry,
 ) -> Result<HealthyChildItems, SvcError> {
     let builder = nexus::CreateVolumeNexus::builder_with_defaults(request, registry).await?;
-
-    if let Some(info) = &builder.context().nexus_info() {
-        if !info.clean_shutdown {
-            let items = builder.collect();
-            return Ok(HealthyChildItems::One(items));
+    let info = builder.context().nexus_info().clone();
+    if let Some(info_inner) = &builder.context().nexus_info() {
+        if !info_inner.clean_shutdown {
+            return Ok(HealthyChildItems::One(info, builder.collect()));
         }
     }
     let items = builder.collect();
-    Ok(HealthyChildItems::All(items))
+    Ok(HealthyChildItems::All(info, items))
 }
 
 /// Get all usable healthy child replicas for nexus recreation

--- a/control-plane/agents/core/src/volume/scheduling.rs
+++ b/control-plane/agents/core/src/volume/scheduling.rs
@@ -61,13 +61,12 @@ pub(crate) async fn get_healthy_volume_replicas(
     registry: &Registry,
 ) -> Result<HealthyChildItems, SvcError> {
     let builder = nexus::CreateVolumeNexus::builder_with_defaults(request, registry).await?;
-
-    if let Some(info) = &builder.context().nexus_info() {
-        if !info.clean_shutdown {
-            let items = builder.collect();
-            return Ok(HealthyChildItems::One(items));
+    let info = builder.context().nexus_info().clone();
+    if let Some(info_inner) = &builder.context().nexus_info() {
+        if !info_inner.clean_shutdown {
+            return Ok(HealthyChildItems::One(info, builder.collect()));
         }
     }
     let items = builder.collect();
-    Ok(HealthyChildItems::All(items))
+    Ok(HealthyChildItems::All(info, items))
 }

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -927,8 +927,8 @@ impl ResourceSpecsLocked {
     ) -> Result<Nexus, SvcError> {
         let children = get_healthy_volume_replicas(vol_spec, target_node, registry).await?;
         let (count, items) = match children {
-            HealthyChildItems::One(candidates) => (1, candidates),
-            HealthyChildItems::All(candidates) => (candidates.len(), candidates),
+            HealthyChildItems::One(_, candidates) => (1, candidates),
+            HealthyChildItems::All(_, candidates) => (candidates.len(), candidates),
         };
 
         let mut nexus_replicas = vec![];

--- a/control-plane/agents/core/src/volume/tests.rs
+++ b/control-plane/agents/core/src/volume/tests.rs
@@ -113,13 +113,14 @@ async fn volume_nexus_reconcile() {
 
 #[tokio::test]
 async fn garbage_collection() {
+    let reconcile_period = Duration::from_millis(500);
     let cluster = ClusterBuilder::builder()
         .with_rest(true)
         .with_agents(vec!["core"])
         .with_mayastors(3)
         .with_tmpfs_pool(POOL_SIZE_BYTES)
         .with_cache_period("1s")
-        .with_reconcile_period(Duration::from_millis(500), Duration::from_millis(500))
+        .with_reconcile_period(reconcile_period, reconcile_period)
         .build()
         .await
         .unwrap();
@@ -128,6 +129,89 @@ async fn garbage_collection() {
 
     unused_nexus_reconcile(&cluster).await;
     unused_reconcile(&cluster).await;
+    offline_replicas_reconcile(&cluster, reconcile_period).await;
+}
+
+async fn offline_replicas_reconcile(cluster: &Cluster, reconcile_period: Duration) {
+    let rest_api = cluster.rest_v00();
+    let volumes_api = rest_api.volumes_api();
+
+    let volume = volumes_api
+        .put_volume(
+            &"1e3cf927-80c2-47a8-adf0-95c481bdd7b7".parse().unwrap(),
+            models::CreateVolumeBody::new(models::VolumePolicy::default(), 2, 5242880u64),
+        )
+        .await
+        .unwrap();
+
+    let nodes = rest_api.nodes_api().get_nodes().await.unwrap();
+    let replica_nodes = rest_api.replicas_api().get_replicas().await.unwrap();
+    let replica_nodes = replica_nodes
+        .into_iter()
+        .map(|r| r.node)
+        .collect::<Vec<_>>();
+    let free_node = nodes
+        .into_iter()
+        .find_map(|n| {
+            if replica_nodes.iter().all(|repl_node| repl_node != &n.id) {
+                Some(n.id)
+            } else {
+                None
+            }
+        })
+        .unwrap();
+
+    // 1. publish on the node with no replicas
+    let volume = volumes_api
+        .put_volume_target(
+            &volume.spec.uuid,
+            &free_node,
+            models::VolumeShareProtocol::Nvmf,
+        )
+        .await
+        .unwrap();
+
+    tracing::info!("Volume: {:?}", volume);
+    let volume_state = volume.state;
+
+    let volume_id = volume_state.uuid;
+    let volume = volumes_api.get_volume(&volume_id).await.unwrap();
+    assert_eq!(volume.state.status, models::VolumeStatus::Online);
+
+    // 2. kill all replica nodes
+    for node in replica_nodes.iter().filter(|n| n != &&free_node) {
+        cluster.composer().stop(node).await.unwrap();
+    }
+
+    // 3. wait for volume to become Faulted
+    wait_till_volume_status(cluster, &volume.spec.uuid, models::VolumeStatus::Faulted).await;
+
+    // 4. restart the core-agent
+    cluster.restart_core().await;
+
+    Liveness::default()
+        .request_on(ChannelVs::Volume)
+        .await
+        .expect("Should have restarted by now");
+    wait_till_volume_status(cluster, &volume.spec.uuid, models::VolumeStatus::Faulted).await;
+
+    // 5. After the reconcilers run, replicas should not have been disowned
+    tokio::time::sleep(reconcile_period * 3).await;
+
+    let volume = volumes_api.get_volume(&volume.spec.uuid).await.unwrap();
+    assert_eq!(volume.state.status, models::VolumeStatus::Faulted);
+
+    let replicas = rest_api.specs_api().get_specs().await.unwrap().replicas;
+    assert_eq!(replicas.len(), 2);
+    assert_eq!(
+        replicas
+            .iter()
+            .filter(|r| r.owners.volume.as_ref() == Some(&volume.spec.uuid))
+            .count(),
+        2
+    );
+
+    volumes_api.del_volume(&volume_id).await.unwrap();
 }
 
 async fn unused_nexus_reconcile(cluster: &Cluster) {

--- a/tests/bdd/common/apiclient.py
+++ b/tests/bdd/common/apiclient.py
@@ -3,6 +3,7 @@ from openapi.api.pools_api import PoolsApi
 from openapi.api.specs_api import SpecsApi
 from openapi.api.replicas_api import ReplicasApi
 from openapi.api.nodes_api import NodesApi
+from openapi.api.nexuses_api import NexusesApi
 from openapi import api_client
 from openapi import configuration
 
@@ -48,3 +49,8 @@ class ApiClient(object):
     @staticmethod
     def replicas_api():
         return ReplicasApi(get_api_client())
+
+    # Return a NexusesApi object which can be used for performing nexus related REST calls.
+    @staticmethod
+    def nexuses_api():
+        return NexusesApi(get_api_client())

--- a/tests/bdd/features/volume/nexus.feature
+++ b/tests/bdd/features/volume/nexus.feature
@@ -1,0 +1,12 @@
+Feature: Managing a Volume Nexus Target
+
+  Background:
+    Given a control plane, two Mayastor instances, two pools
+
+  Scenario: the target nexus is faulted
+    Given a published self-healing volume
+    When its nexus target is faulted
+    And one or more of its healthy replicas are back online
+    Then the nexus target shall be removed from its associated node
+    And it shall be recreated
+

--- a/tests/bdd/setup.sh
+++ b/tests/bdd/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DIR_NAME="$(dirname "$(pwd)/${BASH_SOURCE[0]}")"
+DIR_NAME="$(dirname "$0")"
 
 virtualenv --no-setuptools "$DIR_NAME"/venv
 

--- a/tests/bdd/test_volume_nexus.py
+++ b/tests/bdd/test_volume_nexus.py
@@ -1,0 +1,167 @@
+"""Managing a Volume Nexus Target feature tests."""
+import os
+
+from pytest_bdd import given, scenario, then, when
+import pytest
+from retrying import retry
+
+from common.deployer import Deployer
+from common.apiclient import ApiClient
+from common.docker import Docker
+
+from openapi.model.create_pool_body import CreatePoolBody
+from openapi.model.create_volume_body import CreateVolumeBody
+from openapi.model.protocol import Protocol
+from openapi.model.volume_policy import VolumePolicy
+from openapi.model.nexus_state import NexusState
+from openapi.model.topology import Topology
+from openapi.model.pool_topology import PoolTopology
+from openapi.model.labelled_topology import LabelledTopology
+
+
+@scenario("features/volume/nexus.feature", "the target nexus is faulted")
+def test_the_target_nexus_is_faulted():
+    """the target nexus is faulted."""
+
+
+@given("a control plane, two Mayastor instances, two pools")
+def a_control_plane_two_mayastor_instances_two_pools(init):
+    """a control plane, two Mayastor instances, two pools."""
+
+
+@given("a published self-healing volume")
+def a_published_selfhealing_volume():
+    """a published self-healing volume."""
+    request = CreateVolumeBody(
+        VolumePolicy(True),
+        NUM_VOLUME_REPLICAS,
+        VOLUME_SIZE,
+        topology=Topology(
+            pool_topology=PoolTopology(
+                labelled=LabelledTopology(exclusion={}, inclusion={"node": MAYASTOR_2})
+            )
+        ),
+    )
+    ApiClient.volumes_api().put_volume(VOLUME_UUID, request)
+    ApiClient.volumes_api().put_volume_target(VOLUME_UUID, MAYASTOR_1, Protocol("nvmf"))
+
+
+@when("its nexus target is faulted")
+def its_nexus_target_is_faulted():
+    """its nexus target is faulted."""
+    # Kill remote mayastor instance, which should fault the volume nexus child
+    Docker.kill_container(MAYASTOR_2)
+    check_target_faulted()
+
+
+@when("one or more of its healthy replicas are back online")
+def one_or_more_of_its_healthy_replicas_are_back_online():
+    """one or more of its healthy replicas are back online."""
+    # Brings back the mayastor instance, which should expose the replicas upon pool import
+    Docker.restart_container(MAYASTOR_2)
+    check_replicas_online()
+
+
+@then("it shall be recreated")
+def it_shall_be_recreated():
+    """it shall be recreated."""
+    check_nexus_online()
+
+
+@then("the nexus target shall be removed from its associated node")
+def the_nexus_target_shall_be_removed_from_its_associated_node():
+    """the nexus shall be removed from its associated node."""
+    check_nexus_removed()
+
+
+""" ... """
+
+VOLUME_UUID = "5cd5378e-3f05-47f1-a830-a0f5873a1449"
+VOLUME_SIZE = 10485761
+NUM_VOLUME_REPLICAS = 1
+
+MAYASTOR_1 = "mayastor-1"
+MAYASTOR_2 = "mayastor-2"
+
+POOL_DISK1 = "cdisk1.img"
+POOL1_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
+POOL_DISK2 = "cdisk2.img"
+POOL2_UUID = "4cc6ee64-7232-497d-a26f-38284a444990"
+
+
+@pytest.fixture(scope="function")
+def create_pool_disk_images():
+    # When starting Mayastor instances with the deployer a bind mount is created from /tmp to
+    # /host/tmp, so create disk images in /tmp
+    for disk in [POOL_DISK1, POOL_DISK2]:
+        path = f"/tmp/{disk}"
+        with open(path, "w") as file:
+            file.truncate(20 * 1024 * 1024)
+
+    yield
+    for disk in [POOL_DISK1, POOL_DISK2]:
+        path = f"/tmp/{disk}"
+        if os.path.exists(path):
+            os.remove(path)
+
+
+@pytest.fixture(scope="function")
+def init(create_pool_disk_images):
+    # Shorten the reconcile periods and cache period to speed up the tests.
+    Deployer.start_with_args(
+        [
+            "-j",
+            "-m=2",
+            "-w=10s",
+            "--reconcile-idle-period=500ms",
+            "--reconcile-period=500ms",
+            "--cache-period=1s",
+        ]
+    )
+
+    # Create pools
+    ApiClient.pools_api().put_node_pool(
+        MAYASTOR_2,
+        POOL2_UUID,
+        CreatePoolBody([f"aio:///host/tmp/{POOL_DISK2}"], labels={"node": MAYASTOR_2}),
+    )
+
+    yield
+    Deployer.stop()
+
+
+@retry(wait_fixed=200, stop_max_delay=5000)
+def check_target_faulted():
+    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    assert NexusState(volume.state.target["state"]) == NexusState("Faulted")
+
+
+@retry(wait_fixed=200, stop_max_attempt_number=30)
+def check_nexus_online():
+    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    nexus_uuid = volume.state.target["uuid"]
+    nexus = ApiClient.nexuses_api().get_nexus(nexus_uuid)
+    assert nexus.state == NexusState("Online")
+
+
+@retry(wait_fixed=200, stop_max_delay=5000)
+def check_nexus_removed():
+    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    assert (
+        not hasattr(volume.state, "target")
+        # or it might have been recreated if we lost the "race"...
+        or NexusState(volume.state.target["state"]) == NexusState("Online")
+        or NexusState(volume.state.target["state"]) == NexusState("Degraded")
+    )
+
+
+@retry(wait_fixed=200, stop_max_delay=5000)
+def check_replicas_online():
+    volume = ApiClient.volumes_api().get_volume(VOLUME_UUID)
+    online_replicas = list(
+        filter(
+            lambda uuid: str(volume.state.replica_topology[uuid].state) == "Online",
+            list(volume.state.replica_topology),
+        )
+    )
+    assert len(online_replicas) > 0


### PR DESCRIPTION
fix: don't disown replicas from faulted volumes

Don't attempt to disown replicas if the replica volume is faulted.
Don't disown replicas if the volume target (nexus) contains the replica.
Update the replica owners on core-agent startup - we might get drop the replica nexus owners at
some point since we have obtain then from the nexus specs.

Resolves: CAS-1295

-------------

chore: don't trace reconciliation unless TRACE is set or there is work to do

For clusters with high number of volumes there are a lot of traces being sent that sometimes
seem to overwhelm the telemetry exporter.
During reconciliation we should not create spans needlessly unless we're on TRACE level or unless
the reconciler actually did work.
TODO: We need a generic strategy to cater for this

-------------

fix(nexus): recreate faulted nexuses when appropriate

When the healthy replicas of a faulted nexus are Online we should attempt to recreate said nexuses.
This is done by first destroying the faulted nexus. The missing nexus reconciler will then recreate
the nexus.

When no healthy children are available, the faulted nexus are left behind until such time the node
crashes or the volume is unpublished.

Resolves: CAS-1296