### PR TITLE
chore(terraform): public ssh key

### DIFF
--- a/terraform/cluster/main.tf
+++ b/terraform/cluster/main.tf
@@ -35,7 +35,7 @@ output "kluster" {
 }
 
 locals {
-  ssh_key_pub  = var.ssh_key_pub == "" ? file(pathexpand("~/.ssh/id_rsa.pub")) : var.ssh_key_pub
+  ssh_key_pub  = var.ssh_key_pub == "" ? file(pathexpand("~/.ssh/id_rsa.pub")) : file(var.ssh_key_pub)
   ssh_key_priv = var.ssh_key_priv == "" ? pathexpand("~/.ssh/id_rsa") : var.ssh_key_priv
   qcow2_image  = var.qcow2_image == "" ? pathexpand("~/terraform_images/ubuntu-20.04-server-cloudimg-amd64.img") : pathexpand(var.qcow2_image)
 }

--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -6,7 +6,7 @@ variable "ssh_key_priv" {
 
 variable "ssh_key_pub" {
   type        = string
-  description = "SSH pub key to use"
+  description = "SSH pub key path"
   default     = ""
 }
 


### PR DESCRIPTION
Update the public ssh key variable to take the file path rather than the
content of the file. This now behaves in the same way as the private ssh
key variable.