### PR TITLE
fix(cordon): ensure backwards compatibility

### DIFF
--- a/common/src/types/v0/store/node.rs
+++ b/common/src/types/v0/store/node.rs
@@ -35,6 +35,7 @@ pub struct NodeSpec {
     /// Node labels.
     labels: NodeLabels,
     /// Cordon labels.
+    #[serde(default)] // Ensure backwards compatibility in etcd when upgrading.
     cordon_labels: Vec<String>,
 }
 impl NodeSpec {


### PR DESCRIPTION
The NodeSpec structure is persisted in etcd. A new member
(cordon_labels) has been added to the NodeSpec structure to support node
cordoning.

When the core agent starts, it deserialises the contents of etcd into
it's own internal data structures. During an upgrade, the core agent
will be attempting to deserialise the old NodeSpec into a new NodeSpec
structure. By marking the new field with `#[serde(default)]` we allow
this deserialisation to succeed.

The default cordon_label value will be an empty vector which is correct
as previous versions did not support cordoning. When the node is
subsequently cordoned, the new NodeSpec structure will be persisted to
etcd.

Signed-off-by: Paul Yoong <paul.yoong@mayadata.io>