### PR TITLE
feat: add --request-timeout flag to MSP deployment

### DIFF
--- a/chart/templates/msp-deployment.yaml
+++ b/chart/templates/msp-deployment.yaml
@@ -27,6 +27,7 @@ spec:
           imagePullPolicy: {{ .Values.mayastorCP.pullPolicy }}
           args:
             - "-e http://rest:8081"
+            - "--request-timeout={{ .Values.base.default_req_timeout }}"
             - "--interval={{ .Values.base.cache_poll_period }}"{{ if .Values.base.jaeger.enabled }}
             - "--jaeger={{ .Values.base.jaeger.agent.name }}:{{ .Values.base.jaeger.agent.port }}"{{ end }}
           env:

--- a/control-plane/msp-operator/src/main.rs
+++ b/control-plane/msp-operator/src/main.rs
@@ -888,8 +888,16 @@ async fn pool_controller(args: ArgMatches<'_>) -> anyhow::Result<()> {
     let msp: Api<MayastorPool> = Api::namespaced(k8s.clone(), namespace);
     let lp = ListParams::default();
     let url = Url::parse(args.value_of("endpoint").unwrap()).expect("endpoint is not a valid URL");
-    let cfg = clients::tower::Configuration::new(url, Duration::from_secs(5), None, None, true)
-        .map_err(|error| {
+
+    let timeout: Duration = args
+        .value_of("request-timeout")
+        .unwrap()
+        .parse::<humantime::Duration>()
+        .expect("timeout value is invalid")
+        .into();
+
+    let cfg =
+        clients::tower::Configuration::new(url, timeout, None, None, true).map_err(|error| {
             anyhow::anyhow!(
                 "Failed to create openapi configuration, Error: '{:?}'",
                 error
@@ -965,6 +973,14 @@ async fn main() -> anyhow::Result<()> {
                 .env("INTERVAL")
                 .default_value(utils::CACHE_POLL_PERIOD)
                 .help("specify timer based reconciliation loop"),
+        )
+        .arg(
+            Arg::with_name("request-timeout")
+                .short("t")
+                .long("request-timeout")
+                .env("REQUEST_TIMEOUT")
+                .default_value(utils::DEFAULT_REQ_TIMEOUT)
+                .help("the timeout for remote requests"),
         )
         .arg(
             Arg::with_name("retries")

--- a/deploy/core-agents-deployment.yaml
+++ b/deploy/core-agents-deployment.yaml
@@ -23,8 +23,7 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
-            sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:

--- a/deploy/csi-controller-deployment.yaml
+++ b/deploy/csi-controller-deployment.yaml
@@ -26,8 +26,7 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz rest 8081; do echo "Waiting for REST API endpoint
-            to become available"; sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz rest 8081; do echo "Waiting for REST API endpoint to become available"; sleep 1; done;
           image: busybox:latest
           name: rest-probe
       containers:

--- a/deploy/msp-deployment.yaml
+++ b/deploy/msp-deployment.yaml
@@ -24,15 +24,13 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz core 50051; do echo "Waiting for grpc services...";
-            sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz core 50051; do echo "Waiting for grpc services..."; sleep 1; done;
           image: busybox:latest
           name: grpc-probe
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
-            sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:
@@ -48,6 +46,7 @@ spec:
           imagePullPolicy: Always
           args:
             - "-e http://rest:8081"
+            - "--request-timeout=5s"
             - "--interval=30s"
           env:
             - name: RUST_LOG

--- a/deploy/rest-deployment.yaml
+++ b/deploy/rest-deployment.yaml
@@ -23,15 +23,13 @@ spec:
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz core 50051; do echo "Waiting for grpc services...";
-            sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz core 50051; do echo "Waiting for grpc services..."; sleep 1; done;
           image: busybox:latest
           name: grpc-probe
         - command:
           - sh
           - -c
-          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd...";
-            sleep 1; done;
+          - trap "exit 1" TERM; until nc -vz mayastor-etcd 2379; do echo "Waiting for etcd..."; sleep 1; done;
           image: busybox:latest
           name: etcd-probe
       containers:


### PR DESCRIPTION
Adds a `--request-timeout` flag to the MSP operator, and sets the `default_req_timeout` Helm value (also used by core and rest) to `5s`.  The default could probably be increased.

Fixes https://github.com/openebs/mayastor/issues/1138