### PR TITLE
fix(nodes): don't hold nodes list lock while updating 1 node

### DIFF
--- a/control-plane/agents/core/src/node/service.rs
+++ b/control-plane/agents/core/src/node/service.rs
@@ -132,8 +132,12 @@ impl Service {
     /// Callback to be called when a node's watchdog times out
     pub(super) async fn on_timeout(service: &Service, id: &NodeId) {
         let registry = service.registry.clone();
-        let state = registry.nodes().read().await;
-        if let Some(node) = state.get(id) {
+        let node = {
+            let state = registry.nodes().read().await;
+            state.get(id).cloned()
+        };
+
+        if let Some(node) = node {
             let mut node = node.write().await;
             if node.is_online() {
                 node.update_liveness().await;

--- a/tests/bdd/features/pool/reconcile/test_feature.py
+++ b/tests/bdd/features/pool/reconcile/test_feature.py
@@ -54,6 +54,7 @@ def a_pool_p0_that_could_not_be_deleted_due_to_an_unreachable_node(
     """a pool "p0" that could not be deleted due to an unreachable node."""
     assert attempt_delete_the_pool.status == http.HTTPStatus.PRECONDITION_FAILED
     assert not hasattr(ApiClient.pools_api().get_pool(pool.id), "state")
+    wait_node_offline(pool.spec.node)
 
 
 @when("the node comes back online")
@@ -146,7 +147,7 @@ def a_pool_on_an_unreachable_offline_node(pool):
     Docker.stop_container(pool.spec.node)
     wait_node_offline(pool.spec.node)
     yield pool
-    if Docker.container_status(pool.spec.node) != "Running":
+    if Docker.container_status(pool.spec.node) != "running":
         Docker.restart_container(pool.spec.node)
     wait_node_online(pool.spec.node)
     try:


### PR DESCRIPTION
fix(nodes): don't hold nodes list lock while updating 1 node

This way registrations from other nodes don't get helf up by 1 flaky node

---

fix(pytest): check against lowercase state

Otherwise we'll always think the node is not running, which is wrong.
Also, make sure the node is offline in the control-plane before restarting it.