### PR TITLE
fix(deployer): deploying mayastor binary is fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "composer"
 version = "0.1.0"
-source = "git+https://github.com/mayadata-io/composer?branch=develop#a382d6d50f44ac0e3c8533625e14359c6e2eb69d"
+source = "git+https://github.com/mayadata-io/composer?branch=develop#6e42021d02ad767610972626673e59d566b367a1"
 dependencies = [
  "bollard",
  "crossbeam",

--- a/deployer/src/infra/mayastor.rs
+++ b/deployer/src/infra/mayastor.rs
@@ -16,6 +16,7 @@ impl ComponentAction for Mayastor {
 
             let mut spec = if let Some(binary) = binary {
                 ContainerSpec::from_binary(&name, Binary::from_path(&binary))
+                    .with_bind_binary_dir(true)
             } else {
                 ContainerSpec::from_image(&name, &options.mayastor_image)
             }


### PR DESCRIPTION
Mayastor now links against `libspdk-bundle.so`, which is located in the same
directory as binary itself (previously, it linked against libspdk.so from
a Nix package). Finding this shared library requires access to the directory
with mayastor binary from within the container. Support for that has been
added to the `composer` crate.
This fix does not affect deploying mayastor from image.

Fixes CAS-1290