### PR TITLE
fix(rest): enable http2 keep alive interval and timeout

### DIFF
--- a/common/src/mbus_api/mod.rs
+++ b/common/src/mbus_api/mod.rs
@@ -521,6 +521,11 @@ pub struct TimeoutOptions {
 
     /// Request specific minimum timeouts
     request_timeout: Option<RequestMinTimeout>,
+
+    /// Http2 keep alive interval.
+    keep_alive_interval: std::time::Duration,
+    /// Http2 keep alive timeout.
+    keep_alive_timeout: std::time::Duration,
 }
 
 /// Request specific minimum timeouts
@@ -580,6 +585,14 @@ impl TimeoutOptions {
     pub fn base_timeout(&self) -> Duration {
         self.timeout
     }
+    /// Default http2 Keep Alive interval.
+    pub(crate) fn default_keep_alive_interval() -> std::time::Duration {
+        Duration::from_secs(10)
+    }
+    /// Default http2 Keep Alive timeout.
+    pub(crate) fn default_keep_alive_timeout() -> std::time::Duration {
+        Duration::from_secs(20)
+    }
 }
 
 impl Default for TimeoutOptions {
@@ -590,6 +603,8 @@ impl Default for TimeoutOptions {
             max_retries: Some(Self::default_max_retries()),
             tcp_read_timeout: Self::default_tcp_read_timeout(),
             request_timeout: Self::default_request_timeouts(),
+            keep_alive_timeout: Self::default_keep_alive_timeout(),
+            keep_alive_interval: Self::default_keep_alive_interval(),
         }
     }
 }
@@ -640,6 +655,15 @@ impl TimeoutOptions {
     /// Get the minimum request timeouts
     pub fn request_timeout(&self) -> Option<&RequestMinTimeout> {
         self.request_timeout.as_ref()
+    }
+
+    /// Get the http2 Keep Alive interval.
+    pub fn keep_alive_interval(&self) -> Duration {
+        self.keep_alive_interval
+    }
+    /// Get the http2 Keep Alive timeout.
+    pub fn keep_alive_timeout(&self) -> Duration {
+        self.keep_alive_timeout
     }
 }
 

--- a/control-plane/grpc/src/grpc_opts/mod.rs
+++ b/control-plane/grpc/src/grpc_opts/mod.rs
@@ -80,6 +80,21 @@ impl Context {
             .unwrap_or_else(|| humantime::parse_duration(DEFAULT_REQ_TIMEOUT).unwrap())
     }
 
+    /// Get the http2 keep alive interval.
+    pub fn keep_alive_interval(&self) -> Duration {
+        self.timeout_opts
+            .clone()
+            .unwrap_or_default()
+            .keep_alive_interval()
+    }
+    /// Get the http2 keep alive timeout.
+    pub fn keep_alive_timeout(&self) -> Duration {
+        self.timeout_opts
+            .clone()
+            .unwrap_or_default()
+            .keep_alive_timeout()
+    }
+
     /// Create a new endpoint that connects to the provided Uri.
     /// This endpoint has default connect and request timeouts.
     fn endpoint(&self, uri: Uri) -> tonic::transport::Endpoint {
@@ -89,7 +104,8 @@ impl Context {
             // todo: use a shorter connect timeout
             .connect_timeout(timeout)
             .timeout(timeout)
-            .keep_alive_while_idle(true)
+            .http2_keep_alive_interval(self.keep_alive_interval())
+            .keep_alive_timeout(self.keep_alive_timeout())
     }
 }
 


### PR DESCRIPTION
Enables http2 keep alives - this allows us to failover to servers even when a node crashes and the
core agent is recreated on another node.