### PR TITLE
fix: delete resources pending deletion when the store is online

### DIFF
--- a/common/src/types/v0/store/nexus.rs
+++ b/common/src/types/v0/store/nexus.rs
@@ -388,3 +388,11 @@ impl From<NexusSpec> for DestroyNexus {
         }
     }
 }
+impl From<&NexusSpec> for DestroyNexus {
+    fn from(nexus: &NexusSpec) -> Self {
+        Self {
+            node: nexus.node.clone(),
+            uuid: nexus.uuid.clone(),
+        }
+    }
+}

--- a/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/nexus/garbage_collector.rs
@@ -53,10 +53,10 @@ async fn nexus_garbage_collector(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
 ) -> PollResult {
-    let mode = OperationMode::ReconcileStep;
     let results = vec![
         destroy_orphaned_nexus(nexus_spec, context).await,
-        destroy_disowned_nexus(nexus_spec, context, mode).await,
+        destroy_deleting_nexus(nexus_spec, context).await,
+        destroy_disowned_nexus(nexus_spec, context).await,
     ];
     GarbageCollector::squash_results(results)
 }
@@ -96,42 +96,80 @@ async fn destroy_orphaned_nexus(
 /// Given a control plane managed nexus
 /// When a nexus is not owned by a volume
 /// Then it should eventually be destroyed
-#[tracing::instrument(level = "debug", skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
+#[tracing::instrument(level = "debug", skip(nexus_spec, context), fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
 async fn destroy_disowned_nexus(
     nexus_spec: &Arc<Mutex<NexusSpec>>,
     context: &PollContext,
-    mode: OperationMode,
 ) -> PollResult {
     let _guard = match nexus_spec.operation_guard(OperationMode::ReconcileStart) {
         Ok(guard) => guard,
         Err(_) => return PollResult::Ok(PollerState::Busy),
     };
 
-    let nexus_clone = nexus_spec.lock().clone();
-    if nexus_clone.managed && !nexus_clone.owned() {
-        let node_online = matches!(context.registry().get_node_wrapper(&nexus_clone.node).await, Ok(node) if node.read().await.is_online());
-        if node_online {
-            async {
-                nexus_clone.warn_span(|| tracing::warn!("Attempting to destroy disowned nexus"));
-                let request = DestroyNexus::from(nexus_clone.clone());
-                match context
-                    .specs()
-                    .destroy_nexus(context.registry(), &request, true, mode)
-                    .await {
-                    Ok(_) => {
-                        nexus_clone.info_span(|| tracing::info!("Successfully destroyed disowned nexus"));
-                        Ok(())
-                    }
-                    Err(error) => {
-                        nexus_clone.error_span(|| tracing::error!(error = %error, "Failed to destroy disowned nexus"));
-                        Err(error)
-                    }
-                }
-            }
-            .instrument(tracing::info_span!("destroy_disowned_nexus", nexus.uuid = %nexus_clone.uuid, request.reconcile = true))
+    let not_owned = {
+        let nexus = nexus_spec.lock();
+        nexus.managed && !nexus.owned()
+    };
+    if not_owned {
+        destroy_nexus(nexus_spec, context, OperationMode::ReconcileStep)
+            .instrument(tracing::info_span!("destroy_disowned_nexus", nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))
             .await?;
-        }
     }
 
     PollResult::Ok(PollerState::Idle)
+}
+
+/// Given a control plane nexus
+/// When a nexus destruction fails
+/// Then it should eventually be destroyed
+#[tracing::instrument(level = "debug", skip(nexus_spec, context), fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
+async fn destroy_deleting_nexus(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let _guard = match nexus_spec.operation_guard(OperationMode::ReconcileStart) {
+        Ok(guard) => guard,
+        Err(_) => return PollResult::Ok(PollerState::Busy),
+    };
+
+    let deleting = nexus_spec.lock().status().deleting();
+    if deleting {
+        destroy_nexus(nexus_spec, context, OperationMode::ReconcileStep)
+                .instrument(tracing::info_span!("destroy_deleting_nexus", nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))
+                .await?;
+    }
+
+    PollResult::Ok(PollerState::Idle)
+}
+
+#[tracing::instrument(level = "trace", skip(nexus_spec, context, mode), fields(nexus.uuid = %nexus_spec.lock().uuid, request.reconcile = true))]
+async fn destroy_nexus(
+    nexus_spec: &Arc<Mutex<NexusSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let node = nexus_spec.lock().node.clone();
+    let node_online = matches!(context.registry().get_node_wrapper(&node).await, Ok(node) if node.read().await.is_online());
+    if node_online {
+        let nexus_clone = nexus_spec.lock().clone();
+        nexus_clone.warn_span(|| tracing::warn!("Attempting to destroy nexus"));
+        let request = DestroyNexus::from(&nexus_clone);
+        match context
+            .specs()
+            .destroy_nexus(context.registry(), &request, true, mode)
+            .await
+        {
+            Ok(_) => {
+                nexus_clone.info_span(|| tracing::info!("Successfully destroyed nexus"));
+                Ok(PollerState::Idle)
+            }
+            Err(error) => {
+                nexus_clone
+                    .error_span(|| tracing::error!(error = %error, "Failed to destroy nexus"));
+                Err(error)
+            }
+        }
+    } else {
+        Ok(PollerState::Idle)
+    }
 }

--- a/control-plane/agents/core/src/core/reconciler/replica/mod.rs
+++ b/control-plane/agents/core/src/core/reconciler/replica/mod.rs
@@ -2,13 +2,14 @@
 mod tests;
 
 use crate::core::{
-    specs::{OperationSequenceGuard, SpecOperations},
+    specs::{OperationSequenceGuard, ResourceSpecsLocked, SpecOperations},
     task_poller::{
         PollContext, PollEvent, PollResult, PollTimer, PollTriggerEvent, PollerState, TaskPoller,
     },
 };
-use common_lib::types::v0::{message_bus::ReplicaOwners, store::OperationMode};
-use std::ops::Deref;
+use common_lib::types::v0::store::{replica::ReplicaSpec, OperationMode};
+use parking_lot::Mutex;
+use std::sync::Arc;
 
 /// Replica reconciler
 #[derive(Debug)]
@@ -28,9 +29,15 @@ impl ReplicaReconciler {
 #[async_trait::async_trait]
 impl TaskPoller for ReplicaReconciler {
     async fn poll(&mut self, context: &PollContext) -> PollResult {
-        let mut results = vec![];
-        results.push(disown_missing_owners(context).await);
-        results.push(destroy_orphaned_replicas(context).await);
+        let replicas = context.specs().get_replicas();
+        let mut results = Vec::with_capacity(replicas.len());
+
+        for replica in replicas {
+            results.push(remove_missing_owners(&replica, context).await);
+            results.push(destroy_orphaned_replica(&replica, context).await);
+            results.push(destroy_deleting_replica(&replica, context).await);
+        }
+
         Self::squash_results(results)
     }
 
@@ -49,45 +56,45 @@ impl TaskPoller for ReplicaReconciler {
 /// Remove replica owners who no longer exist.
 /// In the event that the replicas become orphaned (have no owners) they will be destroyed by the
 /// 'destroy_orphaned_replicas' reconcile loop.
-async fn disown_missing_owners(context: &PollContext) -> PollResult {
+async fn remove_missing_owners(
+    replica: &Arc<Mutex<ReplicaSpec>>,
+    context: &PollContext,
+) -> PollResult {
     let specs = context.specs();
 
-    for replica in specs.get_replicas() {
-        // If we obtain the operation guard no one else can be modifying the replica spec.
-        if let Ok(_guard) = replica.operation_guard(OperationMode::ReconcileStart) {
-            let replica_spec = replica.lock().clone();
+    if let Ok(_guard) = replica.operation_guard(OperationMode::ReconcileStart) {
+        let replica_spec = replica.lock().clone();
 
-            if replica_spec.managed && replica_spec.owned() {
-                let mut owner_removed = false;
-                let owners = &replica_spec.owners;
+        if replica_spec.managed && replica_spec.owned() {
+            let mut owner_removed = false;
+            let owners = &replica_spec.owners;
 
-                if let Some(volume) = owners.volume() {
-                    if specs.get_volume(volume).is_err() {
-                        // The volume no longer exists. Remove it as an owner.
-                        replica.lock().owners.disowned_by_volume();
-                        owner_removed = true;
-                        tracing::info!(replica.uuid=%replica_spec.uuid, volume.uuid=%volume, "Removed volume as replica owner");
-                    }
-                };
+            if let Some(volume) = owners.volume() {
+                if specs.get_volume(volume).is_err() {
+                    // The volume no longer exists. Remove it as an owner.
+                    replica.lock().owners.disowned_by_volume();
+                    owner_removed = true;
+                    tracing::info!(replica.uuid=%replica_spec.uuid, volume.uuid=%volume, "Removed volume as replica owner");
+                }
+            };
 
-                owners.nexuses().iter().for_each(|nexus| {
-                    if specs.get_nexus(nexus).is_none() {
-                        // The nexus no longer exists. Remove it as an owner.
-                        replica.lock().owners.disowned_by_nexus(nexus);
-                        owner_removed = true;
-                        tracing::info!(replica.uuid=%replica_spec.uuid, nexus.uuid=%nexus, "Removed nexus as replica owner");
-                    }
-                });
+            owners.nexuses().iter().for_each(|nexus| {
+                if specs.get_nexus(nexus).is_none() {
+                    // The nexus no longer exists. Remove it as an owner.
+                    replica.lock().owners.disowned_by_nexus(nexus);
+                    owner_removed = true;
+                    tracing::info!(replica.uuid=%replica_spec.uuid, nexus.uuid=%nexus, "Removed nexus as replica owner");
+                }
+            });
 
-                if owner_removed {
-                    let replica_clone = replica.lock().clone();
-                    if let Err(error) = context.registry().store_obj(&replica_clone).await {
-                        // Log the fact that we couldn't persist the changes.
-                        // If we reload the stale info from the persistent store (on a restart) we
-                        // will run this reconcile loop again and tidy it up, so no need to retry
-                        // here.
-                        tracing::error!(replica.uuid=%replica_clone.uuid, error=%error, "Failed to persist disowned replica")
-                    }
+            if owner_removed {
+                let replica_clone = replica.lock().clone();
+                if let Err(error) = context.registry().store_obj(&replica_clone).await {
+                    // Log the fact that we couldn't persist the changes.
+                    // If we reload the stale info from the persistent store (on a restart) we
+                    // will run this reconcile loop again and tidy it up, so no need to retry
+                    // here.
+                    tracing::error!(replica.uuid=%replica_clone.uuid, error=%error, "Failed to persist disowned replica")
                 }
             }
         }
@@ -98,34 +105,80 @@ async fn disown_missing_owners(context: &PollContext) -> PollResult {
 
 /// Destroy orphaned replicas.
 /// Orphaned replicas are those that are managed but which don't have any owners.
-async fn destroy_orphaned_replicas(context: &PollContext) -> PollResult {
-    for replica in context.specs().get_replicas() {
-        let _guard = match replica.operation_guard(OperationMode::ReconcileStart) {
-            Ok(guard) => guard,
-            Err(_) => return PollResult::Ok(PollerState::Busy),
-        };
+async fn destroy_orphaned_replica(
+    replica: &Arc<Mutex<ReplicaSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let _guard = match replica.operation_guard(OperationMode::ReconcileStart) {
+        Ok(guard) => guard,
+        Err(_) => return PollResult::Ok(PollerState::Busy),
+    };
 
-        let replica_spec = replica.lock().deref().clone();
-        if replica_spec.managed && !replica_spec.owned() {
-            match context
-                .specs()
-                .destroy_replica_spec(
-                    context.registry(),
-                    &replica_spec,
-                    ReplicaOwners::default(),
-                    false,
-                    OperationMode::ReconcileStep,
-                )
-                .await
-            {
-                Ok(_) => {
-                    tracing::info!(replica.uuid=%replica_spec.uuid, "Successfully destroyed orphaned replica");
-                }
-                Err(e) => {
-                    tracing::trace!(replica.uuid=%replica_spec.uuid, error=%e, "Failed to destroy orphaned replica");
-                }
+    let destroy_owned = {
+        let replica = replica.lock();
+        replica.managed && !replica.owned()
+    };
+
+    if destroy_owned {
+        destroy_replica(replica, context).await
+    } else {
+        PollResult::Ok(PollerState::Idle)
+    }
+}
+
+/// Given a control plane replica
+/// When its destruction fails
+/// Then it should eventually be destroyed
+async fn destroy_deleting_replica(
+    replica_spec: &Arc<Mutex<ReplicaSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let _guard = match replica_spec.operation_guard(OperationMode::ReconcileStart) {
+        Ok(guard) => guard,
+        Err(_) => return PollResult::Ok(PollerState::Busy),
+    };
+
+    let deleting = replica_spec.lock().status().deleting();
+    if deleting {
+        destroy_replica(replica_spec, context).await
+    } else {
+        PollResult::Ok(PollerState::Idle)
+    }
+}
+
+#[tracing::instrument(level = "debug", skip(replica_spec, context), fields(replica.uuid = %replica_spec.lock().uuid, request.reconcile = true))]
+async fn destroy_replica(
+    replica_spec: &Arc<Mutex<ReplicaSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let replica_clone = replica_spec.lock().clone();
+    if let Some(node) =
+        ResourceSpecsLocked::get_replica_node(context.registry(), &replica_clone).await
+    {
+        match context
+            .specs()
+            .destroy_replica(
+                context.registry(),
+                &ResourceSpecsLocked::destroy_replica_request(
+                    replica_clone,
+                    Default::default(),
+                    &node,
+                ),
+                true,
+                OperationMode::ReconcileStep,
+            )
+            .await
+        {
+            Ok(_) => {
+                tracing::info!(replica.uuid=%replica_spec.lock().uuid, "Successfully destroyed replica");
+                PollResult::Ok(PollerState::Idle)
+            }
+            Err(e) => {
+                tracing::trace!(replica.uuid=%replica_spec.lock().uuid, error=%e, "Failed to destroy replica");
+                PollResult::Err(e)
             }
         }
+    } else {
+        PollResult::Ok(PollerState::Busy)
     }
-    PollResult::Ok(PollerState::Idle)
 }

--- a/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
+++ b/control-plane/agents/core/src/core/reconciler/volume/garbage_collector.rs
@@ -9,11 +9,12 @@ use common_lib::types::v0::store::{volume::VolumeSpec, OperationMode, TraceSpan,
 use crate::core::specs::SpecOperations;
 use common::errors::SvcError;
 use common_lib::types::v0::{
-    message_bus::VolumeStatus,
+    message_bus::{DestroyVolume, VolumeStatus},
     store::{nexus_persistence::NexusInfo, replica::ReplicaSpec},
 };
 use parking_lot::Mutex;
 use std::sync::Arc;
+use tracing::Instrument;
 
 /// Volume Garbage Collector reconciler
 #[derive(Debug)]
@@ -34,6 +35,7 @@ impl TaskPoller for GarbageCollector {
     async fn poll(&mut self, context: &PollContext) -> PollResult {
         let mut results = vec![];
         for volume in context.specs().get_locked_volumes() {
+            results.push(destroy_deleting_volume(&volume, context).await);
             results.push(disown_unused_nexuses(&volume, context).await);
             results.push(disown_unused_replicas(&volume, context).await);
         }
@@ -50,6 +52,52 @@ impl TaskPoller for GarbageCollector {
             | PollEvent::Triggered(PollTriggerEvent::VolumeDegraded)
             | PollEvent::Triggered(PollTriggerEvent::Start) => true,
             PollEvent::Shutdown | PollEvent::Triggered(_) => false,
+        }
+    }
+}
+
+#[tracing::instrument(level = "trace", skip(volume_spec, context), fields(volume.uuid = %volume_spec.lock().uuid, request.reconcile = true))]
+async fn destroy_deleting_volume(
+    volume_spec: &Arc<Mutex<VolumeSpec>>,
+    context: &PollContext,
+) -> PollResult {
+    let _guard = match volume_spec.operation_guard(OperationMode::ReconcileStart) {
+        Ok(guard) => guard,
+        Err(_) => return PollResult::Ok(PollerState::Busy),
+    };
+
+    let deleting = volume_spec.lock().status().deleting();
+    if deleting {
+        destroy_volume(volume_spec, context, OperationMode::ReconcileStep)
+            .instrument(tracing::info_span!("destroy_deleting_volume", volume.uuid = %volume_spec.lock().uuid, request.reconcile = true))
+            .await
+    } else {
+        PollResult::Ok(PollerState::Idle)
+    }
+}
+
+async fn destroy_volume(
+    volume_spec: &Arc<Mutex<VolumeSpec>>,
+    context: &PollContext,
+    mode: OperationMode,
+) -> PollResult {
+    let uuid = volume_spec.lock().uuid.clone();
+    match context
+        .specs()
+        .destroy_volume(context.registry(), &DestroyVolume::new(&uuid), mode)
+        .await
+    {
+        Ok(_) => {
+            volume_spec
+                .lock()
+                .info_span(|| tracing::info!("Successfully destroyed volume"));
+            Ok(PollerState::Idle)
+        }
+        Err(error) => {
+            volume_spec
+                .lock()
+                .error_span(|| tracing::error!(error = %error, "Failed to destroy volume"));
+            Err(error)
         }
     }
 }

--- a/control-plane/agents/core/src/nexus/specs.rs
+++ b/control-plane/agents/core/src/nexus/specs.rs
@@ -1,6 +1,6 @@
 use crate::core::{
     registry::Registry,
-    specs::{OperationSequenceGuard, ResourceSpecs, ResourceSpecsLocked, SpecOperations},
+    specs::{ResourceSpecs, ResourceSpecsLocked, SpecOperations},
     wrapper::ClientOps,
 };
 use common::errors::{NexusNotFound, SvcError};
@@ -16,12 +16,11 @@ use common_lib::{
             nexus::{NexusOperation, NexusSpec},
             nexus_child::NexusChild,
             replica::ReplicaSpec,
-            OperationMode, SpecStatus, SpecTransaction,
+            OperationMode, SpecStatus, SpecTransaction, TraceSpan,
         },
     },
 };
 
-use common_lib::types::v0::store::TraceSpan;
 use parking_lot::Mutex;
 use snafu::OptionExt;
 use std::sync::Arc;
@@ -108,6 +107,9 @@ impl SpecOperations for NexusSpec {
     fn disown_all(&mut self) {
         self.owner.take();
     }
+    fn operation_result(&self) -> Option<Option<bool>> {
+        self.operation.as_ref().map(|r| r.result)
+    }
 }
 
 /// Implementation of the ResourceSpecs which is retrieved from the ResourceSpecsLocked
@@ -166,7 +168,8 @@ impl ResourceSpecsLocked {
         let node = registry.get_node_wrapper(&request.node).await?;
 
         let nexus_spec = self.get_or_create_nexus(request);
-        SpecOperations::start_create(&nexus_spec, registry, request, mode).await?;
+        let (_, _guard) =
+            SpecOperations::start_create(&nexus_spec, registry, request, mode).await?;
 
         let result = node.create_nexus(request).await;
         self.on_create_set_owners(request, &nexus_spec, &result);
@@ -515,65 +518,14 @@ impl ResourceSpecsLocked {
     /// This is useful when nexus operations are performed but we fail to
     /// update the spec with the persistent store.
     pub async fn reconcile_dirty_nexuses(&self, registry: &Registry) -> bool {
-        if registry.store_online().await {
-            let mut pending_count = 0;
-
-            let nexuses = self.get_nexuses();
-            for nexus_spec in nexuses {
-                let (mut nexus_clone, _guard) = {
-                    if let Ok(guard) = nexus_spec.operation_guard(OperationMode::ReconcileStart) {
-                        let nexus = nexus_spec.lock();
-                        if !nexus.spec_status.created() {
-                            continue;
-                        }
-                        (nexus.clone(), guard)
-                    } else {
-                        continue;
-                    }
-                };
-
-                if let Some(op) = nexus_clone.operation.clone() {
-                    let fail = !match op.result {
-                        Some(true) => {
-                            nexus_clone.commit_op();
-                            let result = registry.store_obj(&nexus_clone).await;
-                            if result.is_ok() {
-                                let mut nexus = nexus_spec.lock();
-                                nexus.commit_op();
-                            }
-                            result.is_ok()
-                        }
-                        Some(false) => {
-                            nexus_clone.clear_op();
-                            let result = registry.store_obj(&nexus_clone).await;
-                            if result.is_ok() {
-                                let mut nexus = nexus_spec.lock();
-                                nexus.clear_op();
-                            }
-                            result.is_ok()
-                        }
-                        None => {
-                            // we must have crashed... we could check the node to see what the
-                            // current state is but for now assume failure
-                            nexus_clone.clear_op();
-                            let result = registry.store_obj(&nexus_clone).await;
-                            if result.is_ok() {
-                                let mut nexus = nexus_spec.lock();
-                                nexus.clear_op();
-                            }
-                            result.is_ok()
-                        }
-                    };
-                    if fail {
-                        pending_count += 1;
-                    }
-                } else {
-                    // No operation to reconcile.
-                }
+        let mut pending_ops = false;
+        let nexuses = self.get_nexuses();
+        for nexus in nexuses {
+            if !SpecOperations::handle_incomplete_ops(&nexus, registry).await {
+                // Not all pending operations could be handled.
+                pending_ops = true;
             }
-            pending_count > 0
-        } else {
-            true
         }
+        pending_ops
     }
 }

--- a/control-plane/agents/core/src/pool/registry.rs
+++ b/control-plane/agents/core/src/pool/registry.rs
@@ -14,13 +14,10 @@ impl Registry {
             None => {
                 let mut pools = vec![];
                 let pools_from_state =
-                    self.get_pool_states_inner()
-                        .await?
-                        .into_iter()
-                        .map(|state| {
-                            let spec = self.specs().get_pool(&state.id).ok();
-                            Pool::from_state(state, spec)
-                        });
+                    self.get_pool_states_inner().await.into_iter().map(|state| {
+                        let spec = self.specs().get_pool(&state.id).ok();
+                        Pool::from_state(state, spec)
+                    });
 
                 pools.extend(pools_from_state);
 
@@ -79,19 +76,19 @@ impl Registry {
     }
 
     /// Get all pools
-    pub(crate) async fn get_pool_states_inner(&self) -> Result<Vec<PoolState>, SvcError> {
+    pub(crate) async fn get_pool_states_inner(&self) -> Vec<PoolState> {
         let nodes = self.get_node_wrappers().await;
-        let mut pools = vec![];
+        let mut pools = Vec::with_capacity(nodes.len());
         for node in nodes {
             pools.append(&mut node.pools().await)
         }
-        Ok(pools)
+        pools
     }
 
     /// Get all pool wrappers
     pub(crate) async fn get_pool_wrappers(&self) -> Vec<PoolWrapper> {
         let nodes = self.get_node_wrappers().await;
-        let mut pools = vec![];
+        let mut pools = Vec::with_capacity(nodes.len());
         for node in nodes {
             pools.append(&mut node.pool_wrappers().await)
         }

--- a/control-plane/agents/core/src/pool/specs.rs
+++ b/control-plane/agents/core/src/pool/specs.rs
@@ -1,6 +1,6 @@
 use crate::{
     core::{
-        specs::{OperationSequenceGuard, ResourceSpecs, ResourceSpecsLocked, SpecOperations},
+        specs::{ResourceSpecs, ResourceSpecsLocked, SpecOperations},
         wrapper::ClientOps,
     },
     registry::Registry,
@@ -21,7 +21,6 @@ use common_lib::{
         },
     },
 };
-
 use parking_lot::Mutex;
 use std::sync::Arc;
 
@@ -74,6 +73,9 @@ impl SpecOperations for PoolSpec {
     }
     fn set_status(&mut self, status: SpecStatus<Self::Status>) {
         self.status = status;
+    }
+    fn operation_result(&self) -> Option<Option<bool>> {
+        self.operation.as_ref().map(|r| r.result)
     }
 }
 
@@ -148,6 +150,9 @@ impl SpecOperations for ReplicaSpec {
     }
     fn disown_all(&mut self) {
         self.owners.disown_all();
+    }
+    fn operation_result(&self) -> Option<Option<bool>> {
+        self.operation.as_ref().map(|r| r.result)
     }
 }
 
@@ -414,69 +419,35 @@ impl ResourceSpecsLocked {
         specs.replicas.to_vec()
     }
 
+    /// Worker that reconciles dirty PoolSpec's with the persistent store.
+    /// This is useful when pool operations are performed but we fail to
+    /// update the spec with the persistent store.
+    pub(crate) async fn reconcile_dirty_pools(&self, registry: &Registry) -> bool {
+        let mut pending_ops = false;
+
+        let pools = self.get_locked_pools();
+        for pool in pools {
+            if !SpecOperations::handle_incomplete_ops(&pool, registry).await {
+                // Not all pending operations could be handled.
+                pending_ops = true;
+            }
+        }
+        pending_ops
+    }
+
     /// Worker that reconciles dirty ReplicaSpec's with the persistent store.
     /// This is useful when replica operations are performed but we fail to
     /// update the spec with the persistent store.
     pub(crate) async fn reconcile_dirty_replicas(&self, registry: &Registry) -> bool {
-        if registry.store_online().await {
-            let mut pending_count = 0;
+        let mut pending_ops = false;
 
-            let replicas = self.get_replicas();
-            for replica_spec in replicas {
-                let (mut replica_clone, _guard) = {
-                    if let Ok(guard) = replica_spec.operation_guard(OperationMode::ReconcileStart) {
-                        let replica = replica_spec.lock();
-                        if !replica.status.created() {
-                            continue;
-                        }
-                        (replica.clone(), guard)
-                    } else {
-                        continue;
-                    }
-                };
-
-                if let Some(op) = replica_clone.operation.clone() {
-                    let fail = !match op.result {
-                        Some(true) => {
-                            replica_clone.commit_op();
-                            let result = registry.store_obj(&replica_clone).await;
-                            if result.is_ok() {
-                                let mut replica = replica_spec.lock();
-                                replica.commit_op();
-                            }
-                            result.is_ok()
-                        }
-                        Some(false) => {
-                            replica_clone.clear_op();
-                            let result = registry.store_obj(&replica_clone).await;
-                            if result.is_ok() {
-                                let mut replica = replica_spec.lock();
-                                replica.clear_op();
-                            }
-                            result.is_ok()
-                        }
-                        None => {
-                            // we must have crashed... we could check the node to see what the
-                            // current state is but for now assume failure
-                            replica_clone.clear_op();
-                            let result = registry.store_obj(&replica_clone).await;
-                            if result.is_ok() {
-                                let mut replica = replica_spec.lock();
-                                replica.clear_op();
-                            }
-                            result.is_ok()
-                        }
-                    };
-                    if fail {
-                        pending_count += 1;
-                    }
-                } else {
-                    // No operation to reconcile.
-                }
+        let replicas = self.get_replicas();
+        for replica in replicas {
+            if !SpecOperations::handle_incomplete_ops(&replica, registry).await {
+                // Not all pending operations could be handled.
+                pending_ops = true;
             }
-            pending_count > 0
-        } else {
-            true
         }
+        pending_ops
     }
 }

--- a/control-plane/agents/core/src/volume/specs.rs
+++ b/control-plane/agents/core/src/volume/specs.rs
@@ -10,7 +10,7 @@ use crate::{
             },
             ResourceFilter,
         },
-        specs::{OperationSequenceGuard, ResourceSpecs, ResourceSpecsLocked, SpecOperations},
+        specs::{ResourceSpecs, ResourceSpecsLocked, SpecOperations},
     },
     registry::Registry,
     volume::scheduling,
@@ -287,7 +287,7 @@ impl ResourceSpecsLocked {
         registry: &Registry,
         replica: &ReplicaSpec,
     ) -> Option<NodeId> {
-        let pools = registry.get_pool_states_inner().await.unwrap();
+        let pools = registry.get_pool_states_inner().await;
         pools.iter().find_map(|p| {
             if p.id == replica.pool {
                 Some(p.node.clone())
@@ -587,10 +587,20 @@ impl ResourceSpecsLocked {
         // Share the Nexus if it was requested
         let mut result = Ok(nexus.clone());
         if let Some(share) = request.share {
-            result = self
+            result = match self
                 .share_nexus(registry, &ShareNexus::from((&nexus, None, share)), mode)
                 .await
-                .map(|_| nexus);
+            {
+                Ok(_) => Ok(nexus),
+                Err(error) => {
+                    // Since we failed to share, we'll revert back to the previous state.
+                    // If we fail to do this inline, the reconcilers will pick up the slack.
+                    self.destroy_nexus(registry, &DestroyNexus::from(nexus), true, mode)
+                        .await
+                        .ok();
+                    Err(error)
+                }
+            }
         }
 
         SpecOperations::complete_update(registry, result, spec, spec_clone.clone()).await?;
@@ -1372,73 +1382,16 @@ impl ResourceSpecsLocked {
     /// This is useful when nexus operations are performed but we fail to
     /// update the spec with the persistent store.
     pub async fn reconcile_dirty_volumes(&self, registry: &Registry) -> bool {
-        if registry.store_online().await {
-            let mut pending_count = 0;
+        let mut pending_ops = false;
 
-            let volumes = self.get_locked_volumes();
-            for volume_spec in volumes {
-                let (mut volume_clone, _guard) = {
-                    if let Ok(guard) = volume_spec.operation_guard(OperationMode::ReconcileStart) {
-                        let volume = volume_spec.lock().clone();
-                        if !volume.status.created() {
-                            if volume.status.creating() {
-                                // An attempt to create the volume failed. Delete the spec from the
-                                // persistent store and registry.
-                                SpecOperations::delete_spec(registry, &volume_spec)
-                                    .await
-                                    .ok();
-                            }
-                            continue;
-                        }
-                        (volume.clone(), guard)
-                    } else {
-                        continue;
-                    }
-                };
-
-                if let Some(op) = volume_clone.operation.clone() {
-                    let fail = !match op.result {
-                        Some(true) => {
-                            volume_clone.commit_op();
-                            let result = registry.store_obj(&volume_clone).await;
-                            if result.is_ok() {
-                                let mut volume = volume_spec.lock();
-                                volume.commit_op();
-                            }
-                            result.is_ok()
-                        }
-                        Some(false) => {
-                            volume_clone.clear_op();
-                            let result = registry.store_obj(&volume_clone).await;
-                            if result.is_ok() {
-                                let mut volume = volume_spec.lock();
-                                volume.clear_op();
-                            }
-                            result.is_ok()
-                        }
-                        None => {
-                            // we must have crashed... we could check the node to see what the
-                            // current state is but for now assume failure
-                            volume_clone.clear_op();
-                            let result = registry.store_obj(&volume_clone).await;
-                            if result.is_ok() {
-                                let mut volume = volume_spec.lock();
-                                volume.clear_op();
-                            }
-                            result.is_ok()
-                        }
-                    };
-                    if fail {
-                        pending_count += 1;
-                    }
-                } else {
-                    // No operation to reconcile.
-                }
+        let volumes = self.get_locked_volumes();
+        for volume_spec in volumes {
+            if !SpecOperations::handle_incomplete_ops(&volume_spec, registry).await {
+                // Not all pending operations could be handled.
+                pending_ops = true;
             }
-            pending_count > 0
-        } else {
-            true
         }
+        pending_ops
     }
 }
 
@@ -1677,5 +1630,8 @@ impl SpecOperations for VolumeSpec {
     }
     fn set_status(&mut self, status: SpecStatus<Self::Status>) {
         self.status = status;
+    }
+    fn operation_result(&self) -> Option<Option<bool>> {
+        self.operation.as_ref().map(|r| r.result)
     }
 }


### PR DESCRIPTION
When the persistent store (etcd) is not online, we may not be able to delete resources. They remain
in the deleting state.
Mimic the volume dirty spec reconciler for other resources and simply delete them if the creation
was not successful.

Destroy resources in the deleting state from their garbage collection reconciler.

Resolves: CAS-1300