### PR TITLE
feat(cordon): allow cordoning of a node

### DIFF
--- a/common/src/types/v0/message_bus/mod.rs
+++ b/common/src/types/v0/message_bus/mod.rs
@@ -95,6 +95,8 @@ pub enum MessageIdVs {
     /// Node Service
     /// Get all node information
     GetNodes,
+    /// Cordon a node
+    CordonNode,
     /// Pool Service
     ///
     /// Get pools with filter

--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -64,7 +64,7 @@ impl NodeSpec {
 
 impl From<NodeSpec> for models::NodeSpec {
     fn from(src: NodeSpec) -> Self {
-        Self::new(src.endpoint, src.id)
+        Self::new(src.endpoint, src.id, vec![""])
     }
 }
 

--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -34,14 +34,22 @@ pub struct NodeSpec {
     endpoint: String,
     /// Node labels.
     labels: NodeLabels,
+    /// Cordon labels.
+    cordon_labels: Vec<String>,
 }
 impl NodeSpec {
     /// Return a new `Self`
-    pub fn new(id: NodeId, endpoint: String, labels: NodeLabels) -> Self {
+    pub fn new(
+        id: NodeId,
+        endpoint: String,
+        labels: NodeLabels,
+        cordon_label: Option<Vec<String>>,
+    ) -> Self {
         Self {
             id,
             endpoint,
             labels,
+            cordon_labels: cordon_label.unwrap_or_default(),
         }
     }
     /// Node identification
@@ -60,11 +68,29 @@ impl NodeSpec {
     pub fn set_endpoint(&mut self, endpoint: String) {
         self.endpoint = endpoint
     }
+    /// Cordon node by applying the label.
+    pub fn cordon(&mut self, label: String) {
+        self.cordon_labels.push(label);
+    }
+    /// Uncordon node by removing the corresponding label.
+    pub fn uncordon(&mut self, label: String) {
+        if let Some(index) = self.cordon_labels.iter().position(|l| l == &label) {
+            self.cordon_labels.remove(index);
+        }
+    }
+    /// Returns whether or not the node is cordoned.
+    pub fn cordoned(&self) -> bool {
+        !self.cordon_labels.is_empty()
+    }
+    /// Returns the cordon labels
+    pub fn cordon_labels(&self) -> Vec<String> {
+        self.cordon_labels.clone()
+    }
 }
 
 impl From<NodeSpec> for models::NodeSpec {
     fn from(src: NodeSpec) -> Self {
-        Self::new(src.endpoint, src.id, vec![""])
+        Self::new(src.endpoint, src.id, src.cordon_labels)
     }
 }
 

--- a/control-plane/agents/common/src/errors.rs
+++ b/control-plane/agents/common/src/errors.rs
@@ -22,6 +22,12 @@ pub enum SvcError {
     NodeNotOnline { node: NodeId },
     #[snafu(display("No available online nodes"))]
     NoNodes {},
+    #[snafu(display("Node {} is cordoned", node_id))]
+    CordonedNode { node_id: String },
+    #[snafu(display("Node {} is already cordoned with label '{}'", node_id, label))]
+    CordonLabel { node_id: String, label: String },
+    #[snafu(display("Node {} does not have a cordon label '{}'", node_id, label))]
+    UncordonLabel { node_id: String, label: String },
     #[snafu(display(
         "Timed out after '{:?}' attempting to connect to node '{}' via gRPC endpoint '{}'",
         timeout,
@@ -333,6 +339,27 @@ impl From<SvcError> for ReplyError {
             },
 
             SvcError::NoNodes { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPrecondition,
+                resource: ResourceKind::Node,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+
+            SvcError::CordonedNode { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPrecondition,
+                resource: ResourceKind::Node,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+
+            SvcError::CordonLabel { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPrecondition,
+                resource: ResourceKind::Node,
+                source: desc.to_string(),
+                extra: error.full_string(),
+            },
+
+            SvcError::UncordonLabel { .. } => ReplyError {
                 kind: ReplyErrorKind::FailedPrecondition,
                 resource: ResourceKind::Node,
                 source: desc.to_string(),

--- a/control-plane/agents/core/src/core/registry.rs
+++ b/control-plane/agents/core/src/core/registry.rs
@@ -313,4 +313,9 @@ impl Registry {
             None => Ok(()),
         }
     }
+
+    /// Returns whether or not the node with the given ID is cordoned.
+    pub fn node_cordoned(&self, node_id: &NodeId) -> Result<bool, SvcError> {
+        Ok(self.specs.get_node(node_id)?.cordoned())
+    }
 }

--- a/control-plane/agents/core/src/core/scheduling/mod.rs
+++ b/control-plane/agents/core/src/core/scheduling/mod.rs
@@ -59,6 +59,15 @@ impl NodeFilters {
         let used_nodes = registry.specs().get_volume_data_nodes(&request.uuid);
         !used_nodes.contains(&item.pool.node)
     }
+    /// Should only attempt to use nodes which are not cordoned.
+    pub(crate) fn cordoned(request: &GetSuitablePoolsContext, item: &PoolItem) -> bool {
+        let registry = request.registry();
+        !registry
+            .specs()
+            .get_cordoned_nodes()
+            .into_iter()
+            .any(|node_spec| node_spec.id() == &item.pool.node)
+    }
 }
 
 /// Filter pools used for replica creation

--- a/control-plane/agents/core/src/core/scheduling/volume.rs
+++ b/control-plane/agents/core/src/core/scheduling/volume.rs
@@ -88,13 +88,15 @@ impl AddVolumeReplica {
         Self::builder(request, registry)
             .await
             // filter pools according to the following criteria (any order):
-            // 1. if allowed_nodes were specified then only pools from those nodes
+            // 1. exclude nodes that are cordoned
+            // 2. if allowed_nodes were specified then only pools from those nodes
             // can be used.
-            // 2. pools should have enough free space for the
+            // 3. pools should have enough free space for the
             // volume (do we need to take into account metadata?)
-            // 3. ideally use only healthy(online) pools with degraded pools as a
+            // 4. ideally use only healthy(online) pools with degraded pools as a
             // fallback
-            // 4. only one replica per node
+            // 5. only one replica per node
+            .filter(NodeFilters::cordoned)
             .filter(NodeFilters::online)
             .filter(NodeFilters::allowed)
             .filter(NodeFilters::unused)

--- a/control-plane/agents/core/src/nexus/specs.rs
+++ b/control-plane/agents/core/src/nexus/specs.rs
@@ -21,6 +21,7 @@ use common_lib::{
     },
 };
 
+use common::errors::SvcError::CordonedNode;
 use parking_lot::Mutex;
 use snafu::OptionExt;
 use std::sync::Arc;
@@ -165,6 +166,12 @@ impl ResourceSpecsLocked {
         request: &CreateNexus,
         mode: OperationMode,
     ) -> Result<Nexus, SvcError> {
+        if registry.node_cordoned(&request.node)? {
+            return Err(CordonedNode {
+                node_id: request.node.to_string(),
+            });
+        }
+
         let node = registry.get_node_wrapper(&request.node).await?;
 
         let nexus_spec = self.get_or_create_nexus(request);

--- a/control-plane/agents/core/src/node/mod.rs
+++ b/control-plane/agents/core/src/node/mod.rs
@@ -51,6 +51,7 @@ mod tests {
                 id.clone(),
                 endpoint.clone(),
                 NodeLabels::new(),
+                None,
             )),
             Some(NodeState::new(id, endpoint, status)),
         )

--- a/control-plane/agents/core/src/node/service.rs
+++ b/control-plane/agents/core/src/node/service.rs
@@ -78,6 +78,14 @@ impl NodeOperations for Service {
         let blockdevices = self.get_block_devices(&req).await?;
         Ok(blockdevices)
     }
+
+    async fn cordon(&self, _id: NodeId, _label: String) -> Result<Node, ReplyError> {
+        todo!()
+    }
+
+    async fn uncordon(&self, _id: NodeId, _label: String) -> Result<Node, ReplyError> {
+        todo!()
+    }
 }
 
 #[tonic::async_trait]

--- a/control-plane/agents/core/src/node/service.rs
+++ b/control-plane/agents/core/src/node/service.rs
@@ -79,12 +79,14 @@ impl NodeOperations for Service {
         Ok(blockdevices)
     }
 
-    async fn cordon(&self, _id: NodeId, _label: String) -> Result<Node, ReplyError> {
-        todo!()
+    async fn cordon(&self, id: NodeId, label: String) -> Result<Node, ReplyError> {
+        let node = self.cordon(id, label).await?;
+        Ok(node)
     }
 
-    async fn uncordon(&self, _id: NodeId, _label: String) -> Result<Node, ReplyError> {
-        todo!()
+    async fn uncordon(&self, id: NodeId, label: String) -> Result<Node, ReplyError> {
+        let node = self.uncordon(id, label).await?;
+        Ok(node)
     }
 }
 
@@ -303,5 +305,25 @@ impl Service {
             .map(|rpc_bdev| rpc_bdev.to_mbus())
             .collect();
         Ok(BlockDevices(bdevs))
+    }
+
+    async fn cordon(&self, id: NodeId, label: String) -> Result<Node, SvcError> {
+        let spec = self
+            .registry
+            .specs()
+            .cordon_node(&self.registry, &id, label)
+            .await?;
+        let state = self.registry.get_node_state(&id).await.ok();
+        Ok(Node::new(id, Some(spec), state))
+    }
+
+    async fn uncordon(&self, id: NodeId, label: String) -> Result<Node, SvcError> {
+        let spec = self
+            .registry
+            .specs()
+            .uncordon_node(&self.registry, &id, label)
+            .await?;
+        let state = self.registry.get_node_state(&id).await.ok();
+        Ok(Node::new(id, Some(spec), state))
     }
 }

--- a/control-plane/agents/core/src/node/specs.rs
+++ b/control-plane/agents/core/src/node/specs.rs
@@ -30,6 +30,7 @@ impl ResourceSpecsLocked {
                         node.id.clone(),
                         node.grpc_endpoint.clone(),
                         NodeLabels::new(),
+                        None,
                     );
                     specs.nodes.insert(node.clone());
                     (true, node)

--- a/control-plane/agents/core/src/node/specs.rs
+++ b/control-plane/agents/core/src/node/specs.rs
@@ -63,7 +63,7 @@ impl ResourceSpecsLocked {
     }
 
     /// Get all locked node specs
-    pub(crate) fn get_locked_nodes(&self) -> Vec<Arc<Mutex<NodeSpec>>> {
+    fn get_locked_nodes(&self) -> Vec<Arc<Mutex<NodeSpec>>> {
         self.read().nodes.to_vec()
     }
 
@@ -72,6 +72,72 @@ impl ResourceSpecsLocked {
         self.get_locked_nodes()
             .into_iter()
             .map(|n| n.lock().clone())
+            .collect()
+    }
+
+    /// Cordon the node with the given ID.
+    /// Return the NodeSpec after cordoning.
+    pub(crate) async fn cordon_node(
+        &self,
+        registry: &Registry,
+        node_id: &NodeId,
+        label: String,
+    ) -> Result<NodeSpec, SvcError> {
+        let node = self.get_locked_node(node_id)?;
+        let cordoned_node_spec = {
+            let mut locked_node = node.lock();
+            // Do not allow the same label to be applied more than once.
+            if locked_node.cordon_labels().contains(&label) {
+                return Err(SvcError::CordonLabel {
+                    node_id: node_id.to_string(),
+                    label,
+                });
+            }
+            locked_node.cordon(label);
+            locked_node.clone()
+        };
+        registry.store_obj(&cordoned_node_spec).await?;
+        Ok(cordoned_node_spec.clone())
+    }
+
+    /// Uncordon the node with the given ID.
+    /// Return the NodeSpec after uncordoning.
+    pub(crate) async fn uncordon_node(
+        &self,
+        registry: &Registry,
+        node_id: &NodeId,
+        label: String,
+    ) -> Result<NodeSpec, SvcError> {
+        let node = self.get_locked_node(node_id)?;
+        // Return an error if the uncordon label doesn't exist.
+        if !node.lock().cordon_labels().contains(&label) {
+            return Err(SvcError::UncordonLabel {
+                node_id: node_id.to_string(),
+                label,
+            });
+        }
+        let uncordoned_node_spec = {
+            let mut locked_node = node.lock();
+            locked_node.uncordon(label);
+            locked_node.clone()
+        };
+        registry.store_obj(&uncordoned_node_spec).await?;
+        Ok(uncordoned_node_spec.clone())
+    }
+
+    /// Get all cordoned nodes.
+    pub fn get_cordoned_nodes(&self) -> Vec<NodeSpec> {
+        self.read()
+            .nodes
+            .to_vec()
+            .into_iter()
+            .filter_map(|node_spec| {
+                if node_spec.lock().cordoned() {
+                    Some(node_spec.lock().clone())
+                } else {
+                    None
+                }
+            })
             .collect()
     }
 }

--- a/control-plane/grpc/proto/v1/node/node.proto
+++ b/control-plane/grpc/proto/v1/node/node.proto
@@ -17,6 +17,12 @@ message Node {
   optional NodeState state = 3;
 }
 
+// Node cordon information
+message NodeCordon {
+  // Node cordon label.
+  repeated string label = 2;
+}
+
 message NodeSpec {
   // Node identification
   string node_id = 1;
@@ -24,6 +30,9 @@ message NodeSpec {
   string endpoint = 2;
   // Node labels.
   common.StringMapValue labels = 3;
+  // Cordon information.
+  NodeCordon cordon = 4;
+
 }
 
 message NodeState {
@@ -76,8 +85,38 @@ message ProbeResponse {
   bool ready = 1;
 }
 
+message CordonNodeRequest {
+  // Node identification
+  string node_id = 1;
+  // Node cordon label
+  string label = 2;
+}
+
+message CordonNodeReply {
+  oneof reply {
+    Node node = 1;
+    common.ReplyError error = 2;
+  }
+}
+
+message UncordonNodeRequest {
+  // Node identification
+  string node_id = 1;
+  // Node cordon label
+  string label = 2;
+}
+
+message UncordonNodeReply {
+  oneof reply {
+    Node node = 1;
+    common.ReplyError error = 2;
+  }
+}
+
 service NodeGrpc {
   rpc GetNodes (GetNodesRequest) returns (GetNodesReply) {}
   rpc GetBlockDevices (blockdevice.GetBlockDevicesRequest) returns (blockdevice.GetBlockDevicesReply) {}
   rpc Probe (ProbeRequest) returns (ProbeResponse) {}
+  rpc CordonNode (CordonNodeRequest) returns (CordonNodeReply) {}
+  rpc UncordonNode (UncordonNodeRequest) returns (UncordonNodeReply) {}
 }

--- a/control-plane/grpc/src/operations/node/server.rs
+++ b/control-plane/grpc/src/operations/node/server.rs
@@ -2,9 +2,10 @@ use crate::{
     blockdevice::{get_block_devices_reply, GetBlockDevicesReply, GetBlockDevicesRequest},
     node,
     node::{
-        get_nodes_reply,
+        cordon_node_reply, get_nodes_reply,
         node_grpc_server::{NodeGrpc, NodeGrpcServer},
-        GetNodesReply, GetNodesRequest, ProbeRequest, ProbeResponse,
+        uncordon_node_reply, CordonNodeReply, CordonNodeRequest, GetNodesReply, GetNodesRequest,
+        ProbeRequest, ProbeResponse, UncordonNodeReply, UncordonNodeRequest,
     },
     operations::node::traits::NodeOperations,
 };
@@ -68,6 +69,35 @@ impl NodeGrpc for NodeServer {
             })),
             Err(err) => Ok(Response::new(GetBlockDevicesReply {
                 reply: Some(get_block_devices_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+    async fn cordon_node(
+        &self,
+        request: tonic::Request<CordonNodeRequest>,
+    ) -> Result<tonic::Response<CordonNodeReply>, tonic::Status> {
+        let req: CordonNodeRequest = request.into_inner();
+        match self.service.cordon(req.node_id.into(), req.label).await {
+            Ok(node) => Ok(Response::new(CordonNodeReply {
+                reply: Some(cordon_node_reply::Reply::Node(node.into())),
+            })),
+            Err(err) => Ok(Response::new(CordonNodeReply {
+                reply: Some(cordon_node_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn uncordon_node(
+        &self,
+        request: tonic::Request<UncordonNodeRequest>,
+    ) -> Result<tonic::Response<UncordonNodeReply>, tonic::Status> {
+        let req: UncordonNodeRequest = request.into_inner();
+        match self.service.uncordon(req.node_id.into(), req.label).await {
+            Ok(node) => Ok(Response::new(UncordonNodeReply {
+                reply: Some(uncordon_node_reply::Reply::Node(node.into())),
+            })),
+            Err(err) => Ok(Response::new(UncordonNodeReply {
+                reply: Some(uncordon_node_reply::Reply::Error(err.into())),
             })),
         }
     }

--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -2,8 +2,8 @@ use clap::Parser;
 use openapi::tower::client::Url;
 use opentelemetry::global;
 use plugin::{
-    operations::{Get, GetBlockDevices, List, Operations, ReplicaTopology, Scale},
-    resources::{blockdevice, node, pool, volume, GetResources, ScaleResources},
+    operations::{Cordoning, Get, GetBlockDevices, List, Operations, ReplicaTopology, Scale},
+    resources::{blockdevice, node, pool, volume, CordonResources, GetResources, ScaleResources},
     rest_wrapper::RestClient,
 };
 use std::env;
@@ -63,7 +63,13 @@ async fn execute(cli_args: CliArgs) {
             GetResources::Pools => pool::Pools::list(&cli_args.output).await,
             GetResources::Pool { id } => pool::Pool::get(id, &cli_args.output).await,
             GetResources::Nodes => node::Nodes::list(&cli_args.output).await,
-            GetResources::Node { id } => node::Node::get(id, &cli_args.output).await,
+            GetResources::Node(args) => {
+                if args.show_cordon_labels() {
+                    node::Node::get_labels(&args.node_id(), &cli_args.output).await
+                } else {
+                    node::Node::get(&args.node_id(), &cli_args.output).await
+                }
+            }
             GetResources::BlockDevices(bdargs) => {
                 blockdevice::BlockDevice::get_blockdevices(
                     &bdargs.node_id(),
@@ -76,6 +82,16 @@ async fn execute(cli_args: CliArgs) {
         Operations::Scale(resource) => match resource {
             ScaleResources::Volume { id, replica_count } => {
                 volume::Volume::scale(id, *replica_count, &cli_args.output).await
+            }
+        },
+        Operations::Cordon(resource) => match resource {
+            CordonResources::Node { id, label } => {
+                node::Node::cordon(id, label, &cli_args.output).await
+            }
+        },
+        Operations::Uncordon(resource) => match resource {
+            CordonResources::Node { id, label } => {
+                node::Node::uncordon(id, label, &cli_args.output).await
             }
         },
     };

--- a/control-plane/plugin/src/operations.rs
+++ b/control-plane/plugin/src/operations.rs
@@ -1,4 +1,4 @@
-use crate::resources::{utils, GetResources, ScaleResources};
+use crate::resources::{utils, CordonResources, GetResources, ScaleResources};
 use async_trait::async_trait;
 
 /// The types of operations that are supported.
@@ -10,6 +10,12 @@ pub enum Operations {
     /// 'Scale' resources.
     #[clap(subcommand)]
     Scale(ScaleResources),
+    /// 'Cordon' resources.
+    #[clap(subcommand)]
+    Cordon(CordonResources),
+    /// 'Uncordon' resources.
+    #[clap(subcommand)]
+    Uncordon(CordonResources),
 }
 
 /// List trait.
@@ -49,4 +55,14 @@ pub trait ReplicaTopology {
 pub trait GetBlockDevices {
     type ID;
     async fn get_blockdevices(id: &Self::ID, all: &bool, output: &utils::OutputFormat);
+}
+
+/// Cordon trait.
+/// To be implemented by resources which support cordoning.
+#[async_trait(?Send)]
+pub trait Cordoning {
+    type ID;
+    async fn cordon(id: &Self::ID, label: &str, output: &utils::OutputFormat);
+    async fn uncordon(id: &Self::ID, label: &str, output: &utils::OutputFormat);
+    async fn get_labels(id: &Self::ID, output: &utils::OutputFormat);
 }

--- a/control-plane/plugin/src/resources/mod.rs
+++ b/control-plane/plugin/src/resources/mod.rs
@@ -1,4 +1,4 @@
-use crate::resources::blockdevice::BlockDeviceArgs;
+use crate::resources::{blockdevice::BlockDeviceArgs, node::GetNodeArgs};
 
 pub mod blockdevice;
 pub mod node;
@@ -27,7 +27,7 @@ pub enum GetResources {
     /// Get all nodes.
     Nodes,
     /// Get node with the given ID.
-    Node { id: NodeId },
+    Node(GetNodeArgs),
     /// Get BlockDevices present on the Node. Lists usable devices by default.
     /// Currently disks having blobstore pools not created by control-plane are also shown as
     /// usable.
@@ -44,6 +44,13 @@ pub enum ScaleResources {
         /// Replica count of the volume.
         replica_count: ReplicaCount,
     },
+}
+
+/// The types of resources that support cordoning.
+#[derive(clap::Subcommand, Debug)]
+pub enum CordonResources {
+    /// Cordon the node with the given ID by applying the cordon label to that node.
+    Node { id: NodeId, label: String },
 }
 
 /// Tabular Output Tests

--- a/control-plane/plugin/src/resources/node.rs
+++ b/control-plane/plugin/src/resources/node.rs
@@ -1,14 +1,38 @@
 use crate::{
-    operations::{Get, List},
+    operations::{Cordoning, Get, List},
     resources::{
         utils,
-        utils::{CreateRows, GetHeaderRow},
+        utils::{print_table, CreateRows, GetHeaderRow, OutputFormat},
         NodeId,
     },
     rest_wrapper::RestClient,
 };
 use async_trait::async_trait;
-use prettytable::Row;
+use openapi::models::NodeSpec;
+use prettytable::{Cell, Row};
+use serde::Serialize;
+
+#[derive(Debug, Clone, clap::Args)]
+/// Arguments used when getting a node.
+pub struct GetNodeArgs {
+    /// Id of the node
+    node_id: NodeId,
+    #[clap(long)]
+    /// Shows the cordon labels associated with the node
+    show_cordon_labels: bool,
+}
+
+impl GetNodeArgs {
+    /// Return the node ID.
+    pub fn node_id(&self) -> NodeId {
+        self.node_id.clone()
+    }
+
+    /// Return whether or not we should show the cordon labels.
+    pub fn show_cordon_labels(&self) -> bool {
+        self.show_cordon_labels
+    }
+}
 
 /// Nodes resource.
 #[derive(clap::Args, Debug)]
@@ -26,7 +50,12 @@ impl CreateRows for openapi::models::Node {
             grpc_endpoint: spec.grpc_endpoint,
             status: openapi::models::NodeStatus::Unknown,
         });
-        let rows = vec![row![self.id, state.grpc_endpoint, state.status,]];
+        let rows = vec![row![
+            self.id,
+            state.grpc_endpoint,
+            state.status,
+            !spec.cordon_labels.is_empty(),
+        ]];
         rows
     }
 }
@@ -65,10 +94,150 @@ impl Get for Node {
         match RestClient::client().nodes_api().get_node(id).await {
             Ok(node) => {
                 // Print table, json or yaml based on output format.
-                utils::print_table(output, node.into_body());
+                let node_display = NodeDisplay::new(node.into_body(), NodeDisplayFormat::Default);
+                print_table(output, node_display);
             }
             Err(e) => {
                 println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+}
+
+#[async_trait(?Send)]
+impl Cordoning for Node {
+    type ID = NodeId;
+    async fn cordon(id: &Self::ID, label: &str, output: &OutputFormat) {
+        match RestClient::client()
+            .nodes_api()
+            .put_node_cordon(id, label)
+            .await
+        {
+            Ok(node) => match output {
+                OutputFormat::Yaml | OutputFormat::Json => {
+                    // Print json or yaml based on output format.
+                    utils::print_table(output, node.into_body());
+                }
+                OutputFormat::None => {
+                    // In case the output format is not specified, show a success message.
+                    println!("Node {} cordoned successfully", id)
+                }
+            },
+            Err(e) => {
+                println!("Failed to cordon node {}. Error {}", id, e)
+            }
+        }
+    }
+
+    async fn uncordon(id: &Self::ID, label: &str, output: &OutputFormat) {
+        match RestClient::client()
+            .nodes_api()
+            .delete_node_cordon(id, label)
+            .await
+        {
+            Ok(node) => match output {
+                OutputFormat::Yaml | OutputFormat::Json => {
+                    // Print json or yaml based on output format.
+                    utils::print_table(output, node.into_body());
+                }
+                OutputFormat::None => {
+                    // In case the output format is not specified, show a success message.
+                    let cordon_labels = node
+                        .into_body()
+                        .spec
+                        .map(|node_spec| node_spec.cordon_labels)
+                        .unwrap_or_default();
+                    if cordon_labels.is_empty() {
+                        println!("Node {} successfully uncordoned", id);
+                    } else {
+                        println!(
+                            "Cordon label successfully removed. Remaining cordon labels {:?}",
+                            cordon_labels
+                        );
+                    }
+                }
+            },
+            Err(e) => {
+                println!("Failed to uncordon node {}. Error {}", id, e)
+            }
+        }
+    }
+
+    async fn get_labels(id: &Self::ID, output: &OutputFormat) {
+        match RestClient::client().nodes_api().get_node(id).await {
+            Ok(node) => {
+                let node_display =
+                    NodeDisplay::new(node.into_body(), NodeDisplayFormat::CordonLabels);
+                print_table(output, node_display);
+            }
+            Err(e) => {
+                println!("Failed to get node {}. Error {}", id, e)
+            }
+        }
+    }
+}
+
+/// Display format options for a `Node` object.
+#[derive(Debug)]
+enum NodeDisplayFormat {
+    Default,
+    CordonLabels,
+}
+
+/// The NodeDisply structure is responsible for controlling the display formatting of Node objects.
+/// `#[serde(flatten)]` and `#[serde(skip)]` attributes are used to ensure that when the object is
+/// serialised, only the `inner` object is represented.
+#[derive(Serialize, Debug)]
+struct NodeDisplay {
+    #[serde(flatten)]
+    inner: openapi::models::Node,
+    #[serde(skip)]
+    format: NodeDisplayFormat,
+}
+
+impl NodeDisplay {
+    /// Create a new `NodeDisplay` instance.
+    pub(crate) fn new(node: openapi::models::Node, format: NodeDisplayFormat) -> Self {
+        Self {
+            inner: node,
+            format,
+        }
+    }
+}
+
+// Create the rows required for a `NodeDisplay` object. Nodes returned from REST call.
+impl CreateRows for NodeDisplay {
+    fn create_rows(&self) -> Vec<Row> {
+        match self.format {
+            NodeDisplayFormat::Default => self.inner.create_rows(),
+            NodeDisplayFormat::CordonLabels => {
+                let mut rows = self.inner.create_rows();
+                let cordon_labels_string = self
+                    .inner
+                    .spec
+                    .as_ref()
+                    .unwrap_or(&NodeSpec::default())
+                    .cordon_labels
+                    .join(", ");
+
+                // Add the cordon labels to each row.
+                rows.iter_mut()
+                    .for_each(|row| row.add_cell(Cell::new(&cordon_labels_string)));
+                rows
+            }
+        }
+    }
+}
+
+// Create the header for a `NodeDisplay` object.
+impl GetHeaderRow for NodeDisplay {
+    fn get_header_row(&self) -> Row {
+        let mut header = (&*utils::NODE_HEADERS).clone();
+        match self.format {
+            NodeDisplayFormat::Default => header,
+            NodeDisplayFormat::CordonLabels => {
+                header.extend(vec!["CORDON LABELS"]);
+                header
             }
         }
     }

--- a/control-plane/plugin/src/resources/utils.rs
+++ b/control-plane/plugin/src/resources/utils.rs
@@ -29,7 +29,7 @@ lazy_static! {
         "STATUS",
         "MANAGED"
     ];
-    pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS",];
+    pub static ref NODE_HEADERS: Row = row!["ID", "GRPC ENDPOINT", "STATUS", "CORDONED"];
     pub static ref REPLICA_TOPOLOGY_HEADERS: Row = row!["ID", "NODE", "POOL", "STATUS"];
     pub static ref BLOCKDEVICE_HEADERS_ALL: Row = row![
         "DEVNAME",

--- a/control-plane/plugin/src/resources/volume.rs
+++ b/control-plane/plugin/src/resources/volume.rs
@@ -126,7 +126,7 @@ impl Scale for Volume {
                 }
                 OutputFormat::None => {
                     // In case the output format is not specified, show a success message.
-                    println!("Volume {} Scaled Successfully 🚀", id)
+                    println!("Volume {} scaled successfully 🚀", id)
                 }
             },
             Err(e) => {

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -228,6 +228,63 @@ paths:
           $ref: '#/components/responses/ServerError'
       security:
         - JWT: []
+  '/nodes/{id}/cordon/{label}':
+    put:
+      tags:
+        - Nodes
+      operationId: put_node_cordon
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: label
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
+    delete:
+      tags:
+        - Nodes
+      operationId: delete_node_cordon
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: label
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Node'
+        '4XX':
+          $ref: '#/components/responses/ClientError'
+        '5XX':
+          $ref: '#/components/responses/ServerError'
+      security:
+        - JWT: [ ]
   '/nodes/{id}/nexuses':
     get:
       tags:
@@ -2010,6 +2067,7 @@ components:
       example:
         grpcEndpoint: '10.1.0.5:10124'
         id: io-engine-1
+        cordonLabels: [label-1]
       description: io-engine storage node information
       type: object
       properties:
@@ -2018,9 +2076,14 @@ components:
           type: string
         id:
           $ref: '#/components/schemas/NodeId'
+        cordonLabels:
+          type: array
+          items:
+            type: string
       required:
         - grpcEndpoint
         - id
+        - cordonLabels
     NodeState:
       example:
         grpcEndpoint: '10.1.0.5:10124'

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -23,6 +23,18 @@ impl apis::actix_server::Nodes for RestApi {
         let nodes = client().get(Filter::None, None).await?;
         Ok(nodes.into_inner().into_vec())
     }
+
+    async fn put_node_cordon(
+        Path((_id, _label)): Path<(String, String)>,
+    ) -> Result<models::Node, RestError<RestJsonError>> {
+        todo!()
+    }
+
+    async fn delete_node_cordon(
+        Path((_id, _label)): Path<(String, String)>,
+    ) -> Result<models::Node, RestError<RestJsonError>> {
+        todo!()
+    }
 }
 
 /// returns node from node option and returns an error on non existence

--- a/control-plane/rest/service/src/v0/nodes.rs
+++ b/control-plane/rest/service/src/v0/nodes.rs
@@ -25,15 +25,17 @@ impl apis::actix_server::Nodes for RestApi {
     }
 
     async fn put_node_cordon(
-        Path((_id, _label)): Path<(String, String)>,
+        Path((id, label)): Path<(String, String)>,
     ) -> Result<models::Node, RestError<RestJsonError>> {
-        todo!()
+        let node = client().cordon(id.into(), label).await?;
+        Ok(node.into())
     }
 
     async fn delete_node_cordon(
-        Path((_id, _label)): Path<(String, String)>,
+        Path((id, label)): Path<(String, String)>,
     ) -> Result<models::Node, RestError<RestJsonError>> {
-        todo!()
+        let node = client().uncordon(id.into(), label).await?;
+        Ok(node.into())
     }
 }
 

--- a/control-plane/rest/tests/v0_test.rs
+++ b/control-plane/rest/tests/v0_test.rs
@@ -94,6 +94,7 @@ async fn client_test(cluster: &Cluster, auth: &bool) {
                 "{}:10124",
                 cluster.composer().container_ip(cluster.node(0).as_str())
             ),
+            cordon_labels: vec![],
         }),
         state: Some(models::NodeState {
             id: io_engine1.to_string(),

--- a/k8s/plugin/src/resources/mod.rs
+++ b/k8s/plugin/src/resources/mod.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use plugin::resources::{GetResources, ScaleResources};
+use plugin::resources::{CordonResources, GetResources, ScaleResources};
 use supportability::DumpArgs;
 
 /// The types of operations that are supported.
@@ -11,6 +11,12 @@ pub enum Operations {
     /// 'Scale' resources.
     #[clap(subcommand)]
     Scale(ScaleResources),
+    /// 'Cordon' resources.
+    #[clap(subcommand)]
+    Cordon(CordonResources),
+    /// 'Uncordon' resources.
+    #[clap(subcommand)]
+    Uncordon(CordonResources),
     /// `Dump` resources.
     Dump(DumpArgs),
 }

--- a/tests/bdd/features/cordon/node/feature.feature
+++ b/tests/bdd/features/cordon/node/feature.feature
@@ -38,10 +38,29 @@ Feature: Cordoning
 
   Scenario: Deleting resources on a cordoned node
     Given a cordoned node with resources
-    When the control plane attempts to delete a resource on a cordoned node
-    Then the resource should be deleted
+    When the control plane attempts to delete resources on a cordoned node
+    Then the resources should be deleted
 
   Scenario: Restarting a cordoned node
     Given a cordoned node with resources
     When the cordoned node is restarted
     Then resources that existed on the cordoned node prior to the restart should be recreated on the same cordoned node
+
+  Scenario: Cordoning a node with an existing label
+    Given a cordoned node
+    When the node is cordoned again with the same label
+    Then cordoning should fail
+    And the cordoned node should remain cordoned
+
+  Scenario: Uncordoning a node with an unknown label
+    Given a cordoned node
+    When the node is uncordoned using an unknown cordon label
+    Then uncordoning should fail
+    And the cordoned node should remain cordoned
+
+  Scenario: Unschedulable replicas due to node cordon
+    Given a published volume with multiple replicas
+    And a cordoned node
+    When the volume becomes degraded
+    And there are insufficient uncordoned nodes to accommodate new replicas
+    Then the volume will remain in a degraded state


### PR DESCRIPTION
Provide the ability to cordon a node. Applying a cordon prevents the
control plane from being able to schedule resources on that node.

When cordoning a node a label must be applied. This uniquely identifies
a particular cordon operation. When uncordoning a node the appropriate
label must also be supplied.

A particular cordon label can only be applied once. Attempting to apply
a cordon with a label that already exists will fail.

Cordoning a node can be achieved through the kubectl plugin using the
following command:
    kubectl-mayastor cordon node <node_id> <label>

Uncordoning a node can be achieved through the kubectl plugin using the
following command:
    kubectl-mayastor uncordon node <node_id> <label>

Cordon labels can be listed through the kubectl plugin using the
following command:
    kubectl-mayastor get cordon-labels <node_id>