### PR TITLE
feat(kubectl plugin): add get block-devices command to list all/usable disks per node

### DIFF
--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -2,8 +2,8 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use opentelemetry::global;
 use plugin::{
-    operations::{Get, List, Operations, ReplicaTopology, Scale},
-    resources::{node, pool, volume, GetResources, ScaleResources},
+    operations::{Get, GetBlockDevices, List, Operations, ReplicaTopology, Scale},
+    resources::{blockdevice, node, pool, volume, GetResources, ScaleResources},
     rest_wrapper::RestClient,
 };
 use std::env;
@@ -64,6 +64,14 @@ async fn execute(cli_args: CliArgs) {
             GetResources::Pool { id } => pool::Pool::get(id, &cli_args.output).await,
             GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
             GetResources::Node { id } => node::Node::get(id, &cli_args.output).await,
+            GetResources::BlockDevices(bdargs) => {
+                blockdevice::BlockDevice::get_blockdevices(
+                    &bdargs.node_id(),
+                    &bdargs.all(),
+                    &cli_args.output,
+                )
+                .await
+            }
         },
         Operations::Scale(resource) => match resource {
             ScaleResources::Volume { id, replica_count } => {

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -42,3 +42,11 @@ pub trait ReplicaTopology {
     type ID;
     async fn topology(id: &Self::ID, output: &utils::OutputFormat);
 }
+
+/// GetBlockDevices trait.
+/// To be implemented by resources which support the 'get block-devices' operation
+#[async_trait(?Send)]
+pub trait GetBlockDevices {
+    type ID;
+    async fn get_blockdevices(id: &Self::ID, all: &bool, output: &utils::OutputFormat);
+}

--- a/control-plane/plugin/src/resources/blockdevice.rs
+++ b/control-plane/plugin/src/resources/blockdevice.rs
@@ -1,0 +1,214 @@
+use crate::{
+    operations::GetBlockDevices,
+    resources::{
+        utils::{
+            print_table, CreateRows, GetHeaderRow, OutputFormat, BLOCKDEVICE_HEADERS_ALL,
+            BLOCKDEVICE_HEADERS_USABLE,
+        },
+        NodeId,
+    },
+    rest_wrapper::RestClient,
+};
+use async_trait::async_trait;
+use openapi::apis::Url;
+use prettytable::Row;
+use serde::Serialize;
+
+/// Blockdevice resource.
+#[derive(clap::Args, Debug)]
+pub struct BlockDevice {}
+
+/// New type to wrap BD returned from REST call with all set to true
+#[derive(Clone, Debug, Serialize)]
+struct BlockDeviceAll(openapi::models::BlockDevice);
+
+/// New type to wrap BD returned from REST call with all set to false
+#[derive(Clone, Debug, Serialize)]
+struct BlockDeviceUsable(openapi::models::BlockDevice);
+
+#[derive(Debug, Clone, clap::Args)]
+/// BlockDevice args
+pub struct BlockDeviceArgs {
+    /// Id of the node
+    node_id: NodeId,
+    #[clap(long)]
+    /// Shows all devices if invoked, otherwise shows usable disks.
+    all: bool,
+}
+
+impl BlockDeviceArgs {
+    /// get the node id
+    pub fn node_id(&self) -> NodeId {
+        self.node_id.clone()
+    }
+    /// get the all value
+    pub fn all(&self) -> bool {
+        self.all
+    }
+}
+
+// CreateRows trait for BlockDeviceAll would create the row from the
+// BD returned from REST call with all set to true.
+impl CreateRows for BlockDeviceAll {
+    fn create_rows(&self) -> Vec<Row> {
+        vec![row![
+            self.0.devname.clone(),
+            self.0.devtype.clone(),
+            self.0.size.to_string(),
+            String::from(if self.0.available { "yes" } else { "no" }),
+            self.0.model.clone(),
+            self.0.devpath.clone(),
+            self.0.devmajor.to_string(),
+            self.0.devminor.to_string(),
+            self.0.filesystem.fstype.clone(),
+            self.0.filesystem.uuid.clone(),
+            self.0.filesystem.mountpoint.clone(),
+            get_partition_type(&self.0.partition),
+            self.0
+                .devlinks
+                .iter()
+                .map(|s| format!("\"{}\"", s))
+                .collect::<Vec<String>>()
+                .join(", "),
+        ]]
+    }
+}
+
+// CreateRows trait for BlockDeviceUsable would create row from the
+// BD returned from REST call with all set to false.
+impl CreateRows for BlockDeviceUsable {
+    fn create_rows(&self) -> Vec<Row> {
+        vec![row![
+            self.0.devname.clone(),
+            self.0.devtype.clone(),
+            self.0.size.to_string(),
+            String::from(if self.0.available { "yes" } else { "no" }),
+            self.0.model.clone(),
+            self.0.devpath.clone(),
+            self.0.devmajor.to_string(),
+            self.0.devminor.to_string(),
+            self.0
+                .devlinks
+                .iter()
+                .map(|s| format!("\"{}\"", s))
+                .collect::<Vec<String>>()
+                .join(", "),
+        ]]
+    }
+}
+
+fn get_partition_type(partition: &openapi::models::BlockDevicePartition) -> String {
+    if !partition.scheme.is_empty() && !partition.typeid.is_empty() {
+        return format!("{}:{}", partition.scheme, partition.typeid);
+    }
+    "".to_string()
+}
+
+// GetHeaderRow being trait for BlockDeviceAll would return the Header Row for
+// BD returned from REST call with all set to true.
+impl GetHeaderRow for BlockDeviceAll {
+    fn get_header_row(&self) -> Row {
+        (&*BLOCKDEVICE_HEADERS_ALL).clone()
+    }
+}
+
+// GetHeaderRow being trait for BlockDeviceUsable would return the Header Row for
+// BD returned from REST call with all set to false.
+impl GetHeaderRow for BlockDeviceUsable {
+    fn get_header_row(&self) -> Row {
+        (&*BLOCKDEVICE_HEADERS_USABLE).clone()
+    }
+}
+
+#[async_trait(?Send)]
+impl GetBlockDevices for BlockDevice {
+    type ID = NodeId;
+    async fn get_blockdevices(id: &Self::ID, all: &bool, output: &OutputFormat) {
+        let mut used_disks: Vec<String> = vec![];
+        match RestClient::client().pools_api().get_node_pools(id).await {
+            Ok(pools) => {
+                for pool in pools.into_body() {
+                    let mut normalized_disks: Vec<String> = pool
+                        .spec
+                        .unwrap()
+                        .disks
+                        .into_iter()
+                        .map(|disk| normalize_disk(disk.as_str()))
+                        .collect();
+                    used_disks.append(&mut normalized_disks);
+                }
+            }
+            Err(e) => {
+                println!("Failed to list blockdevices for node {} . Error {}", id, e);
+                return;
+            }
+        }
+
+        match RestClient::client()
+            .block_devices_api()
+            .get_node_block_devices(id, Some(*all))
+            .await
+        {
+            Ok(blockdevices) => {
+                // Print table, json or yaml based on output format.
+                if *all {
+                    let bds: Vec<BlockDeviceAll> =
+                        transform(&used_disks, blockdevices.into_body(), true)
+                            .into_iter()
+                            .map(BlockDeviceAll)
+                            .collect();
+                    print_table(output, bds);
+                } else {
+                    let bds: Vec<BlockDeviceUsable> =
+                        transform(&used_disks, blockdevices.into_body(), false)
+                            .into_iter()
+                            .map(BlockDeviceUsable)
+                            .collect();
+                    print_table(output, bds);
+                };
+            }
+            Err(e) => {
+                println!("Failed to list blockdevices for node {} . Error {}", id, e)
+            }
+        }
+    }
+}
+
+fn transform(
+    used_disks: &[String],
+    blockdevices: Vec<openapi::models::BlockDevice>,
+    all: bool,
+) -> Vec<openapi::models::BlockDevice> {
+    let mut transformed_bds = Vec::with_capacity(blockdevices.len());
+    for mut bd in blockdevices {
+        let mut possible_values = bd.devlinks.clone();
+        possible_values.push(bd.devname.clone());
+        if bd.available && check_available(used_disks, possible_values) {
+            bd.available = true;
+            transformed_bds.push(bd);
+        } else if all {
+            bd.available = false;
+            transformed_bds.push(bd);
+        }
+    }
+    transformed_bds
+}
+
+fn check_available(used_disks: &[String], possible_values: Vec<String>) -> bool {
+    for value in possible_values {
+        if used_disks.contains(&value) {
+            return false;
+        }
+    }
+    true
+}
+
+fn normalize_disk(disk: &str) -> String {
+    Url::parse(disk).map_or(disk.to_string(), |u| {
+        u.to_file_path()
+            .unwrap_or_else(|_| disk.into())
+            .as_path()
+            .display()
+            .to_string()
+    })
+}

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,3 +1,6 @@
+use crate::resources::blockdevice::BlockDeviceArgs;
+
+pub mod blockdevice;
 pub mod node;
 pub mod pool;
 pub mod utils;
@@ -15,7 +18,7 @@ pub enum GetResources {
     Volumes,
     /// Get volume with the given ID.
     Volume { id: VolumeId },
-    /// Get the replica toplogy for the volume with the given ID
+    /// Get the replica topology for the volume with the given ID
     VolumeReplicaTopology { id: VolumeId },
     /// Get all pools.
     Pools,
@@ -25,6 +28,10 @@ pub enum GetResources {
     Nodes,
     /// Get node with the given ID.
     Node { id: NodeId },
+    /// Get BlockDevices present on the Node. Lists usable devices by default.
+    /// Currently disks having blobstore pools not created by control-plane are also shown as
+    /// usable.
+    BlockDevices(BlockDeviceArgs),
 }
 
 /// The types of resources that support the 'scale' operation.

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -31,6 +31,32 @@ lazy_static! {
     ];
     pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS",];
     pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row!["ID", "NODE", "POOL", "STATUS"];
+    pub static ref BLOCKDEVICE_HEADERS_ALL: Row = row![
+        "DEVNAME",
+        "DEVTYPE",
+        "SIZE",
+        "AVAILABLE",
+        "MODEL",
+        "DEVPATH",
+        "FSTYPE",
+        "FSUUID",
+        "MOUNTPOINT",
+        "PARTTYPE",
+        "MAJOR",
+        "MINOR",
+        "DEVLINKS",
+    ];
+    pub static ref BLOCKDEVICE_HEADERS_USABLE: Row = row![
+        "DEVNAME",
+        "DEVTYPE",
+        "SIZE",
+        "AVAILABLE",
+        "MODEL",
+        "DEVPATH",
+        "MAJOR",
+        "MINOR",
+        "DEVLINKS",
+    ];
 }
 
 // table_printer takes the above defined headers and the rows created at execution,
@@ -46,12 +72,12 @@ pub fn table_printer(titles: Row, rows: Vec<Row>) {
     table.printstd();
 }
 
-// CreateRows trait to be implemented by Vec<Volume/Pool> to create the rows.
+// CreateRows trait to be implemented by Vec<`resource`> to create the rows.
 pub trait CreateRows {
     fn create_rows(&self) -> Vec<Row>;
 }
 
-// GetHeaderRow trait to be implemented by Volume/Pool to fetch the corresponding headers.
+// GetHeaderRow trait to be implemented by Vec<`resource`> to fetch the corresponding headers.
 pub trait GetHeaderRow {
     fn get_header_row(&self) -> Row;
 }

--- a/k8s/plugin/README.md
+++ b/k8s/plugin/README.md
@@ -114,6 +114,22 @@ The plugin needs to be able to connect to the REST server in order to make the a
  93b1e1e9-ffcd-4c56-971e-294a530ea5cd  ksnode-2  pool-on-ksnode-2  Online
  88d89a92-40cf-4147-97d4-09e64979f548  ksnode-3  pool-on-ksnode-3  Online
 ```
+
+9. Get BlockDevices by NodeID
+```
+❯ kubectl mayastor get block-devices worker-node1 --all
+ DEVNAME          DEVTYPE    SIZE       AVAILABLE  MODEL                       DEVPATH                                                         FSTYPE  FSUUID  MOUNTPOINT  PARTTYPE                              MAJOR            MINOR                                     DEVLINKS
+ /dev/nvme1n1     disk       4194304    no         Amazon Elastic Block Store  /devices/pci0000:00/0000:00:1f.0/nvme/nvme1/nvme1n1             259     4       ext4        4616cd08-7a7d-49fe-ae6d-908f9e864fc7                                                             "/dev/disk/by-uuid/4616cd08-7a7d-49fe-ae6d-908f9e864fc7", "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol04bfba0a58c4ffdae", "/dev/disk/by-id/nvme-nvme.1d0f-766f6c303462666261306135386334666664
+ /dev/nvme4n1     disk       20971520   yes        Amazon Elastic Block Store  /devices/pci0000:00/0000:00:1d.0/nvme/nvme4/nvme4n1             259     12                                                                                                                   "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol06eb486c9593587a9", "/dev/disk/by-id/nvme-nvme.1d0f-766f6c3036656234383663393539333538376139-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001", "/dev/disk/by-path/pci-0000:00:1d.0-nvme-1"
+ /dev/nvme2n1     disk       104857600  no         Amazon Elastic Block Store  /devices/pci0000:00/0000:00:1e.0/nvme/nvme2/nvme2n1             259     5                                                                                                                    "/dev/disk/by-id/nvme-nvme.1d0f-766f6c3033623636623930363535636636656465-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001", "/dev/disk/by-path/pci-0000:00:1e.0-nvme-1", "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol03b66b90655cf6ede"
+```
+```
+❯ kubectl mayastor get block-devices worker-node1
+ DEVNAME       DEVTYPE  SIZE      AVAILABLE  MODEL                       DEVPATH                                              MAJOR  MINOR  DEVLINKS
+ /dev/nvme4n1  disk     20971520  yes        Amazon Elastic Block Store  /devices/pci0000:00/0000:00:1d.0/nvme/nvme4/nvme4n1  259    12     "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol06eb486c9593587a9", "/dev/disk/by-id/nvme-nvme.1d0f-766f6c3036656234383663393539333538376139-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001", "/dev/disk/by-path/pci-0000:00:1d.0-nvme-1"
+```
+**NOTE: The above command lists usable blockdevices if `--all` flag is not used, but currently since there isn't a way to identify whether the `disk` has a blobstore pool, `disks` not used by `pools` created by `control-plane` are shown as usable if they lack any filesystem uuid.**
+
 </details>
 
 <details>

--- a/k8s/plugin/src/main.rs
+++ b/k8s/plugin/src/main.rs
@@ -3,8 +3,8 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use opentelemetry::global;
 use plugin::{
-    operations::{Get, List, ReplicaTopology, Scale},
-    resources::{node, pool, volume, GetResources, ScaleResources},
+    operations::{Get, GetBlockDevices, List, ReplicaTopology, Scale},
+    resources::{blockdevice, node, pool, volume, GetResources, ScaleResources},
     rest_wrapper::RestClient,
 };
 use std::{
@@ -82,6 +82,14 @@ async fn execute(cli_args: CliArgs) {
             GetResources::Pool { id } => pool::Pool::get(&id, &cli_args.output).await,
             GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
             GetResources::Node { id } => node::Node::get(&id, &cli_args.output).await,
+            GetResources::BlockDevices(bdargs) => {
+                blockdevice::BlockDevice::get_blockdevices(
+                    &bdargs.node_id(),
+                    &bdargs.all(),
+                    &cli_args.output,
+                )
+                .await
+            }
         },
         Operations::Scale(resource) => match resource {
             ScaleResources::Volume { id, replica_count } => {


### PR DESCRIPTION
Usage/Output All, Usable

```
➜  mayastor-control-plane (device-inv) kubectl mayastor get block-devices <node-name> --all

 DEVNAME          DEVTYPE    SIZE       AVAILABLE  MODEL                       DEVPATH                                                         FSTYPE  FSUUID  MOUNTPOINT  PARTTYPE                              MAJOR            MINOR                                     DEVLINKS 
 /dev/nvme0n1     disk       167772160  no         Amazon Elastic Block Store  /devices/pci0000:00/0000:00:04.0/nvme/nvme0/nvme0n1             259     0                                                                                                                    "/dev/disk/by-path/pci-0000:00:04.0-nvme-1", "/dev/disk/by-id/nvme-nvme.1d0f-766f6c3038346136373931663365363866613164-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001", "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol084a6791f3e68fa1d" 
 /dev/nvme0n1p1   partition  167544799  no         Amazon Elastic Block Store  /devices/pci0000:00/0000:00:04.0/nvme/nvme0/nvme0n1/nvme0n1p1   259     1       ext4        4211f95f-755b-4c22-9740-17b12a609123  cloudimg-rootfs  gpt:0fc63daf-8483-4772-8e79-3d69d8477de4  "/dev/disk/by-uuid/4211f95f-755b-4c22-9740-17b12a609123", "/dev/disk/by-id/nvme-nvme.1d0f-766f6c3038346136373931663365363866613164-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001-part1", "/dev/disk/by-partuuid/54ecbbe1-f829-4864-bd41-588e2ccc038b", "/dev/disk/by-label/cloudimg-rootfs", "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol084a6791f3e68fa1d-part1", "/dev/disk/by-path/pci-0000:00:04.0-nvme-1-part1" 

```

```
➜  mayastor-control-plane (device-inv) kubectl mayastor get block-devices <node name>

 DEVNAME       DEVTYPE  SIZE       AVAILABLE  MODEL                       DEVPATH                                              MAJOR  MINOR  DEVLINKS 
 /dev/nvme3n2  disk     104857600  yes        Amazon Elastic Block Store  /devices/pci0000:00/0000:00:1e.0/nvme/nvme2/nvme3n2  259    7      "/dev/disk/by-path/pci-0000:00:1e.0-nvme-1", "/dev/disk/by-id/nvme-Amazon_Elastic_Block_Store_vol019d8523478a2a7cc", "/dev/disk/by-id/nvme-nvme.1d0f-766f6c3031396438353233343738613261376363-416d617a6f6e20456c617374696320426c6f636b2053746f7265-00000001" 

```

Signed-off-by: Abhinandan Purkait <abhinandan.purkait@mayadata.io>