### PR TITLE
feat: enable long-lived grpc clients whilst supporting per request timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ version = "0.1.0"
 dependencies = [
  "common-lib",
  "humantime",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
  "prost 0.8.0",

--- a/control-plane/agents/core/src/pool/service.rs
+++ b/control-plane/agents/core/src/pool/service.rs
@@ -38,7 +38,8 @@ impl PoolOperations for Service {
         _ctx: Option<Context>,
     ) -> Result<Pool, ReplyError> {
         let req = pool.into();
-        let pool = self.create_pool(&req).await?;
+        let service = self.clone();
+        let pool = tokio::spawn(async move { service.create_pool(&req).await }).await??;
         Ok(pool)
     }
 
@@ -48,7 +49,8 @@ impl PoolOperations for Service {
         _ctx: Option<Context>,
     ) -> Result<(), ReplyError> {
         let req = pool.into();
-        self.destroy_pool(&req).await?;
+        let service = self.clone();
+        tokio::spawn(async move { service.destroy_pool(&req).await }).await??;
         Ok(())
     }
 

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -25,3 +25,6 @@ tracing = "0.1.28"
 [build-dependencies]
 tonic-build = "0.5.2"
 prost-build = "0.8.0"
+
+[dev-dependencies]
+once_cell = "1.9.0"

--- a/control-plane/grpc/src/grpc_opts/mod.rs
+++ b/control-plane/grpc/src/grpc_opts/mod.rs
@@ -1,5 +1,10 @@
 use common_lib::{mbus_api::TimeoutOptions, types::v0::message_bus::MessageIdVs};
 use std::time::Duration;
+use tonic::{
+    transport::{Channel, Uri},
+    IntoRequest,
+};
+use utils::DEFAULT_REQ_TIMEOUT;
 
 /// Request specific minimum timeouts
 /// zeroing replicas on create/destroy takes some time (observed up to 7seconds)
@@ -51,17 +56,84 @@ pub fn timeout_grpc(op_id: MessageIdVs, min_timeout: Duration) -> Duration {
 
 /// context to be sent along with each request encapsulating the extra add ons that changes the
 /// behaviour of each request.
+#[derive(Clone)]
 pub struct Context {
     timeout_opts: Option<TimeoutOptions>,
 }
 impl Context {
-    /// generate a new context with the provided timeout options
+    /// Generate a new context with the provided `TimeoutOptions`.
     pub fn new(timeout_opts: impl Into<Option<TimeoutOptions>>) -> Self {
         Self {
             timeout_opts: timeout_opts.into(),
         }
     }
+    /// Get the optional `TimeoutOptions`.
     pub fn timeout_opts(&self) -> Option<TimeoutOptions> {
         self.timeout_opts.clone()
+    }
+
+    /// Get the base timeout if specified, or `DEFAULT_REQ_TIMEOUT`.
+    pub fn base_timeout(&self) -> Duration {
+        self.timeout_opts
+            .as_ref()
+            .map(|o| o.base_timeout())
+            .unwrap_or_else(|| humantime::parse_duration(DEFAULT_REQ_TIMEOUT).unwrap())
+    }
+
+    /// Create a new endpoint that connects to the provided Uri.
+    /// This endpoint has default connect and request timeouts.
+    fn endpoint(&self, uri: Uri) -> tonic::transport::Endpoint {
+        let timeout = self.base_timeout();
+        tonic::transport::Endpoint::from(uri)
+            // we use the same timeout for the connection so we can pass the existing nats tests
+            // todo: use a shorter connect timeout
+            .connect_timeout(timeout)
+            .timeout(timeout)
+            .keep_alive_while_idle(true)
+    }
+}
+
+/// Generic RPC Client.
+#[derive(Clone)]
+pub struct Client<C: Clone> {
+    context: Context,
+    client: C,
+}
+
+impl<C: Clone> Client<C> {
+    /// Creates a generic RPC client based on the provided arguments.
+    /// options: Timeout options which are used for connection and request timeouts.
+    /// make_client: Creates a client of the appropriate type.
+    pub(crate) async fn new<O, M>(uri: Uri, options: O, make_client: M) -> Self
+    where
+        O: Into<Option<TimeoutOptions>>,
+        M: FnOnce(Channel) -> C,
+    {
+        let context = Context::new(options);
+        let endpoint = context.endpoint(uri);
+        let channel = endpoint.connect_lazy().unwrap();
+        let client = make_client(channel);
+        Self { context, client }
+    }
+
+    /// Prepares a new `tonic::Request<T>` for the given request `R: Into<T>`.
+    /// If `context` is specified the timeout of the request will be set to the base_timeout of
+    /// context. Otherwise, `op_id` will be used to select an appropriate timeout.
+    pub(crate) fn request<T, R: Into<T>>(
+        &self,
+        request: R,
+        context: Option<Context>,
+        op_id: MessageIdVs,
+    ) -> tonic::Request<T> {
+        let timeout = context
+            .map(|c| c.base_timeout())
+            .unwrap_or_else(|| timeout_grpc(op_id, self.context.base_timeout()));
+        let mut request = request.into().into_request();
+        request.set_timeout(timeout);
+        request
+    }
+    /// Returns a new client.
+    pub(crate) fn client(&self) -> C {
+        self.client.clone()
     }
 }

--- a/control-plane/grpc/src/operations/pool/client.rs
+++ b/control-plane/grpc/src/operations/pool/client.rs
@@ -1,72 +1,36 @@
 use crate::{
     common::{NodeFilter, NodePoolFilter, PoolFilter},
-    grpc_opts::{timeout_grpc, Context},
+    grpc_opts::{Client, Context},
     operations::pool::traits::{CreatePoolInfo, DestroyPoolInfo, PoolOperations},
     pool::{
         create_pool_reply, get_pools_reply, get_pools_request, pool_grpc_client::PoolGrpcClient,
-        CreatePoolRequest, DestroyPoolRequest, GetPoolsRequest,
+        GetPoolsRequest,
     },
 };
 use common_lib::{
     mbus_api::{v0::Pools, ReplyError, ResourceKind, TimeoutOptions},
     types::v0::message_bus::{Filter, MessageIdVs, Pool},
 };
-use std::{convert::TryFrom, time::Duration};
-use tonic::transport::{Channel, Endpoint, Uri};
-use utils::DEFAULT_REQ_TIMEOUT;
+use std::{convert::TryFrom, ops::Deref};
+use tonic::transport::{Channel, Uri};
 
 /// RPC Pool Client
 #[derive(Clone)]
 pub struct PoolClient {
-    base_timeout: Duration,
-    endpoint: Endpoint,
+    inner: Client<PoolGrpcClient<Channel>>,
+}
+impl Deref for PoolClient {
+    type Target = Client<PoolGrpcClient<Channel>>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
 }
 
 impl PoolClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let timeout_opts = opts.into();
-        let timeout = timeout_opts
-            .map(|opt| opt.base_timeout())
-            .unwrap_or_else(|| humantime::parse_duration(DEFAULT_REQ_TIMEOUT).unwrap());
-        let endpoint = tonic::transport::Endpoint::from(addr)
-            .connect_timeout(timeout)
-            .timeout(timeout);
-        Self {
-            base_timeout: timeout,
-            endpoint,
-        }
-    }
-    /// creates a new pool grpc client on a new endpoint after altering the properties of the
-    /// base endpoint according to the provided context
-    pub async fn reconnect(
-        &self,
-        ctx: Option<Context>,
-        op_id: MessageIdVs,
-    ) -> Result<PoolGrpcClient<Channel>, tonic::transport::Error> {
-        let ctx_timeout = ctx.map(|ctx| ctx.timeout_opts()).flatten();
-        match ctx_timeout {
-            None => {
-                let timeout = timeout_grpc(op_id, self.base_timeout);
-                let endpoint = self
-                    .endpoint
-                    .clone()
-                    .connect_timeout(timeout)
-                    .timeout(timeout);
-                let client = PoolGrpcClient::connect(endpoint.clone()).await?;
-                Ok(client)
-            }
-            Some(timeout) => {
-                let timeout = timeout.base_timeout();
-                let endpoint = self
-                    .endpoint
-                    .clone()
-                    .connect_timeout(timeout)
-                    .timeout(timeout);
-                let client = PoolGrpcClient::connect(endpoint.clone()).await?;
-                Ok(client)
-            }
-        }
+        let client = Client::new(addr, opts, PoolGrpcClient::new).await;
+        Self { inner: client }
     }
 }
 
@@ -79,9 +43,9 @@ impl PoolOperations for PoolClient {
         create_pool_req: &dyn CreatePoolInfo,
         ctx: Option<Context>,
     ) -> Result<Pool, ReplyError> {
-        let client = self.reconnect(ctx, MessageIdVs::CreatePool).await?;
-        let req: CreatePoolRequest = create_pool_req.into();
-        let response = client.clone().create_pool(req).await?.into_inner();
+        let req = self.request(create_pool_req, ctx, MessageIdVs::CreatePool);
+
+        let response = self.client().create_pool(req).await?.into_inner();
         match response.reply {
             Some(create_pool_reply) => match create_pool_reply {
                 create_pool_reply::Reply::Pool(pool) => Ok(Pool::try_from(pool)?),
@@ -97,9 +61,8 @@ impl PoolOperations for PoolClient {
         destroy_pool_req: &dyn DestroyPoolInfo,
         ctx: Option<Context>,
     ) -> Result<(), ReplyError> {
-        let client = self.reconnect(ctx, MessageIdVs::DestroyPool).await?;
-        let req: DestroyPoolRequest = destroy_pool_req.into();
-        let response = client.clone().destroy_pool(req).await?.into_inner();
+        let req = self.request(destroy_pool_req, ctx, MessageIdVs::DestroyPool);
+        let response = self.client().destroy_pool(req).await?.into_inner();
         match response.error {
             None => Ok(()),
             Some(err) => Err(err.into()),
@@ -107,7 +70,6 @@ impl PoolOperations for PoolClient {
     }
 
     async fn get(&self, filter: Filter, ctx: Option<Context>) -> Result<Pools, ReplyError> {
-        let client = self.reconnect(ctx, MessageIdVs::GetPools).await?;
         let req: GetPoolsRequest = match filter {
             Filter::Node(id) => GetPoolsRequest {
                 filter: Some(get_pools_request::Filter::Node(NodeFilter {
@@ -127,7 +89,8 @@ impl PoolOperations for PoolClient {
             },
             _ => GetPoolsRequest { filter: None },
         };
-        let response = client.clone().get_pools(req).await?.into_inner();
+        let req = self.request(req, ctx, MessageIdVs::GetPools);
+        let response = self.client().get_pools(req).await?.into_inner();
         match response.reply {
             Some(get_pools_reply) => match get_pools_reply {
                 get_pools_reply::Reply::Pools(pools) => Ok(Pools::try_from(pools)?),

--- a/control-plane/grpc/src/operations/pool/mod.rs
+++ b/control-plane/grpc/src/operations/pool/mod.rs
@@ -1,8 +1,141 @@
-// Pool grpc Client related code
+/// Pool grpc Client related code
 pub mod client;
 
-// Pool grpc Server related code
+/// Pool grpc Server related code
 pub mod server;
 
-// Pool traits for the transport
+/// Pool traits for the transport
 pub mod traits;
+
+#[cfg(test)]
+mod test {
+    use crate::{
+        grpc_opts::Context,
+        operations::pool::{client::PoolClient, server::PoolServer, traits::PoolOperations},
+    };
+    use common_lib::{mbus_api::TimeoutOptions, types::v0::message_bus::Filter};
+    use once_cell::sync::OnceCell;
+    use std::{
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    };
+    use tokio::sync::oneshot::Sender;
+    use tonic::transport::Uri;
+
+    type CompleteSender = Arc<Mutex<Option<Sender<(bool, Instant)>>>>;
+    static COMPLETE_CHAN: OnceCell<CompleteSender> = OnceCell::new();
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn timeout() {
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::from(0)), 50011);
+        let uri = Uri::builder()
+            .scheme("https")
+            .path_and_query("")
+            .authority(socket_addr.to_string())
+            .build()
+            .unwrap();
+
+        tokio::spawn(async move {
+            let service = PoolServer::new(Arc::new(server::Server {}));
+            tonic::transport::Server::builder()
+                .add_service(service.into_grpc_server())
+                .serve(socket_addr)
+                .await
+                .unwrap();
+        });
+        // todo: wait until the server is running
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        COMPLETE_CHAN.get_or_init(|| Arc::new(Mutex::new(None)));
+
+        let channel = COMPLETE_CHAN.get().unwrap().clone();
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        *channel.lock().unwrap() = Some(sender);
+
+        let timeout_opts = TimeoutOptions::new().with_timeout(Duration::from_secs(10));
+        let client = PoolClient::new(uri, timeout_opts).await;
+
+        let req_timeout = Duration::from_secs(1);
+        let ctx = Context::new(TimeoutOptions::new().with_timeout(req_timeout));
+        let before = std::time::Instant::now();
+        let result = client.get(Filter::None, Some(ctx)).await;
+        let (complete, timestamp) = receiver.await.unwrap();
+        println!(
+            "Request completed: {}, duration: {:?}",
+            complete,
+            timestamp - before
+        );
+        // client should have timed out!
+        assert!(result.is_err());
+        // timeout within the req_timeout, with 200ms slack
+        assert!(before.elapsed() < (req_timeout + Duration::from_millis(200)));
+        // server request should have been dropped
+        assert!(!complete);
+    }
+
+    struct TimeoutTester {
+        complete: bool,
+    }
+    impl TimeoutTester {
+        fn new() -> Self {
+            Self { complete: false }
+        }
+        fn complete(mut self) {
+            self.complete = true;
+        }
+    }
+    impl Drop for TimeoutTester {
+        fn drop(&mut self) {
+            let channel = COMPLETE_CHAN.get().unwrap().clone();
+            let sender = channel.lock().unwrap().take().unwrap();
+            sender
+                .send((self.complete, std::time::Instant::now()))
+                .unwrap();
+        }
+    }
+
+    mod server {
+        use crate::{
+            grpc_opts::Context,
+            operations::pool::{
+                test::TimeoutTester,
+                traits::{CreatePoolInfo, DestroyPoolInfo, PoolOperations},
+            },
+        };
+        use common_lib::{
+            mbus_api::{v0::Pools, ReplyError},
+            types::v0::message_bus::{Filter, Pool},
+        };
+        use std::time::Duration;
+
+        pub(super) struct Server {}
+        #[tonic::async_trait]
+        impl PoolOperations for Server {
+            async fn create(
+                &self,
+                _pool: &dyn CreatePoolInfo,
+                _ctx: Option<Context>,
+            ) -> Result<Pool, ReplyError> {
+                todo!()
+            }
+            async fn destroy(
+                &self,
+                _pool: &dyn DestroyPoolInfo,
+                _ctx: Option<Context>,
+            ) -> Result<(), ReplyError> {
+                todo!()
+            }
+            async fn get(
+                &self,
+                _filter: Filter,
+                _ctx: Option<Context>,
+            ) -> Result<Pools, ReplyError> {
+                let tester = TimeoutTester::new();
+                tokio::time::sleep(Duration::from_secs(3)).await;
+                tester.complete();
+                Ok(Pools(vec![]))
+            }
+        }
+    }
+}

--- a/control-plane/grpc/src/operations/pool/server.rs
+++ b/control-plane/grpc/src/operations/pool/server.rs
@@ -8,11 +8,10 @@ use crate::{
         GetPoolsRequest,
     },
 };
-use common_lib::mbus_api::{ErrorChain, ReplyError};
 use std::sync::Arc;
 use tonic::{Request, Response};
 
-/// RPC Pool Server
+/// gRPC Pool Server
 #[derive(Clone)]
 pub struct PoolServer {
     /// Service which executes the operations.
@@ -24,62 +23,40 @@ impl PoolServer {
     pub fn new(service: Arc<dyn PoolOperations>) -> Self {
         Self { service }
     }
-    /// coverts the poolserver to its corresponding grpc server type
-    pub fn into_grpc_server(self) -> PoolGrpcServer<PoolServer> {
+    /// converts the poolserver to its corresponding grpc server type
+    pub fn into_grpc_server(self) -> PoolGrpcServer<Self> {
         PoolGrpcServer::new(self)
     }
 }
 
-// Implementation of the RPC methods.
 #[tonic::async_trait]
 impl PoolGrpc for PoolServer {
-    async fn destroy_pool(
-        &self,
-        request: Request<DestroyPoolRequest>,
-    ) -> Result<tonic::Response<DestroyPoolReply>, tonic::Status> {
-        let req = request.into_inner();
-        // Dispatch the destroy call to the registered service.
-        let service = self.service.clone();
-        tokio::spawn(async move {
-            match service.destroy(&req, None).await {
-                Ok(()) => Ok(Response::new(DestroyPoolReply { error: None })),
-                Err(e) => Ok(Response::new(DestroyPoolReply {
-                    error: Some(e.into()),
-                })),
-            }
-        })
-        .await
-        .unwrap_or_else(|e| {
-            Ok(Response::new(DestroyPoolReply {
-                error: Some(ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into()),
-            }))
-        })
-    }
-
     async fn create_pool(
         &self,
         request: Request<CreatePoolRequest>,
     ) -> Result<tonic::Response<pool::CreatePoolReply>, tonic::Status> {
         let req: CreatePoolRequest = request.into_inner();
-        let service = self.service.clone();
-        tokio::spawn(async move {
-            match service.create(&req, None).await {
-                Ok(pool) => Ok(Response::new(CreatePoolReply {
-                    reply: Some(create_pool_reply::Reply::Pool(pool.into())),
-                })),
-                Err(err) => Ok(Response::new(CreatePoolReply {
-                    reply: Some(create_pool_reply::Reply::Error(err.into())),
-                })),
-            }
-        })
-        .await
-        .unwrap_or_else(|e| {
-            Ok(Response::new(CreatePoolReply {
-                reply: Some(create_pool_reply::Reply::Error(
-                    ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into(),
-                )),
-            }))
-        })
+        match self.service.create(&req, None).await {
+            Ok(pool) => Ok(Response::new(CreatePoolReply {
+                reply: Some(create_pool_reply::Reply::Pool(pool.into())),
+            })),
+            Err(err) => Ok(Response::new(CreatePoolReply {
+                reply: Some(create_pool_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn destroy_pool(
+        &self,
+        request: Request<DestroyPoolRequest>,
+    ) -> Result<tonic::Response<DestroyPoolReply>, tonic::Status> {
+        let req = request.into_inner();
+        match self.service.destroy(&req, None).await {
+            Ok(()) => Ok(Response::new(DestroyPoolReply { error: None })),
+            Err(e) => Ok(Response::new(DestroyPoolReply {
+                error: Some(e.into()),
+            })),
+        }
     }
 
     async fn get_pools(
@@ -88,24 +65,13 @@ impl PoolGrpc for PoolServer {
     ) -> Result<tonic::Response<pool::GetPoolsReply>, tonic::Status> {
         let req: GetPoolsRequest = request.into_inner();
         let filter = req.filter.map(Into::into).unwrap_or_default();
-        let service = self.service.clone();
-        tokio::spawn(async move {
-            match service.get(filter, None).await {
-                Ok(pools) => Ok(Response::new(GetPoolsReply {
-                    reply: Some(get_pools_reply::Reply::Pools(pools.into())),
-                })),
-                Err(err) => Ok(Response::new(GetPoolsReply {
-                    reply: Some(get_pools_reply::Reply::Error(err.into())),
-                })),
-            }
-        })
-        .await
-        .unwrap_or_else(|e| {
-            Ok(Response::new(GetPoolsReply {
-                reply: Some(get_pools_reply::Reply::Error(
-                    ReplyError::tonic_reply_error(e.to_string(), e.full_string()).into(),
-                )),
-            }))
-        })
+        match self.service.get(filter, None).await {
+            Ok(pools) => Ok(Response::new(GetPoolsReply {
+                reply: Some(get_pools_reply::Reply::Pools(pools.into())),
+            })),
+            Err(err) => Ok(Response::new(GetPoolsReply {
+                reply: Some(get_pools_reply::Reply::Error(err.into())),
+            })),
+        }
     }
 }

--- a/control-plane/rest/service/src/v0/mod.rs
+++ b/control-plane/rest/service/src/v0/mod.rs
@@ -36,9 +36,15 @@ use once_cell::sync::OnceCell;
 use rest_client::versions::v0::*;
 use serde::Deserialize;
 
-/// once cell static variable to store the grpc client and initialise
-/// once at startup
+/// Once cell static variable to store the grpc client and initialise once at startup
 pub static CORE_CLIENT: OnceCell<CoreClient> = OnceCell::new();
+
+/// Get Core gRPC Client
+pub(crate) fn core_grpc<'a>() -> &'a CoreClient {
+    CORE_CLIENT
+        .get()
+        .expect("gRPC Core Client should have been initialised")
+}
 
 fn version() -> String {
     "v0".into()

--- a/scripts/rust/test.sh
+++ b/scripts/rust/test.sh
@@ -17,7 +17,7 @@ set -euxo pipefail
 export PATH=$PATH:${HOME}/.cargo/bin
 # test dependencies
 cargo build --bins
-for test in agents rest ctrlp-tests kubectl-plugin; do
+for test in grpc agents rest ctrlp-tests kubectl-plugin; do
     cargo test -p ${test} -- --test-threads=1
 done
 cleanup_handler


### PR DESCRIPTION
feat: new base grpc client that supports adding timeouts per request

This can be used as a inner helper which provides common functionality of creating a new client
connection and setting specific timeouts for each request.
This allows us to use long-lived connections with keep-alives.

-------------

refactor(pool): use of the new generic gRPC client

-------------

refactor: keep the pool gRPC server handlers cancellable

The specific service implementations will be responsible for making it otherwise. This gives finer
grained control to decide how to implement each handler.

-------------

fix: spawn core pool create/destroy to avoid early drop on timeout

The existing code does not handle being dropped very well, as it will leave things in a
potentially "bad" state.
TODO: handle serive handlers drops gracefully. This will be tricky as eg ETCD client is async and so
we can't really flush things to ETCD in a nice way on drop.

For now, try to avoid dropping the futures when the client times out by spawning it.
NOTE: the future can still be dropped on reactor shutdown.

-------------

test: add grpc request timeout test

This validates that timeouts by modifying the grpc timeout header works.

------------

refactor(rest): use long lived gRPC connections