### PR TITLE
feat(replace NATS): add nexus and child ops over grpc

### DIFF
--- a/common/src/mbus_api/mod.rs
+++ b/common/src/mbus_api/mod.rs
@@ -26,8 +26,8 @@ pub use send::*;
 use serde::{de::StdError, Deserialize, Serialize};
 use snafu::{ResultExt, Snafu};
 use std::{
-    collections::HashMap, fmt::Debug, io, marker::PhantomData, ops::Deref, str::FromStr,
-    time::Duration,
+    collections::HashMap, fmt::Debug, io, marker::PhantomData, num::TryFromIntError, ops::Deref,
+    str::FromStr, time::Duration,
 };
 use strum_macros::{AsRefStr, ToString};
 use tokio::task::JoinError;
@@ -365,6 +365,13 @@ impl From<ReplyError> for tonic::Status {
 impl From<tonic::transport::Error> for ReplyError {
     fn from(e: tonic::transport::Error) -> Self {
         Self::tonic_reply_error(ReplyErrorKind::Aborted, e.to_string(), e.full_string())
+    }
+}
+
+/// Error type for invalid integer type conversion
+impl From<TryFromIntError> for ReplyError {
+    fn from(e: TryFromIntError) -> Self {
+        Self::invalid_argument(ResourceKind::Unknown, "", e.to_string())
     }
 }
 

--- a/control-plane/agents/core/src/lib.rs
+++ b/control-plane/agents/core/src/lib.rs
@@ -4,7 +4,7 @@ use common::ServiceError;
 use futures::{future::join_all, FutureExt};
 use grpc::{
     operations::{
-        node::server::NodeServer, pool::server::PoolServer,
+        nexus::server::NexusServer, node::server::NodeServer, pool::server::PoolServer,
         registration::server::RegistrationServer, registry::server::RegistryServer,
         replica::server::ReplicaServer, volume::server::VolumeServer,
     },
@@ -46,6 +46,7 @@ impl Service {
             .base_service
             .get_shared_state::<RegistryServer>()
             .clone();
+        let nexus_service = self.base_service.get_shared_state::<NexusServer>().clone();
 
         let tonic_router = self
             .tonic_grpc_server
@@ -55,7 +56,8 @@ impl Service {
             .add_service(volume_service.into_grpc_server())
             .add_service(node_service.into_grpc_server())
             .add_service(registration_service.into_grpc_server())
-            .add_service(registry_service.into_grpc_server());
+            .add_service(registry_service.into_grpc_server())
+            .add_service(nexus_service.into_grpc_server());
 
         let mut threads = if self.base_service.nats_enabled() {
             self.base_service.mbus_handles().await

--- a/control-plane/agents/core/src/nexus/mod.rs
+++ b/control-plane/agents/core/src/nexus/mod.rs
@@ -1,34 +1,17 @@
+use super::core::registry::Registry;
+use grpc::operations::nexus::server::NexusServer;
+use std::sync::Arc;
+
 pub(crate) mod registry;
 pub(crate) mod scheduling;
 mod service;
 pub mod specs;
 
-use async_trait::async_trait;
-use std::{convert::TryInto, marker::PhantomData};
-
-use super::{core::registry::Registry, handler, impl_request_handler};
-use common::{errors::SvcError, handler::*};
-
-// Nexus Operations
-use common_lib::types::v0::message_bus::{
-    CreateNexus, DestroyNexus, GetNexuses, ShareNexus, UnshareNexus,
-};
-// Nexus Child Operations
-use common_lib::types::v0::message_bus::{AddNexusChild, RemoveNexusChild};
-
 pub(crate) fn configure(builder: common::Service) -> common::Service {
     let registry = builder.get_shared_state::<Registry>().clone();
-    builder
-        .with_channel(ChannelVs::Nexus)
-        .with_default_liveness()
-        .with_shared_state(service::Service::new(registry))
-        .with_subscription(handler!(GetNexuses))
-        .with_subscription(handler!(CreateNexus))
-        .with_subscription(handler!(DestroyNexus))
-        .with_subscription(handler!(ShareNexus))
-        .with_subscription(handler!(UnshareNexus))
-        .with_subscription(handler!(AddNexusChild))
-        .with_subscription(handler!(RemoveNexusChild))
+    let new_service = Arc::new(service::Service::new(registry));
+    let nexus_service = NexusServer::new(new_service);
+    builder.with_shared_state(nexus_service)
 }
 
 /// Nexus Agent's Tests

--- a/control-plane/grpc/proto/v1/misc/common.proto
+++ b/control-plane/grpc/proto/v1/misc/common.proto
@@ -144,6 +144,17 @@ message NodePoolFilter{
   string pool_id = 2;
 }
 
+// Filter by Nexus Id
+message NexusFilter{
+  string nexus_id = 1;
+}
+
+// Filter by Node and Nexus id
+message NodeNexusFilter{
+  string node_id = 1;
+  string nexus_id = 2;
+}
+
 // Pagination related parameters.
 // This allows a large response to be split over multiple requests to prevent timeouts.
 message Pagination {

--- a/control-plane/grpc/proto/v1/nexus/nexus.proto
+++ b/control-plane/grpc/proto/v1/nexus/nexus.proto
@@ -27,6 +27,11 @@ message Nexus {
   common.Protocol share = 9;
 }
 
+// Multiple nexus
+message Nexuses {
+  repeated Nexus nexuses = 1;
+}
+
 enum NexusStatus {
   // Default Unknown state
   Unknown = 0;
@@ -81,6 +86,7 @@ message NexusSpec {
   optional common.SpecOperation operation = 10;
 }
 
+// Nexus children (replica or "raw" URI)
 message NexusChild {
   oneof child {
     // When the child is a pool replica (in case of a volume)
@@ -90,11 +96,175 @@ message NexusChild {
   }
 }
 
+// ReplicaUri used by managed nexus creation
+// Includes the ReplicaId which is unique and allows us to pinpoint the exact replica
 message Replica {
   google.protobuf.StringValue replica_id = 1;
   string ChildUri = 2;
 }
 
+// URI of a nexus child
 message Uri {
   string ChildUri = 1;
+}
+
+// Get all nexuses based on the filter criteria
+message GetNexusesRequest {
+  oneof filter {
+    common.NodeFilter node = 1;
+    common.NodeNexusFilter node_nexus = 2;
+    common.NexusFilter nexus = 3;
+  }
+}
+
+// Reply type for a GetNexuses request
+message GetNexusesReply {
+  oneof reply {
+    Nexuses nexuses = 1;
+    common.ReplyError error = 2;
+  }
+}
+
+message CreateNexusRequest {
+  // id of the io-engine instance
+  string node_id = 1;
+  // the nexus uuid will be set to this
+  google.protobuf.StringValue nexus_id = 2;
+  // size of the device in bytes
+  uint64 size = 3;
+  // replica can be iscsi and nvmf remote targets or a local spdk bdev
+  // (i.e. bdev:///name-of-the-bdev).
+  // uris to the targets we connect to
+  repeated NexusChild children = 4;
+  // Managed by our control plane
+  bool managed = 5;
+  // Volume which owns this nexus, if any
+  google.protobuf.StringValue owner = 6;
+  // Nexus Nvmf Configuration
+  optional NexusNvmfConfig config = 7;
+}
+
+// Nvmf Controller Id Range
+// Ranges between 1 to 0xFFEF
+message NvmfControllerIdRange {
+  uint32 start = 1;
+  uint32 end = 2;
+}
+
+// Nexus Nvmf Configuration
+message NexusNvmfConfig {
+  // limits the controller id range
+  NvmfControllerIdRange controller_id_range = 1;
+  // persistent reservation key
+  uint64 reservation_key = 2;
+  // preempts this reservation key
+  optional uint64 preempt_reservation_key = 3;
+}
+
+// Reply type for CreateNexusRequest
+message CreateNexusReply {
+  oneof reply {
+    Nexus nexus = 1;
+    common.ReplyError error = 2;
+  }
+}
+
+// Destroy Nexus Request
+message DestroyNexusRequest {
+  // id of the io-engine instance
+  string node_id = 1;
+  // uuid of the nexus
+  google.protobuf.StringValue nexus_id = 2;
+}
+
+// Reply type for DestroyNexusRequest
+message DestroyNexusReply {
+  optional common.ReplyError error = 1;
+}
+
+// Share Nexus Request
+message ShareNexusRequest {
+  // id of the io-engine instance
+  string node_id = 1;
+  // uuid of the nexus
+  google.protobuf.StringValue nexus_id = 2;
+  // encryption key
+  optional string key = 3;
+  // share protocol
+  NexusShareProtocol protocol = 4;
+}
+
+// Reply type for a ShareNexusRequest
+message ShareNexusReply {
+  oneof reply {
+    string response = 1;
+    common.ReplyError error = 2;
+  }
+}
+
+// Unshare Nexus Request
+message UnshareNexusRequest {
+  // id of the io-engine instance
+  string node_id = 1;
+  // uuid of the nexus
+  google.protobuf.StringValue nexus_id = 2;
+}
+
+// Reply type for a UnshareNexus request
+message UnshareNexusReply {
+  optional common.ReplyError error = 1;
+}
+
+// The protocol used to share the nexus.
+enum NexusShareProtocol {
+  // shared as NVMe-oF TCP
+  Nvmf = 0;
+  // shared as iSCSI
+  Iscsi = 1;
+}
+
+// Add child to Nexus Request
+message AddNexusChildRequest {
+  // id of the io-engine instance
+  string node_id = 1;
+  // uuid of the nexus
+  google.protobuf.StringValue nexus_id = 2;
+  // URI of the child device to be added
+  string uri = 3;
+  // auto start rebuilding
+  bool auto_rebuild = 4;
+}
+
+// Remove Child from Nexus Request
+message RemoveNexusChildRequest {
+  // id of the io-engine instance
+  string node_id = 1;
+  // uuid of the nexus
+  google.protobuf.StringValue nexus_id = 2;
+  // URI of the child device to be added
+  string uri = 3;
+}
+
+// Reply type for a AddNexusChildRequest request
+message AddNexusChildReply {
+  oneof reply {
+    Child child = 1;
+    common.ReplyError error = 2;
+  }
+}
+
+// Reply type for a RemoveNexusChildRequest request
+message RemoveNexusChildReply {
+  optional common.ReplyError error = 1;
+}
+
+// Nexus Grpc Service
+service NexusGrpc {
+  rpc GetNexuses (GetNexusesRequest) returns (GetNexusesReply) {}
+  rpc CreateNexus (CreateNexusRequest) returns (CreateNexusReply) {}
+  rpc DestroyNexus (DestroyNexusRequest) returns (DestroyNexusReply) {}
+  rpc ShareNexus (ShareNexusRequest) returns (ShareNexusReply) {}
+  rpc UnshareNexus (UnshareNexusRequest) returns (UnshareNexusReply) {}
+  rpc AddNexusChild (AddNexusChildRequest) returns (AddNexusChildReply) {}
+  rpc RemoveNexusChild (RemoveNexusChildRequest) returns (RemoveNexusChildReply) {}
 }

--- a/control-plane/grpc/src/client.rs
+++ b/control-plane/grpc/src/client.rs
@@ -1,6 +1,7 @@
 use crate::{
     context::Context,
     operations::{
+        nexus::{client::NexusClient, traits::NexusOperations},
         node::{client::NodeClient, traits::NodeOperations},
         pool::{client::PoolClient, traits::PoolOperations},
         registry::{client::RegistryClient, traits::RegistryOperations},
@@ -19,6 +20,7 @@ pub struct CoreClient {
     volume: VolumeClient,
     node: NodeClient,
     registry: RegistryClient,
+    nexus: NexusClient,
 }
 
 impl CoreClient {
@@ -29,13 +31,15 @@ impl CoreClient {
         let replica_client = ReplicaClient::new(addr.clone(), timeout_opts.clone()).await;
         let volume_client = VolumeClient::new(addr.clone(), timeout_opts.clone()).await;
         let node_client = NodeClient::new(addr.clone(), timeout_opts.clone()).await;
-        let registry_client = RegistryClient::new(addr, timeout_opts).await;
+        let registry_client = RegistryClient::new(addr.clone(), timeout_opts.clone()).await;
+        let nexus_client = NexusClient::new(addr, timeout_opts).await;
         Self {
             pool: pool_client,
             replica: replica_client,
             volume: volume_client,
             node: node_client,
             registry: registry_client,
+            nexus: nexus_client,
         }
     }
     /// retrieve the corresponding pool client
@@ -57,6 +61,10 @@ impl CoreClient {
     /// retrieve the corresponding registry client
     pub fn registry(&self) -> impl RegistryOperations {
         self.registry.clone()
+    }
+    /// retrieve the corresponding nexus client
+    pub fn nexus(&self) -> impl NexusOperations {
+        self.nexus.clone()
     }
     /// Try to wait until the Core Agent is ready, up to a timeout, by using the Probe method.
     pub async fn wait_ready(&self, timeout_opts: Option<TimeoutOptions>) -> Result<(), ()> {

--- a/control-plane/grpc/src/operations/nexus/client.rs
+++ b/control-plane/grpc/src/operations/nexus/client.rs
@@ -1,0 +1,177 @@
+use crate::{
+    common::{NexusFilter, NodeFilter, NodeNexusFilter},
+    context::{Client, Context, TracedChannel},
+    nexus::{
+        add_nexus_child_reply, create_nexus_reply, get_nexuses_reply, get_nexuses_request,
+        nexus_grpc_client::NexusGrpcClient, share_nexus_reply, GetNexusesRequest,
+    },
+    operations::nexus::traits::{
+        AddNexusChildInfo, CreateNexusInfo, DestroyNexusInfo, NexusOperations,
+        RemoveNexusChildInfo, ShareNexusInfo, UnshareNexusInfo,
+    },
+};
+use common_lib::{
+    mbus_api::{v0::Nexuses, ReplyError, ResourceKind, TimeoutOptions},
+    types::v0::message_bus::{Child, Filter, MessageIdVs, Nexus},
+};
+use std::{convert::TryFrom, ops::Deref};
+use tonic::transport::Uri;
+
+/// RPC Nexus Client
+#[derive(Clone)]
+pub struct NexusClient {
+    inner: Client<NexusGrpcClient<TracedChannel>>,
+}
+
+impl Deref for NexusClient {
+    type Target = Client<NexusGrpcClient<TracedChannel>>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl NexusClient {
+    /// creates a new base tonic endpoint with the timeout options and the address
+    pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
+        let client = Client::new(addr, opts, NexusGrpcClient::new).await;
+        Self { inner: client }
+    }
+}
+
+#[tonic::async_trait]
+impl NexusOperations for NexusClient {
+    #[tracing::instrument(name = "NexusClient::create", level = "debug", skip(self), err)]
+    async fn create(
+        &self,
+        request: &dyn CreateNexusInfo,
+        ctx: Option<Context>,
+    ) -> Result<Nexus, ReplyError> {
+        let req = self.request(request, ctx, MessageIdVs::CreateNexus);
+        let response = self.client().create_nexus(req).await?.into_inner();
+        match response.reply {
+            Some(create_nexus_reply) => match create_nexus_reply {
+                create_nexus_reply::Reply::Nexus(nexus) => Ok(Nexus::try_from(nexus)?),
+                create_nexus_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Nexus)),
+        }
+    }
+
+    #[tracing::instrument(name = "NexusClient::get", level = "debug", skip(self), err)]
+    async fn get(&self, filter: Filter, ctx: Option<Context>) -> Result<Nexuses, ReplyError> {
+        let req: GetNexusesRequest = match filter {
+            Filter::Node(id) => GetNexusesRequest {
+                filter: Some(get_nexuses_request::Filter::Node(NodeFilter {
+                    node_id: id.into(),
+                })),
+            },
+            Filter::NodeNexus(node_id, nexus_id) => GetNexusesRequest {
+                filter: Some(get_nexuses_request::Filter::NodeNexus(NodeNexusFilter {
+                    node_id: node_id.into(),
+                    nexus_id: nexus_id.to_string(),
+                })),
+            },
+            Filter::Nexus(nexus_id) => GetNexusesRequest {
+                filter: Some(get_nexuses_request::Filter::Nexus(NexusFilter {
+                    nexus_id: nexus_id.to_string(),
+                })),
+            },
+            _ => GetNexusesRequest { filter: None },
+        };
+        let req = self.request(req, ctx, MessageIdVs::GetNexuses);
+        let response = self.client().get_nexuses(req).await?.into_inner();
+        match response.reply {
+            Some(get_nexuses_reply) => match get_nexuses_reply {
+                get_nexuses_reply::Reply::Nexuses(nexuses) => Ok(Nexuses::try_from(nexuses)?),
+                get_nexuses_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Nexus)),
+        }
+    }
+
+    #[tracing::instrument(name = "NexusClient::destroy", level = "debug", skip(self), err)]
+    async fn destroy(
+        &self,
+        request: &dyn DestroyNexusInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError> {
+        let req = self.request(request, ctx, MessageIdVs::DestroyNexus);
+        let response = self.client().destroy_nexus(req).await?.into_inner();
+        match response.error {
+            None => Ok(()),
+            Some(err) => Err(err.into()),
+        }
+    }
+
+    #[tracing::instrument(name = "NexusClient::share", level = "debug", skip(self), err)]
+    async fn share(
+        &self,
+        request: &dyn ShareNexusInfo,
+        ctx: Option<Context>,
+    ) -> Result<String, ReplyError> {
+        let req = self.request(request, ctx, MessageIdVs::ShareNexus);
+        let response = self.client().share_nexus(req).await?.into_inner();
+        match response.reply {
+            Some(share_nexus_reply) => match share_nexus_reply {
+                share_nexus_reply::Reply::Response(message) => Ok(message),
+                share_nexus_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Nexus)),
+        }
+    }
+
+    #[tracing::instrument(name = "NexusClient::unshare", level = "debug", skip(self), err)]
+    async fn unshare(
+        &self,
+        request: &dyn UnshareNexusInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError> {
+        let req = self.request(request, ctx, MessageIdVs::UnshareNexus);
+        let response = self.client().unshare_nexus(req).await?.into_inner();
+        match response.error {
+            None => Ok(()),
+            Some(err) => Err(err.into()),
+        }
+    }
+
+    #[tracing::instrument(
+        name = "NexusClient::add_nexus_child",
+        level = "debug",
+        skip(self),
+        err
+    )]
+    async fn add_nexus_child(
+        &self,
+        request: &dyn AddNexusChildInfo,
+        ctx: Option<Context>,
+    ) -> Result<Child, ReplyError> {
+        let req = self.request(request, ctx, MessageIdVs::AddNexusChild);
+        let response = self.client().add_nexus_child(req).await?.into_inner();
+        match response.reply {
+            Some(add_nexus_child_reply) => match add_nexus_child_reply {
+                add_nexus_child_reply::Reply::Child(child) => Ok(Child::try_from(child)?),
+                add_nexus_child_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Child)),
+        }
+    }
+
+    #[tracing::instrument(
+        name = "NexusClient::remove_nexus_child",
+        level = "debug",
+        skip(self),
+        err
+    )]
+    async fn remove_nexus_child(
+        &self,
+        request: &dyn RemoveNexusChildInfo,
+        ctx: Option<Context>,
+    ) -> Result<(), ReplyError> {
+        let req = self.request(request, ctx, MessageIdVs::RemoveNexusChild);
+        let response = self.client().remove_nexus_child(req).await?.into_inner();
+        match response.error {
+            None => Ok(()),
+            Some(err) => Err(err.into()),
+        }
+    }
+}

--- a/control-plane/grpc/src/operations/nexus/mod.rs
+++ b/control-plane/grpc/src/operations/nexus/mod.rs
@@ -1,2 +1,8 @@
 /// Nexus traits for the transport
 pub mod traits;
+
+/// Nexus grpc Server related code
+pub mod server;
+
+/// Nexus grpc client related code
+pub mod client;

--- a/control-plane/grpc/src/operations/nexus/server.rs
+++ b/control-plane/grpc/src/operations/nexus/server.rs
@@ -1,0 +1,138 @@
+use crate::{
+    misc::traits::ValidateRequestTypes,
+    nexus::{
+        add_nexus_child_reply, create_nexus_reply, get_nexuses_reply,
+        nexus_grpc_server::{NexusGrpc, NexusGrpcServer},
+        share_nexus_reply, AddNexusChildReply, AddNexusChildRequest, CreateNexusReply,
+        CreateNexusRequest, DestroyNexusReply, DestroyNexusRequest, GetNexusesReply,
+        GetNexusesRequest, RemoveNexusChildReply, RemoveNexusChildRequest, ShareNexusReply,
+        ShareNexusRequest, UnshareNexusReply, UnshareNexusRequest,
+    },
+    operations::nexus::traits::NexusOperations,
+};
+use common_lib::types::v0::message_bus::Filter;
+use std::{convert::TryFrom, sync::Arc};
+use tonic::Response;
+
+/// RPC Nexus Server
+#[derive(Clone)]
+pub struct NexusServer {
+    /// Service which executes the operations.
+    service: Arc<dyn NexusOperations>,
+}
+
+impl NexusServer {
+    /// returns a new nexus server with the service implementing nexus operations
+    pub fn new(service: Arc<dyn NexusOperations>) -> Self {
+        Self { service }
+    }
+    /// coverts the nexus server to its corresponding grpc server type
+    pub fn into_grpc_server(self) -> NexusGrpcServer<NexusServer> {
+        NexusGrpcServer::new(self)
+    }
+}
+
+/// Implementation of the RPC methods.
+#[tonic::async_trait]
+impl NexusGrpc for NexusServer {
+    async fn create_nexus(
+        &self,
+        request: tonic::Request<CreateNexusRequest>,
+    ) -> Result<tonic::Response<CreateNexusReply>, tonic::Status> {
+        let req = request.into_inner().validated()?;
+        match self.service.create(&req, None).await {
+            Ok(nexus) => Ok(Response::new(CreateNexusReply {
+                reply: Some(create_nexus_reply::Reply::Nexus(nexus.into())),
+            })),
+            Err(err) => Ok(Response::new(CreateNexusReply {
+                reply: Some(create_nexus_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+    async fn destroy_nexus(
+        &self,
+        request: tonic::Request<DestroyNexusRequest>,
+    ) -> Result<tonic::Response<DestroyNexusReply>, tonic::Status> {
+        let req = request.into_inner().validated()?;
+        match self.service.destroy(&req, None).await {
+            Ok(()) => Ok(Response::new(DestroyNexusReply { error: None })),
+            Err(e) => Ok(Response::new(DestroyNexusReply {
+                error: Some(e.into()),
+            })),
+        }
+    }
+
+    async fn share_nexus(
+        &self,
+        request: tonic::Request<ShareNexusRequest>,
+    ) -> Result<tonic::Response<ShareNexusReply>, tonic::Status> {
+        let req = request.into_inner().validated()?;
+        match self.service.share(&req, None).await {
+            Ok(message) => Ok(Response::new(ShareNexusReply {
+                reply: Some(share_nexus_reply::Reply::Response(message)),
+            })),
+            Err(err) => Ok(Response::new(ShareNexusReply {
+                reply: Some(share_nexus_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn unshare_nexus(
+        &self,
+        request: tonic::Request<UnshareNexusRequest>,
+    ) -> Result<tonic::Response<UnshareNexusReply>, tonic::Status> {
+        let req = request.into_inner().validated()?;
+        match self.service.unshare(&req, None).await {
+            Ok(()) => Ok(Response::new(UnshareNexusReply { error: None })),
+            Err(e) => Ok(Response::new(UnshareNexusReply {
+                error: Some(e.into()),
+            })),
+        }
+    }
+
+    async fn add_nexus_child(
+        &self,
+        request: tonic::Request<AddNexusChildRequest>,
+    ) -> Result<tonic::Response<AddNexusChildReply>, tonic::Status> {
+        let req = request.into_inner().validated()?;
+        match self.service.add_nexus_child(&req, None).await {
+            Ok(child) => Ok(Response::new(AddNexusChildReply {
+                reply: Some(add_nexus_child_reply::Reply::Child(child.into())),
+            })),
+            Err(err) => Ok(Response::new(AddNexusChildReply {
+                reply: Some(add_nexus_child_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+    async fn remove_nexus_child(
+        &self,
+        request: tonic::Request<RemoveNexusChildRequest>,
+    ) -> Result<tonic::Response<RemoveNexusChildReply>, tonic::Status> {
+        let req = request.into_inner().validated()?;
+        match self.service.remove_nexus_child(&req, None).await {
+            Ok(()) => Ok(Response::new(RemoveNexusChildReply { error: None })),
+            Err(e) => Ok(Response::new(RemoveNexusChildReply {
+                error: Some(e.into()),
+            })),
+        }
+    }
+
+    async fn get_nexuses(
+        &self,
+        request: tonic::Request<GetNexusesRequest>,
+    ) -> Result<tonic::Response<GetNexusesReply>, tonic::Status> {
+        let req: GetNexusesRequest = request.into_inner();
+        let filter: Filter = match req.filter {
+            Some(filter) => Filter::try_from(filter)?,
+            None => Filter::None,
+        };
+        match self.service.get(filter, None).await {
+            Ok(nexuses) => Ok(Response::new(GetNexusesReply {
+                reply: Some(get_nexuses_reply::Reply::Nexuses(nexuses.into())),
+            })),
+            Err(err) => Ok(Response::new(GetNexusesReply {
+                reply: Some(get_nexuses_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+}

--- a/control-plane/grpc/src/operations/replica/traits.rs
+++ b/control-plane/grpc/src/operations/replica/traits.rs
@@ -210,7 +210,7 @@ impl From<Replicas> for replica::Replicas {
 /// CreateReplicaInfo trait for the replica creation to be implemented by entities which want to
 /// avail this operation
 pub trait CreateReplicaInfo: Send + Sync + std::fmt::Debug {
-    /// Id of the IoEngine instanc
+    /// Id of the IoEngine instance
     fn node(&self) -> NodeId;
     /// Name of the replica
     fn name(&self) -> Option<ReplicaName>;


### PR DESCRIPTION
- Change transport for nexus and child ops from rest over gRPC replacing NATS.
- Fix corresponding tests

Signed-off-by: Abhinandan Purkait <abhinandan.purkait@mayadata.io>