### PR TITLE
fix(pool spec dirty): check for pending op

### DIFF
--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -59,9 +59,9 @@ impl SpecOperations for PoolSpec {
         registry.specs().remove_pool(&id);
     }
     fn dirty(&self) -> bool {
-        // pools are not updatable currently, so the spec is never dirty (not written to etcd)
-        // because it can never change after creation
-        false
+        // The pool spec can be dirty if a pool create operation fails to complete because it cannot
+        // write to etcd.
+        self.pending_op()
     }
     fn kind(&self) -> ResourceKind {
         ResourceKind::Pool


### PR DESCRIPTION
It is possible for the pool spec to be in a "dirty" state so we should
ensure that we correctly check for this.

An issue relating to this was seen in production. It occurred when the
connection to etcd was lost in the middle of a pool creation operation.
As a consequence the pool could not subsequently be created. Manual
intervention was required to rectify this.