### PR TITLE
Terraform - Libvirt network fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ __pycache__
 !/openapi/build.rs
 /tests/bdd/autogen/
 /terraform/cluster/ansible-hosts
+/terraform/cluster/current_user.txt

--- a/shell.nix
+++ b/shell.nix
@@ -64,7 +64,7 @@ mkShell {
     ${pkgs.lib.optionalString (norust) "echo"}
     if [ -n "$USE_NIX_RUST" ]; then
       RUST_SRC_PATH="${rust_chan.nightly_src}/lib/rustlib/src/rust/library/"
-      if ! diff "$RUST_SRC_PATH" "$RUST_SRC_CLONE" &>/dev/null; then
+      if ! diff -r "$RUST_SRC_PATH" "$RUST_SRC_CLONE" &>/dev/null; then
         rm -rf "$RUST_SRC_CLONE"
         mkdir -p "$RUST_SRC_CLONE" 2>/dev/null
         cp -r "$RUST_SRC_PATH"/* "$RUST_SRC_CLONE"

--- a/terraform/cluster/main.tf
+++ b/terraform/cluster/main.tf
@@ -2,7 +2,7 @@ module "k8s" {
   source = "./mod/k8s"
 
   num_nodes          = var.num_nodes
-  ssh_user           = var.ssh_user
+  ssh_user           = local.ssh_user
   private_key_path   = local.ssh_key_priv
   node_list          = module.provider.node_list
   overlay_cidr       = var.overlay_cidr
@@ -15,7 +15,7 @@ module "provider" {
   source = "./mod/libvirt"
 
   # lxd and libvirt
-  ssh_user  = var.ssh_user
+  ssh_user  = local.ssh_user
   ssh_key   = local.ssh_key_pub
   num_nodes = var.num_nodes
   memory    = var.memory
@@ -39,7 +39,19 @@ output "kluster" {
 locals {
   ssh_key_pub  = var.ssh_key_pub == "" ? file(pathexpand("~/.ssh/id_rsa.pub")) : file(var.ssh_key_pub)
   ssh_key_priv = var.ssh_key_priv == "" ? pathexpand("~/.ssh/id_rsa") : var.ssh_key_priv
+  ssh_user     = var.ssh_user == "" ? data.local_file.current_username.content : var.ssh_user
   qcow2_image  = var.qcow2_image == "" ? pathexpand("~/terraform_images/ubuntu-20.04-server-cloudimg-amd64.img") : pathexpand(var.qcow2_image)
+}
+
+resource "null_resource" "generate_current_username" {
+  provisioner "local-exec" {
+    command = "echo -n $USER > ${path.module}/current_user.txt"
+  }
+}
+
+data "local_file" "current_username" {
+  depends_on = [null_resource.generate_current_username]
+  filename   = "${path.module}/current_user.txt"
 }
 
 resource "null_resource" "default_kube_config" {

--- a/terraform/cluster/main.tf
+++ b/terraform/cluster/main.tf
@@ -28,6 +28,8 @@ module "provider" {
   disk_size          = var.disk_size
   pooldisk_size      = var.pooldisk_size
   qcow2_image        = local.qcow2_image
+  network_mode       = var.network_mode
+  bridge_name        = var.bridge_name
 }
 
 output "kluster" {

--- a/terraform/cluster/mod/libvirt/main.tf
+++ b/terraform/cluster/mod/libvirt/main.tf
@@ -75,10 +75,10 @@ resource "libvirt_network" "kube_network_nat" {
   # mode can be: "nat" (default), "none", "route", "bridge"
   mode = var.network_mode
 
-  #  the domain used by the DNS server in this network
+  # the domain used by the DNS server in this network
   domain = "k8s.local"
 
-  #  list of subnets the addresses allowed for domains connected
+  # list of subnets the addresses allowed for domains connected
   # also derived to define the host addresses
   # also derived to define the addresses served by the DHCP server
   addresses = ["10.0.0.0/24"]

--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -45,6 +45,18 @@ variable "num_nodes" {
   description = "The number of nodes to create (should be > 1)"
 }
 
+variable "network_mode" {
+  type        = string
+  default     = "nat"
+  description = "mode can be: nat, bridge, default. If default, the default libvirt network is used."
+}
+
+variable "bridge_name" {
+  type        = string
+  default     = "virbr0"
+  description = "Name of the bridge - when using bridge network mode."
+}
+
 variable "qcow2_image" {
   type        = string
   description = "Ubuntu image for VMs - only needed for libvirt provider"

--- a/terraform/cluster/variables.tf
+++ b/terraform/cluster/variables.tf
@@ -13,7 +13,7 @@ variable "ssh_key_pub" {
 variable "ssh_user" {
   type        = string
   description = "The user that should be created and who has sudo power"
-  default     = "tiago"
+  default     = ""
 }
 
 variable "image_path" {

--- a/terraform/shell.nix
+++ b/terraform/shell.nix
@@ -1,7 +1,18 @@
-with import <nixpkgs> { };
 let
-  t = terraform.withPlugins (p: [ p.libvirt p.null p.template p.lxd p.kubernetes p.helm ]);
+  sources = import ../nix/sources.nix;
+  pkgs = import sources.nixpkgs {
+    overlays = [ (_: _: { inherit sources; }) (import ../nix/overlay.nix { }) ];
+  };
 in
+with pkgs;
 mkShell {
-  buildInputs = [ t tflint ];
+  name = "control-plane-tf-shell";
+  buildInputs = [
+    git
+    jq
+    utillinux
+    which
+    (terraform.withPlugins (p: [ p.libvirt p.null p.template p.lxd p.kubernetes p.helm p.local ]))
+    tflint
+  ];
 }


### PR DESCRIPTION
fix(terraform): default ssh_user to current user (if not specified)
    
    Also, make terraform shell use the nixpkgs from the root shell.

---

chore(terraform): add network mode which defaults to NAT
    
    Creates a named (k8snet) network which is set to autostart when the host boots up.

---

fix(rust-src): compare rust sources recursively
    
    This is a WRITEABLE clone of the rust sources, copied from the nix output derivation.
    Useful when using rust-analyzer from JetBrains which wants a writeable rust source.
