### PR TITLE
fix(delay): only lock nodes list when necessary

### DIFF
--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -261,7 +261,9 @@ impl Registry {
     async fn poller(&self) {
         loop {
             {
-                let nodes = self.nodes().read().await;
+                // Clone the nodes so we don't hold the read lock on the nodes list while
+                // we may be busy or waiting on node information being fetched.
+                let nodes = self.nodes().read().await.clone();
                 for (_, node) in nodes.iter() {
                     let (id, online) = {
                         let node = node.read().await;

--- a/control-plane/agents/core/src/core/wrapper.rs
+++ b/control-plane/agents/core/src/core/wrapper.rs
@@ -129,6 +129,11 @@ impl NodeWrapper {
         )
     }
 
+    /// Get the `NodeStateFetcher` to fetch information from the data-plane.
+    pub(crate) fn fetcher(&self) -> NodeStateFetcher {
+        NodeStateFetcher::new(self.node_state.clone())
+    }
+
     /// Whether the watchdog deadline has expired
     pub(crate) fn registration_expired(&self) -> bool {
         self.watchdog.timestamp().elapsed() > self.watchdog.deadline()
@@ -358,7 +363,7 @@ impl NodeWrapper {
         );
 
         let mut client = self.grpc_client().await?;
-        match self.fetch_resources(&mut client).await {
+        match self.fetcher().fetch_resources(&mut client).await {
             Ok((replicas, pools, nexuses)) => {
                 let mut states = self.resources_mut();
                 states.update(pools, replicas, nexuses);
@@ -420,6 +425,51 @@ impl NodeWrapper {
         }
     }
 
+    /// Update all the nexus states.
+    async fn update_nexus_states(
+        node: &Arc<tokio::sync::RwLock<NodeWrapper>>,
+        client: &mut GrpcClient,
+    ) -> Result<(), SvcError> {
+        let nexuses = node.read().await.fetcher().fetch_nexuses(client).await?;
+        node.write().await.resources_mut().update_nexuses(nexuses);
+        Ok(())
+    }
+
+    /// Update all the pool states.
+    async fn update_pool_states(
+        node: &Arc<tokio::sync::RwLock<NodeWrapper>>,
+        client: &mut GrpcClient,
+    ) -> Result<(), SvcError> {
+        let pools = node.read().await.fetcher().fetch_pools(client).await?;
+        node.write().await.resources_mut().update_pools(pools);
+        Ok(())
+    }
+
+    /// Update all the replica states.
+    async fn update_replica_states(
+        node: &Arc<tokio::sync::RwLock<NodeWrapper>>,
+        client: &mut GrpcClient,
+    ) -> Result<(), SvcError> {
+        let replicas = node.read().await.fetcher().fetch_replicas(client).await?;
+        node.write().await.resources_mut().update_replicas(replicas);
+        Ok(())
+    }
+}
+
+/// Fetches node state from the dataplane.
+#[derive(Debug, Clone)]
+pub(crate) struct NodeStateFetcher {
+    /// inner Node state
+    node_state: NodeState,
+}
+impl NodeStateFetcher {
+    /// Get new `Self` from the `NodeState`.
+    fn new(node_state: NodeState) -> Self {
+        Self { node_state }
+    }
+    fn id(&self) -> &NodeId {
+        self.node_state.id()
+    }
     /// Fetch the various resources from Mayastor.
     async fn fetch_resources(
         &self,
@@ -505,27 +555,6 @@ impl NodeWrapper {
             })
             .collect();
         Ok(nexuses)
-    }
-
-    /// Update all the nexus states.
-    async fn update_nexus_states(&self, client: &mut GrpcClient) -> Result<(), SvcError> {
-        let nexuses = self.fetch_nexuses(client).await?;
-        self.resources_mut().update_nexuses(nexuses);
-        Ok(())
-    }
-
-    /// Update all the pool states.
-    async fn update_pool_states(&self, client: &mut GrpcClient) -> Result<(), SvcError> {
-        let pools = self.fetch_pools(client).await?;
-        self.resources_mut().update_pools(pools);
-        Ok(())
-    }
-
-    /// Update all the replica states.
-    async fn update_replica_states(&self, client: &mut GrpcClient) -> Result<(), SvcError> {
-        let replicas = self.fetch_replicas(client).await?;
-        self.resources_mut().update_replicas(replicas);
-        Ok(())
     }
 }
 
@@ -644,23 +673,23 @@ impl InternalOps for Arc<tokio::sync::RwLock<NodeWrapper>> {
     }
 
     async fn update_nexus_states(&self, mut ctx: &mut GrpcClient) -> Result<(), SvcError> {
-        self.read().await.update_nexus_states(ctx.deref_mut()).await
+        NodeWrapper::update_nexus_states(self, ctx.deref_mut()).await
     }
 
     async fn update_pool_states(&self, mut ctx: &mut GrpcClient) -> Result<(), SvcError> {
-        self.read().await.update_pool_states(ctx.deref_mut()).await
+        NodeWrapper::update_pool_states(self, ctx.deref_mut()).await
     }
 
     async fn update_replica_states(&self, mut ctx: &mut GrpcClient) -> Result<(), SvcError> {
-        let node = self.read().await;
-        node.update_replica_states(ctx.deref_mut()).await
+        NodeWrapper::update_replica_states(self, ctx.deref_mut()).await
     }
 
     async fn update_all(&self, setting_online: bool) -> Result<(), SvcError> {
         let ctx = self.read().await.grpc_context_ext(GETS_TIMEOUT)?;
         match ctx.connect_locked().await {
             Ok(mut lock) => {
-                let results = self.read().await.fetch_resources(lock.deref_mut()).await;
+                let node_fetcher = self.read().await.fetcher();
+                let results = node_fetcher.fetch_resources(lock.deref_mut()).await;
 
                 let mut node = self.write().await;
                 node.update(setting_online, results)

--- a/control-plane/csi-driver/node/src/node.rs
+++ b/control-plane/csi-driver/node/src/node.rs
@@ -505,6 +505,8 @@ impl node_server::Node for Node {
     ) -> Result<Response<NodeUnstageVolumeResponse>, Status> {
         let msg = request.into_inner();
 
+        trace!("node_unstage_volume {:?}", msg);
+
         if msg.volume_id.is_empty() {
             return Err(failure!(
                 Code::InvalidArgument,

--- a/deploy/terraform/mod/csi-node/main.tf
+++ b/deploy/terraform/mod/csi-node/main.tf
@@ -30,6 +30,7 @@ resource "kubernetes_daemonset" "csi_node" {
       }
 
       spec {
+        service_account_name = "mayastor-service-account"
         termination_grace_period_seconds = var.grace_period
 
         volume {
@@ -122,10 +123,6 @@ resource "kubernetes_daemonset" "csi_node" {
             value = "1"
           }
 
-          env {
-            name  = "RUST_LOG"
-            value = var.rust_log
-          }
 
           volume_mount {
             name       = "device"

--- a/tests/bdd/features/volume/nexus/test_feature.py
+++ b/tests/bdd/features/volume/nexus/test_feature.py
@@ -1,4 +1,6 @@
 """Managing a Volume Nexus Target feature tests."""
+import time
+
 import os
 
 from pytest_bdd import given, scenario, then, when
@@ -49,8 +51,10 @@ def a_published_selfhealing_volume():
 @when("its nexus target is faulted")
 def its_nexus_target_is_faulted():
     """its nexus target is faulted."""
-    # Kill remote mayastor instance, which should fault the volume nexus child
-    Docker.kill_container(MAYASTOR_2)
+    # Stop remote mayastor instance, which should fault the volume nexus child
+    # By Stopping instead of killing, the control plane should see the node is down due to the
+    # DeRegister event.
+    Docker.stop_container(MAYASTOR_2)
     check_target_faulted()
 
 


### PR DESCRIPTION
Ensure that we don't hold on to the nodes list lock while waiting on
nodes.

While fetching node information we now don't hold the nodes list lock as they may prevent
other writers or readers (if a write is waiting) from proceeding which may cause GET delays.
Also, don't hold on to the read lock while fetching node information since we already have
the grpc lock for exclusivity.

Note: This change is to fix the occasional timeouts that we are seeing on CI.