### PR TITLE
fix: fix run on arm64

### DIFF
--- a/chart/templates/csi-node-daemonset.yaml
+++ b/chart/templates/csi-node-daemonset.yaml
@@ -21,8 +21,6 @@ spec:
     spec:
       serviceAccount: mayastor-service-account
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
       # NOTE: Each container must have mem/cpu limits defined in order to
       # belong to Guaranteed QoS class, hence can never get evicted in case of
       # pressure unless they exceed those limits. limits and requests must be

--- a/deploy/csi-node-daemonset.yaml
+++ b/deploy/csi-node-daemonset.yaml
@@ -23,8 +23,6 @@ spec:
     spec:
       serviceAccount: mayastor-service-account
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/arch: amd64
       # NOTE: Each container must have mem/cpu limits defined in order to
       # belong to Guaranteed QoS class, hence can never get evicted in case of
       # pressure unless they exceed those limits. limits and requests must be


### PR DESCRIPTION
Mayastor can run on arm64 now, not just x86_64.
See verfied result here:
https://linaro.atlassian.net/browse/STOR-35

Signed-off-by: Xinliang Liu <xinliang.liu@linaro.org>

This PR is related to Mayastor arm64 support: https://github.com/openebs/mayastor/issues/1063