### PR TITLE
feat(tracing): add opentelemetry tracing to the grpc interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1503,9 +1503,11 @@ name = "grpc"
 version = "0.1.0"
 dependencies = [
  "common-lib",
+ "http-body",
  "humantime",
  "once_cell",
  "opentelemetry",
+ "opentelemetry-http",
  "opentelemetry-semantic-conventions",
  "prost 0.8.0",
  "prost-build",
@@ -1513,6 +1515,7 @@ dependencies = [
  "tokio",
  "tonic 0.5.2",
  "tonic-build",
+ "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber 0.2.25",

--- a/control-plane/agents/core/src/pool/service.rs
+++ b/control-plane/agents/core/src/pool/service.rs
@@ -14,7 +14,7 @@ use common_lib::{
     },
 };
 use grpc::{
-    grpc_opts::Context,
+    context::Context,
     operations::{
         pool::traits::{CreatePoolInfo, DestroyPoolInfo, PoolOperations},
         replica::traits::{
@@ -39,7 +39,7 @@ impl PoolOperations for Service {
     ) -> Result<Pool, ReplyError> {
         let req = pool.into();
         let service = self.clone();
-        let pool = tokio::spawn(async move { service.create_pool(&req).await }).await??;
+        let pool = Context::spawn(async move { service.create_pool(&req).await }).await??;
         Ok(pool)
     }
 
@@ -50,7 +50,7 @@ impl PoolOperations for Service {
     ) -> Result<(), ReplyError> {
         let req = pool.into();
         let service = self.clone();
-        tokio::spawn(async move { service.destroy_pool(&req).await }).await??;
+        Context::spawn(async move { service.destroy_pool(&req).await }).await??;
         Ok(())
     }
 
@@ -71,7 +71,7 @@ impl ReplicaOperations for Service {
         let create_replica = req.into();
         let service = self.clone();
         let replica =
-            tokio::spawn(async move { service.create_replica(&create_replica).await }).await??;
+            Context::spawn(async move { service.create_replica(&create_replica).await }).await??;
         Ok(replica)
     }
 
@@ -88,7 +88,7 @@ impl ReplicaOperations for Service {
     ) -> Result<(), ReplyError> {
         let destroy_replica = req.into();
         let service = self.clone();
-        tokio::spawn(async move { service.destroy_replica(&destroy_replica).await }).await??;
+        Context::spawn(async move { service.destroy_replica(&destroy_replica).await }).await??;
         Ok(())
     }
 
@@ -100,7 +100,7 @@ impl ReplicaOperations for Service {
         let share_replica = req.into();
         let service = self.clone();
         let response =
-            tokio::spawn(async move { service.share_replica(&share_replica).await }).await??;
+            Context::spawn(async move { service.share_replica(&share_replica).await }).await??;
         Ok(response)
     }
 
@@ -111,7 +111,7 @@ impl ReplicaOperations for Service {
     ) -> Result<(), ReplyError> {
         let unshare_replica = req.into();
         let service = self.clone();
-        tokio::spawn(async move { service.unshare_replica(&unshare_replica).await }).await??;
+        Context::spawn(async move { service.unshare_replica(&unshare_replica).await }).await??;
         Ok(())
     }
 }
@@ -236,7 +236,7 @@ impl Service {
     }
 
     /// Create pool
-    #[tracing::instrument(level = "debug", skip(self), fields(pool.uuid = %request.id))]
+    #[tracing::instrument(level = "debug", skip(self), err, fields(pool.uuid = %request.id))]
     pub(super) async fn create_pool(&self, request: &CreatePool) -> Result<Pool, SvcError> {
         self.specs()
             .create_pool(&self.registry, request, OperationMode::Exclusive)

--- a/control-plane/agents/core/src/pool/tests.rs
+++ b/control-plane/agents/core/src/pool/tests.rs
@@ -17,7 +17,7 @@ use common_lib::{
     },
 };
 use grpc::{
-    grpc_opts::Context,
+    context::Context,
     operations::{pool::traits::PoolOperations, replica::traits::ReplicaOperations},
 };
 use itertools::Itertools;

--- a/control-plane/agents/core/src/volume/service.rs
+++ b/control-plane/agents/core/src/volume/service.rs
@@ -11,7 +11,7 @@ use common_lib::{
     },
 };
 use grpc::{
-    grpc_opts::Context,
+    context::Context,
     operations::volume::traits::{
         CreateVolumeInfo, DestroyVolumeInfo, PublishVolumeInfo, SetVolumeReplicaInfo,
         ShareVolumeInfo, UnpublishVolumeInfo, UnshareVolumeInfo, VolumeOperations,
@@ -101,7 +101,7 @@ impl VolumeOperations for Service {
         Ok(volume)
     }
 
-    async fn set_volume_replica(
+    async fn set_replica(
         &self,
         req: &dyn SetVolumeReplicaInfo,
         _ctx: Option<Context>,

--- a/control-plane/agents/core/src/volume/tests.rs
+++ b/control-plane/agents/core/src/volume/tests.rs
@@ -1534,7 +1534,7 @@ async fn replica_count_test(cluster: &Cluster) {
         .unwrap();
 
     let volume = volume_client
-        .set_volume_replica(
+        .set_replica(
             &SetVolumeReplica {
                 uuid: volume.spec().uuid.clone(),
                 replicas: 3,
@@ -1547,7 +1547,7 @@ async fn replica_count_test(cluster: &Cluster) {
 
     let volume_state = volume.state();
     let error = volume_client
-        .set_volume_replica(
+        .set_replica(
             &SetVolumeReplica {
                 uuid: volume_state.uuid.clone(),
                 replicas: 4,
@@ -1571,7 +1571,7 @@ async fn replica_count_test(cluster: &Cluster) {
         .unwrap();
 
     let error = volume_client
-        .set_volume_replica(
+        .set_replica(
             &SetVolumeReplica {
                 uuid: volume.uuid.clone(),
                 replicas: 4,
@@ -1592,7 +1592,7 @@ async fn replica_count_test(cluster: &Cluster) {
     ));
 
     let volume = volume_client
-        .set_volume_replica(
+        .set_replica(
             &SetVolumeReplica {
                 uuid: volume.uuid.clone(),
                 replicas: 2,
@@ -1605,7 +1605,7 @@ async fn replica_count_test(cluster: &Cluster) {
 
     let volume_state = volume.state();
     let volume = volume_client
-        .set_volume_replica(
+        .set_replica(
             &SetVolumeReplica {
                 uuid: volume_state.uuid.clone(),
                 replicas: 1,
@@ -1624,7 +1624,7 @@ async fn replica_count_test(cluster: &Cluster) {
         .any(|n| n.children.iter().any(|c| c.state != ChildState::Online)));
 
     let error = volume_client
-        .set_volume_replica(
+        .set_replica(
             &SetVolumeReplica {
                 uuid: volume_state.uuid.clone(),
                 replicas: 0,
@@ -1645,7 +1645,7 @@ async fn replica_count_test(cluster: &Cluster) {
     ));
 
     let volume = volume_client
-        .set_volume_replica(
+        .set_replica(
             &SetVolumeReplica {
                 uuid: volume_state.uuid.clone(),
                 replicas: 2,
@@ -1663,7 +1663,7 @@ async fn replica_count_test(cluster: &Cluster) {
         .unwrap();
 
     let volume = volume_client
-        .set_volume_replica(
+        .set_replica(
             &SetVolumeReplica {
                 uuid: volume_state.uuid.clone(),
                 replicas: 3,

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -19,8 +19,11 @@ utils = { path = "../../utils/utils-lib" }
 tracing-subscriber = "0.2.24"
 tracing-opentelemetry = "0.15.0"
 opentelemetry = { version = "0.16.0", features = ["rt-tokio-current-thread"] }
+opentelemetry-http = { version = "0.5.0" }
 opentelemetry-semantic-conventions = "0.8.0"
 tracing = "0.1.28"
+http-body = "0.4.4"
+tower = { version = "0.4.8", features = [ "timeout", "util" ] }
 
 [build-dependencies]
 tonic-build = "0.5.2"

--- a/control-plane/grpc/src/client.rs
+++ b/control-plane/grpc/src/client.rs
@@ -13,7 +13,6 @@ pub struct CoreClient {
     volume: VolumeClient,
 }
 
-/// implement the CoreClient
 impl CoreClient {
     /// generates a new CoreClient to get the individual clients
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {

--- a/control-plane/grpc/src/lib.rs
+++ b/control-plane/grpc/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod client;
-pub mod grpc_opts;
+pub mod context;
 pub mod misc;
 /// All server, client implementations and the traits
 pub mod operations;
+pub mod tracing;
 
 /// Common module for all the misc operations
 pub(crate) mod common {

--- a/control-plane/grpc/src/operations/mod.rs
+++ b/control-plane/grpc/src/operations/mod.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+
 /// module for all corresponding client, server, traits for nexus rpc transport
 pub mod nexus;
 

--- a/control-plane/grpc/src/operations/pool/mod.rs
+++ b/control-plane/grpc/src/operations/pool/mod.rs
@@ -10,7 +10,7 @@ pub mod traits;
 #[cfg(test)]
 mod test {
     use crate::{
-        grpc_opts::Context,
+        context::Context,
         operations::pool::{client::PoolClient, server::PoolServer, traits::PoolOperations},
     };
     use common_lib::{mbus_api::TimeoutOptions, types::v0::message_bus::Filter};
@@ -97,7 +97,7 @@ mod test {
 
     mod server {
         use crate::{
-            grpc_opts::Context,
+            context::Context,
             operations::pool::{
                 test::TimeoutTester,
                 traits::{CreatePoolInfo, DestroyPoolInfo, PoolOperations},

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     common,
-    grpc_opts::Context,
+    context::Context,
     pool,
     pool::{get_pools_request, CreatePoolRequest, DestroyPoolRequest},
 };
@@ -201,7 +201,7 @@ impl From<get_pools_request::Filter> for Filter {
 
 /// CreatePoolInfo trait for the pool creation to be implemented by entities which want to avail
 /// this operation
-pub trait CreatePoolInfo: Send + Sync {
+pub trait CreatePoolInfo: Send + Sync + std::fmt::Debug {
     /// Id of the pool
     fn pool_id(&self) -> PoolId;
     /// Id of the mayastor instance
@@ -214,7 +214,7 @@ pub trait CreatePoolInfo: Send + Sync {
 
 /// DestroyPoolInfo trait for the pool deletion to be implemented by entities which want to avail
 /// this operation
-pub trait DestroyPoolInfo: Sync + Send {
+pub trait DestroyPoolInfo: Sync + Send + std::fmt::Debug {
     /// Id of the pool
     fn pool_id(&self) -> PoolId;
     /// Id of the mayastor instance

--- a/control-plane/grpc/src/operations/replica/traits.rs
+++ b/control-plane/grpc/src/operations/replica/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     common,
-    grpc_opts::Context,
+    context::Context,
     misc::traits::ValidateRequestTypes,
     replica,
     replica::{
@@ -234,7 +234,7 @@ impl From<Replicas> for replica::Replicas {
 
 /// CreateReplicaInfo trait for the replica creation to be implemented by entities which want to
 /// avail this operation
-pub trait CreateReplicaInfo: Send + Sync {
+pub trait CreateReplicaInfo: Send + Sync + std::fmt::Debug {
     /// Id of the mayastor instanc
     fn node(&self) -> NodeId;
     /// Name of the replica
@@ -294,6 +294,7 @@ impl CreateReplicaInfo for CreateReplica {
 }
 
 /// Intermediate structure that validates the conversion to CreateVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedCreateReplicaRequest {
     inner: CreateReplicaRequest,
     uuid: ReplicaId,
@@ -426,7 +427,7 @@ impl ValidateRequestTypes for CreateReplicaRequest {
 
 /// DestroyReplicaInfo trait for the replica deletion to be implemented by entities which want to
 /// avail this operation
-pub trait DestroyReplicaInfo: Send + Sync {
+pub trait DestroyReplicaInfo: Send + Sync + std::fmt::Debug {
     /// Id of the mayastor instance
     fn node(&self) -> NodeId;
     /// Id of the pool
@@ -462,6 +463,7 @@ impl DestroyReplicaInfo for DestroyReplica {
 }
 
 /// Intermediate structure that validates the conversion to DestroyVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedDestroyReplicaRequest {
     inner: DestroyReplicaRequest,
     uuid: ReplicaId,
@@ -567,7 +569,7 @@ impl ValidateRequestTypes for DestroyReplicaRequest {
 
 /// ShareReplicaInfo trait for the replica sharing to be implemented by entities which want to avail
 /// this operation
-pub trait ShareReplicaInfo: Send + Sync {
+pub trait ShareReplicaInfo: Send + Sync + std::fmt::Debug {
     /// Id of the mayastor instance
     fn node(&self) -> NodeId;
     /// Id of the pool
@@ -603,6 +605,7 @@ impl ShareReplicaInfo for ShareReplica {
 }
 
 /// Intermediate structure that validates the conversion to ShareVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedShareReplicaRequest {
     inner: ShareReplicaRequest,
     uuid: ReplicaId,
@@ -670,7 +673,7 @@ impl ValidateRequestTypes for ShareReplicaRequest {
 
 /// UnshareReplicaInfo trait for the replica sharing to be implemented by entities which want to
 /// avail this operation
-pub trait UnshareReplicaInfo: Send + Sync {
+pub trait UnshareReplicaInfo: Send + Sync + std::fmt::Debug {
     /// Id of the mayastor instance
     fn node(&self) -> NodeId;
     /// Id of the pool
@@ -700,6 +703,7 @@ impl UnshareReplicaInfo for UnshareReplica {
 }
 
 /// Intermediate structure that validates the conversion to ShareVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedUnshareReplicaRequest {
     inner: UnshareReplicaRequest,
     uuid: ReplicaId,

--- a/control-plane/grpc/src/operations/volume/server.rs
+++ b/control-plane/grpc/src/operations/volume/server.rs
@@ -147,7 +147,7 @@ impl VolumeGrpc for VolumeServer {
         request: tonic::Request<SetVolumeReplicaRequest>,
     ) -> Result<tonic::Response<SetVolumeReplicaReply>, tonic::Status> {
         let req = request.into_inner().validated()?;
-        match self.service.set_volume_replica(&req, None).await {
+        match self.service.set_replica(&req, None).await {
             Ok(volume) => Ok(Response::new(SetVolumeReplicaReply {
                 reply: Some(set_volume_replica_reply::Reply::Volume(volume.into())),
             })),

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -1,6 +1,6 @@
 use crate::{
     common,
-    grpc_opts::Context,
+    context::Context,
     misc::traits::ValidateRequestTypes,
     nexus, replica, volume,
     volume::{
@@ -65,7 +65,7 @@ pub trait VolumeOperations: Send + Sync {
         ctx: Option<Context>,
     ) -> Result<Volume, ReplyError>;
     /// Increase or decrease volume replica
-    async fn set_volume_replica(
+    async fn set_replica(
         &self,
         req: &dyn SetVolumeReplicaInfo,
         ctx: Option<Context>,
@@ -647,7 +647,7 @@ impl TryFrom<get_volumes_request::Filter> for Filter {
 }
 
 /// Trait to be implemented for CreateVolume operation
-pub trait CreateVolumeInfo: Send + Sync {
+pub trait CreateVolumeInfo: Send + Sync + std::fmt::Debug {
     /// Uuid of the volume
     fn uuid(&self) -> VolumeId;
     /// Size in bytes of the volume
@@ -689,6 +689,7 @@ impl CreateVolumeInfo for CreateVolume {
 }
 
 /// Intermediate structure that validates the conversion to CreateVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedCreateVolumeRequest {
     inner: CreateVolumeRequest,
     uuid: VolumeId,
@@ -796,7 +797,7 @@ impl From<&dyn CreateVolumeInfo> for CreateVolumeRequest {
 }
 
 /// Trait to be implemented for DestroyVolume operation
-pub trait DestroyVolumeInfo: Send + Sync {
+pub trait DestroyVolumeInfo: Send + Sync + std::fmt::Debug {
     /// Uuid of the volume to be destroyed
     fn uuid(&self) -> VolumeId;
 }
@@ -808,6 +809,7 @@ impl DestroyVolumeInfo for DestroyVolume {
 }
 
 /// Intermediate structure that validates the conversion to DestroyVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedDestroyVolumeRequest {
     uuid: VolumeId,
 }
@@ -859,7 +861,7 @@ impl From<&dyn DestroyVolumeInfo> for DestroyVolumeRequest {
 }
 
 /// Trait to be implemented for ShareVolume operation
-pub trait ShareVolumeInfo: Send + Sync {
+pub trait ShareVolumeInfo: Send + Sync + std::fmt::Debug {
     /// Uuid of the volume to be shared
     fn uuid(&self) -> VolumeId;
     /// Protocol over which the volume be shared
@@ -877,6 +879,7 @@ impl ShareVolumeInfo for ShareVolume {
 }
 
 /// Intermediate structure that validates the conversion to ShareVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedShareVolumeRequest {
     inner: ShareVolumeRequest,
     uuid: VolumeId,
@@ -939,7 +942,7 @@ impl From<&dyn ShareVolumeInfo> for ShareVolumeRequest {
 }
 
 /// Trait to be implemented for UnshareVolume operation
-pub trait UnshareVolumeInfo: Send + Sync {
+pub trait UnshareVolumeInfo: Send + Sync + std::fmt::Debug {
     /// Uuid of the volume to be unshared
     fn uuid(&self) -> VolumeId;
 }
@@ -951,6 +954,7 @@ impl UnshareVolumeInfo for UnshareVolume {
 }
 
 /// Intermediate structure that validates the conversion to UnshareVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedUnshareVolumeRequest {
     uuid: VolumeId,
 }
@@ -1002,7 +1006,7 @@ impl From<&dyn UnshareVolumeInfo> for UnshareVolumeRequest {
 }
 
 /// Trait to be implemented for PublishVolume operation
-pub trait PublishVolumeInfo: Send + Sync {
+pub trait PublishVolumeInfo: Send + Sync + std::fmt::Debug {
     /// Uuid of the volume to be published
     fn uuid(&self) -> VolumeId;
     /// The node where front-end IO will be sent to
@@ -1026,6 +1030,7 @@ impl PublishVolumeInfo for PublishVolume {
 }
 
 /// Intermediate structure that validates the conversion to PublishVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedPublishVolumeRequest {
     inner: PublishVolumeRequest,
     uuid: VolumeId,
@@ -1117,7 +1122,7 @@ impl From<&dyn PublishVolumeInfo> for PublishVolumeRequest {
 }
 
 /// Trait to be implemented for PublishVolume operation
-pub trait UnpublishVolumeInfo: Send + Sync {
+pub trait UnpublishVolumeInfo: Send + Sync + std::fmt::Debug {
     /// Uuid of the volume to unpublish
     fn uuid(&self) -> VolumeId;
     /// Force unpublish
@@ -1135,6 +1140,7 @@ impl UnpublishVolumeInfo for UnpublishVolume {
 }
 
 /// Intermediate structure that validates the conversion to UnpublishVolumeRequest type
+#[derive(Debug)]
 pub struct ValidatedUnpublishVolumeRequest {
     inner: UnpublishVolumeRequest,
     uuid: VolumeId,
@@ -1192,7 +1198,7 @@ impl From<&dyn UnpublishVolumeInfo> for UnpublishVolumeRequest {
 }
 
 /// Trait to be implemented for SetVolumeReplica operation
-pub trait SetVolumeReplicaInfo: Send + Sync {
+pub trait SetVolumeReplicaInfo: Send + Sync + std::fmt::Debug {
     /// Uuid of the concerned volume
     fn uuid(&self) -> VolumeId;
     /// No of replicas we want to set for the volume
@@ -1210,6 +1216,7 @@ impl SetVolumeReplicaInfo for SetVolumeReplica {
 }
 
 /// Intermediate structure that validates the conversion to SetVolumeReplicaRequest type
+#[derive(Debug)]
 pub struct ValidatedSetVolumeReplicaRequest {
     inner: SetVolumeReplicaRequest,
     uuid: VolumeId,

--- a/control-plane/grpc/src/tracing.rs
+++ b/control-plane/grpc/src/tracing.rs
@@ -1,0 +1,208 @@
+use opentelemetry::{
+    global,
+    trace::{FutureExt, SpanKind, TraceContextExt, Tracer},
+    KeyValue,
+};
+use opentelemetry_http::HeaderInjector;
+use opentelemetry_semantic_conventions::trace::{HTTP_STATUS_CODE, RPC_GRPC_STATUS_CODE};
+use std::{future::Future, pin::Pin};
+use tonic::{
+    codegen::http::{Request, Response},
+    transport::Channel,
+};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+/// Add OpenTelemetry Span to the Http Headers
+#[derive(Default)]
+pub struct OpenTelClient {}
+impl OpenTelClient {
+    /// Return new `Self
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+impl<S> tower::Layer<S> for OpenTelClient {
+    type Service = OpenTelClientService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        OpenTelClientService::new(service)
+    }
+}
+
+/// OpenTelemetry Service that injects the current span into the Http Headers
+#[derive(Clone)]
+pub struct OpenTelClientService<S> {
+    service: S,
+}
+impl<S> OpenTelClientService<S> {
+    fn new(service: S) -> Self {
+        Self { service }
+    }
+}
+
+type TonicClientRequest =
+    Request<http_body::combinators::BoxBody<prost::bytes::Bytes, tonic::Status>>;
+type BoxedFuture<Resp, Err> = Pin<Box<dyn Future<Output = Result<Resp, Err>> + Send>>;
+
+impl tower::Service<TonicClientRequest> for OpenTelClientService<Channel> {
+    type Response = <Channel as tower::Service<TonicClientRequest>>::Response;
+    type Error = <Channel as tower::Service<TonicClientRequest>>::Error;
+    type Future = BoxedFuture<Self::Response, Self::Error>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut request: TonicClientRequest) -> Self::Future {
+        let tracer = global::tracer("grpc-client");
+        let context = tracing::Span::current().context();
+
+        let span = tracer
+            .span_builder(format!("{}", request.uri()))
+            .with_kind(SpanKind::Client)
+            .with_attributes(vec![
+                KeyValue::new("rpc.grpc.method", request.method().to_string()),
+                KeyValue::new("rpc.grpc.uri", request.uri().to_string()),
+                KeyValue::new("rpc.grpc.version", format!("{:?}", request.version())),
+            ])
+            .with_parent_context(context.clone())
+            .start(&tracer);
+
+        let context = context.with_span(span);
+        global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(&context, &mut HeaderInjector(request.headers_mut()))
+        });
+        trace_http_service_call(&mut self.service, request, context)
+    }
+}
+
+/// Extract OpenTelemetry Spans from Http Headers
+#[derive(Clone, Default)]
+pub struct OpenTelServer {}
+impl OpenTelServer {
+    /// Return new `Self`
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+impl<S> tower::Layer<S> for OpenTelServer {
+    type Service = OpenTelServerService<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        OpenTelServerService::new(service)
+    }
+}
+
+/// OpenTelemetry Service that extracts tracing spans from the Http Headers
+#[derive(Clone)]
+pub struct OpenTelServerService<S> {
+    service: S,
+}
+impl<S> OpenTelServerService<S> {
+    fn new(service: S) -> Self {
+        Self { service }
+    }
+}
+
+type TonicServerRequest = Request<tonic::transport::Body>;
+type TonicServerResponse = Response<tonic::body::BoxBody>;
+impl<S> tower::Service<TonicServerRequest> for OpenTelServerService<S>
+where
+    S: tower::Service<TonicServerRequest, Response = TonicServerResponse> + Send + Clone + 'static,
+    S::Future: Send,
+    S::Error: ToString,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxedFuture<Self::Response, Self::Error>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: TonicServerRequest) -> Self::Future {
+        let tracer = global::tracer_with_version("grpc-server", env!("CARGO_PKG_VERSION"));
+        let extractor = opentelemetry_http::HeaderExtractor(request.headers());
+
+        let parent_context =
+            global::get_text_map_propagator(|propagator| propagator.extract(&extractor));
+
+        let mut builder = tracer.span_builder(request.uri().to_string());
+        builder.parent_context = parent_context.clone();
+        builder.span_kind = Some(SpanKind::Server);
+
+        let span = tracer.build(builder);
+        let context = parent_context.with_span(span);
+
+        trace_http_service_call(&mut self.service, request, context)
+    }
+}
+
+/// We cannot simply clone a tower Service as the cloned service may not be ready for calling yet
+/// (see `poll_ready` ).
+/// The simple solution here is to clone the service but swap the clone with the original, so we can
+/// use the original service which is ready.
+fn clone_service<
+    T: tower::Service<Req, Response = Response<R>, Error = E> + Clone + Send + 'static,
+    Req: Send + 'static,
+    R,
+    E: ToString,
+>(
+    service: &mut T,
+) -> T {
+    let service_clone = service.clone();
+    std::mem::replace(service, service_clone)
+}
+
+fn trace_http_service_call<
+    T: tower::Service<Req, Response = Response<R>, Error = E> + Clone + Send + 'static,
+    Req: Send + 'static,
+    R,
+    E: ToString,
+>(
+    service: &mut T,
+    request: Req,
+    context: opentelemetry::Context,
+) -> BoxedFuture<Response<R>, E>
+where
+    <T as tower::Service<Req>>::Future: Send,
+{
+    let mut service = clone_service(service);
+    Box::pin(async move {
+        match service.call(request).with_context(context.clone()).await {
+            Ok(response) => {
+                update_span_from_response(context, &response);
+                Ok(response)
+            }
+            Err(error) => {
+                let span = context.span();
+                span.set_status(opentelemetry::trace::StatusCode::Error, error.to_string());
+                span.end();
+                Err(error)
+            }
+        }
+    })
+}
+fn update_span_from_response<T>(context: opentelemetry::Context, response: &Response<T>) {
+    let span = context.span();
+    let grpc_code = match tonic::Status::from_header_map(response.headers()) {
+        Some(status) => {
+            if status.code() == tonic::Code::Ok {
+                span.set_status(opentelemetry::trace::StatusCode::Ok, status.to_string());
+            } else {
+                span.set_status(opentelemetry::trace::StatusCode::Error, status.to_string());
+            }
+            status.code()
+        }
+        None => tonic::Code::Ok,
+    };
+    span.set_attribute(KeyValue::new(RPC_GRPC_STATUS_CODE, grpc_code as i64));
+    span.set_attribute(HTTP_STATUS_CODE.i64(response.status().as_u16() as i64));
+    span.end();
+}

--- a/control-plane/rest/service/src/v0/volumes.rs
+++ b/control-plane/rest/service/src/v0/volumes.rs
@@ -83,7 +83,7 @@ impl apis::actix_server::Volumes for RestApi {
         Path((volume_id, replica_count)): Path<(Uuid, u8)>,
     ) -> Result<models::Volume, RestError<RestJsonError>> {
         let volume = client()
-            .set_volume_replica(
+            .set_replica(
                 &SetVolumeReplica {
                     uuid: volume_id.into(),
                     replicas: replica_count,

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -32,5 +32,5 @@ reqwest = { version = "0.11.4", features = ["multipart"] }
 futures = "0.3.17"
 tracing = "0.1.28"
 tracing-subscriber = "0.2.24"
-tower = { version = "0.4" }
+tower = { version = "0.4.8", features = [ "timeout", "util" ] }
 utils = { path = "../utils/utils-lib" }

--- a/tests/tests-mayastor/src/lib.rs
+++ b/tests/tests-mayastor/src/lib.rs
@@ -26,7 +26,7 @@ pub use etcd_client;
 use etcd_client::DeleteOptions;
 use grpc::{
     client::CoreClient,
-    grpc_opts::Context,
+    context::Context,
     operations::{
         pool::traits::PoolOperations, replica::traits::ReplicaOperations,
         volume::traits::VolumeOperations,

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -35,3 +35,6 @@ pub const DEFAULT_GRPC_SERVER_ADDR: &str = "https://0.0.0.0:50051";
 
 /// The default value to be assigned as GRPC client addr if not overridden
 pub const DEFAULT_GRPC_CLIENT_ADDR: &str = "https://core:50051";
+
+/// The default value for a concurrency limit.
+pub const DEFAULT_GRPC_CLIENT_CONCURRENCY: usize = 25;


### PR DESCRIPTION
Added a tracing layer for the clients which injects tracing span context in the grpc headers.
Added a tracing layer for the servers which extracts what was injected by the client layer.

Added a new Context::spawn helper which spawns the future with the current spawn context.

Resolves: ER1-275