### PR TITLE
refactor(csi): accessible topology to be not used for data placement

### DIFF
--- a/control-plane/csi-driver/controller/src/config.rs
+++ b/control-plane/csi-driver/controller/src/config.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, time::Duration};
 static CONFIG: OnceCell<CsiControllerConfig> = OnceCell::new();
 
 // Global CSI Controller config.
-pub struct CsiControllerConfig {
+pub(crate) struct CsiControllerConfig {
     /// REST API endpoint URL.
     rest_endpoint: String,
     /// I/O timeout for REST API operations.
@@ -17,7 +17,7 @@ pub struct CsiControllerConfig {
 
 impl CsiControllerConfig {
     /// Initialize global instance of the CSI config. Must be called prior to using the config.
-    pub fn initialize(args: &ArgMatches) -> anyhow::Result<()> {
+    pub(crate) fn initialize(args: &ArgMatches) -> anyhow::Result<()> {
         assert!(
             CONFIG.get().is_none(),
             "CSI Controller config already initialized"
@@ -72,24 +72,24 @@ impl CsiControllerConfig {
     }
 
     /// Get global instance of CSI controller config.
-    pub fn get_config() -> &'static CsiControllerConfig {
+    pub(crate) fn get_config() -> &'static CsiControllerConfig {
         CONFIG
             .get()
             .expect("CSI Controller config is not initialized")
     }
 
     /// Get REST API endpoint.
-    pub fn rest_endpoint(&self) -> &str {
+    pub(crate) fn rest_endpoint(&self) -> &str {
         &self.rest_endpoint
     }
 
     /// Get I/O timeout for REST API operations.
-    pub fn io_timeout(&self) -> Duration {
+    pub(crate) fn io_timeout(&self) -> Duration {
         self.io_timeout
     }
 
     /// IO-Engine DaemonSet selector labels.
-    pub fn io_engine_selector(&self) -> HashMap<String, String> {
+    pub(crate) fn io_engine_selector(&self) -> HashMap<String, String> {
         self.io_engine_selector.clone()
     }
 }

--- a/control-plane/csi-driver/controller/src/identity.rs
+++ b/control-plane/csi-driver/controller/src/identity.rs
@@ -5,7 +5,7 @@ use tonic::{Request, Response, Status};
 use tracing::{debug, error, instrument};
 
 #[derive(Debug, Default)]
-pub struct CsiIdentitySvc {}
+pub(crate) struct CsiIdentitySvc {}
 
 const CSI_PLUGIN_NAME: &str = "io.openebs.csi-mayastor";
 const CSI_PLUGIN_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/control-plane/csi-driver/controller/src/main.rs
+++ b/control-plane/csi-driver/controller/src/main.rs
@@ -23,7 +23,7 @@ fn initialize_controller(args: &ArgMatches) -> anyhow::Result<()> {
 }
 
 #[tokio::main(worker_threads = 2)]
-pub async fn main() -> anyhow::Result<()> {
+async fn main() -> anyhow::Result<()> {
     let default_io_selector = CsiControllerConfig::default_io_selector();
     let args = App::new(utils::package_description!())
         .author(clap::crate_authors!())

--- a/control-plane/csi-driver/controller/src/server.rs
+++ b/control-plane/csi-driver/controller/src/server.rs
@@ -20,7 +20,7 @@ use rpc::csi::{controller_server::ControllerServer, identity_server::IdentitySer
 use crate::{controller::CsiControllerSvc, identity::CsiIdentitySvc};
 
 #[derive(Debug)]
-struct UnixStream(pub tokio::net::UnixStream);
+struct UnixStream(tokio::net::UnixStream);
 
 impl Connected for UnixStream {
     type ConnectInfo = UdsConnectInfo;

--- a/control-plane/csi-driver/node/src/block_vol.rs
+++ b/control-plane/csi-driver/node/src/block_vol.rs
@@ -16,7 +16,7 @@ use crate::{
     mount::{self},
 };
 
-pub async fn publish_block_volume(msg: &NodePublishVolumeRequest) -> Result<(), Status> {
+pub(crate) async fn publish_block_volume(msg: &NodePublishVolumeRequest) -> Result<(), Status> {
     let target_path = &msg.target_path;
     let volume_id = &msg.volume_id;
 
@@ -113,7 +113,7 @@ pub async fn publish_block_volume(msg: &NodePublishVolumeRequest) -> Result<(), 
     }
 }
 
-pub fn unpublish_block_volume(msg: &NodeUnpublishVolumeRequest) -> Result<(), Status> {
+pub(crate) fn unpublish_block_volume(msg: &NodeUnpublishVolumeRequest) -> Result<(), Status> {
     let target_path = &msg.target_path;
     let volume_id = &msg.volume_id;
 

--- a/control-plane/csi-driver/node/src/config.rs
+++ b/control-plane/csi-driver/node/src/config.rs
@@ -68,7 +68,7 @@ impl TryFrom<NvmeArgValues> for NvmeConfig {
     }
 }
 /// Nvme Arguments taken from the CSI volume calls (storage class parameters)
-pub type NvmeParseParams<'a> = &'a HashMap<String, String>;
+pub(crate) type NvmeParseParams<'a> = &'a HashMap<String, String>;
 impl TryFrom<NvmeParseParams<'_>> for NvmeArgValues {
     type Error = String;
     fn try_from(_value: NvmeParseParams) -> Result<Self, Self::Error> {

--- a/control-plane/csi-driver/node/src/dev.rs
+++ b/control-plane/csi-driver/node/src/dev.rs
@@ -41,13 +41,13 @@ mod util;
 
 const NVME_NQN_PREFIX: &str = "nqn.2019-05.io.openebs";
 
-pub use crate::error::DeviceError;
+pub(crate) use crate::error::DeviceError;
 use crate::match_dev;
 
-pub type DeviceName = String;
+pub(crate) type DeviceName = String;
 
 #[tonic::async_trait]
-pub trait Attach: Sync + Send {
+pub(crate) trait Attach: Sync + Send {
     async fn parse_parameters(
         &mut self,
         context: &HashMap<String, String>,
@@ -59,17 +59,17 @@ pub trait Attach: Sync + Send {
 }
 
 #[tonic::async_trait]
-pub trait Detach: Sync + Send {
+pub(crate) trait Detach: Sync + Send {
     async fn detach(&self) -> Result<(), DeviceError>;
     fn devname(&self) -> DeviceName;
 }
 
-pub struct Device;
+pub(crate) struct Device;
 
 impl Device {
     /// Main dispatch function for parsing URIs in order
     /// to obtain a device implementing the Attach trait.
-    pub fn parse(uri: &str) -> Result<Box<dyn Attach>, DeviceError> {
+    pub(crate) fn parse(uri: &str) -> Result<Box<dyn Attach>, DeviceError> {
         let url = Url::parse(uri).map_err(|error| error.to_string())?;
         match url.scheme() {
             "file" => Ok(Box::new(nbd::Nbd::try_from(&url)?)),
@@ -85,7 +85,7 @@ impl Device {
 
     /// Lookup an existing device in udev matching the given UUID
     /// to obtain a device implementing the Detach trait.
-    pub async fn lookup(uuid: &Uuid) -> Result<Option<Box<dyn Detach>>, DeviceError> {
+    pub(crate) async fn lookup(uuid: &Uuid) -> Result<Option<Box<dyn Detach>>, DeviceError> {
         let nvmf_key: String = format!("uuid.{}", uuid);
 
         let mut enumerator = Enumerator::new()?;
@@ -122,7 +122,7 @@ impl Device {
 
     /// Wait for a device to show up in udev
     /// once attach() has been called.
-    pub async fn wait_for_device(
+    pub(crate) async fn wait_for_device(
         device: &dyn Attach,
         timeout: Duration,
         retries: u32,

--- a/control-plane/csi-driver/node/src/error.rs
+++ b/control-plane/csi-driver/node/src/error.rs
@@ -2,12 +2,12 @@
 use nvmeadm::nvmf_discovery;
 use std::string::FromUtf8Error;
 
-pub struct DeviceError {
-    pub message: String,
+pub(crate) struct DeviceError {
+    pub(crate) message: String,
 }
 
 impl DeviceError {
-    pub fn new(message: &str) -> DeviceError {
+    pub(crate) fn new(message: &str) -> DeviceError {
         DeviceError {
             message: String::from(message),
         }

--- a/control-plane/csi-driver/node/src/filesystem_vol.rs
+++ b/control-plane/csi-driver/node/src/filesystem_vol.rs
@@ -15,7 +15,7 @@ use crate::{
     mount::{self, subset, ReadOnly},
 };
 
-pub async fn stage_fs_volume(
+pub(crate) async fn stage_fs_volume(
     msg: &NodeStageVolumeRequest,
     device_path: String,
     mnt: &MountVolume,
@@ -118,7 +118,7 @@ pub async fn stage_fs_volume(
 }
 
 /// Unstage a filesystem volume
-pub async fn unstage_fs_volume(msg: &NodeUnstageVolumeRequest) -> Result<(), Status> {
+pub(crate) async fn unstage_fs_volume(msg: &NodeUnstageVolumeRequest) -> Result<(), Status> {
     let volume_id = &msg.volume_id;
     let fs_staging_path = &msg.staging_target_path;
 
@@ -143,7 +143,7 @@ pub async fn unstage_fs_volume(msg: &NodeUnstageVolumeRequest) -> Result<(), Sta
 }
 
 /// Publish a filesystem volume
-pub fn publish_fs_volume(
+pub(crate) fn publish_fs_volume(
     msg: &NodePublishVolumeRequest,
     mnt: &MountVolume,
     filesystems: &[String],
@@ -281,7 +281,7 @@ pub fn publish_fs_volume(
     Ok(())
 }
 
-pub fn unpublish_fs_volume(msg: &NodeUnpublishVolumeRequest) -> Result<(), Status> {
+pub(crate) fn unpublish_fs_volume(msg: &NodeUnpublishVolumeRequest) -> Result<(), Status> {
     // filesystem mount
     let target_path = &msg.target_path;
     let volume_id = &msg.volume_id;

--- a/control-plane/csi-driver/node/src/identity.rs
+++ b/control-plane/csi-driver/node/src/identity.rs
@@ -9,7 +9,7 @@ const PLUGIN_NAME: &str = "io.openebs.csi-mayastor";
 const PLUGIN_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Clone, Debug)]
-pub struct Identity {}
+pub(crate) struct Identity {}
 
 impl Identity {}
 #[tonic::async_trait]

--- a/control-plane/csi-driver/node/src/main.rs
+++ b/control-plane/csi-driver/node/src/main.rs
@@ -33,7 +33,7 @@ use tracing::info;
 #[allow(clippy::redundant_closure)]
 #[allow(clippy::enum_variant_names)]
 #[allow(clippy::upper_case_acronyms)]
-pub mod csi {
+pub(crate) mod csi {
     #![allow(clippy::derive_partial_eq_without_eq)]
     tonic::include_proto!("csi.v1");
 }
@@ -237,10 +237,10 @@ impl CsiServer {
         };
 
         if let Err(e) = Server::builder()
-            .add_service(NodeServer::new(Node {
-                node_name: node_name.into(),
-                filesystems: probe_filesystems(),
-            }))
+            .add_service(NodeServer::new(Node::new(
+                node_name.into(),
+                probe_filesystems(),
+            )))
             .add_service(IdentityServer::new(Identity {}))
             .serve_with_incoming_shutdown(incoming, Shutdown::wait())
             .await

--- a/control-plane/csi-driver/node/src/mount.rs
+++ b/control-plane/csi-driver/node/src/mount.rs
@@ -25,7 +25,7 @@ impl ReadOnly for &str {
 }
 
 /// Return mountinfo matching source and/or destination.
-pub fn find_mount(source: Option<&str>, target: Option<&str>) -> Option<MountInfo> {
+pub(crate) fn find_mount(source: Option<&str>, target: Option<&str>) -> Option<MountInfo> {
     let mut found: Option<MountInfo> = None;
 
     for mount in MountIter::new().unwrap().flatten() {
@@ -70,7 +70,7 @@ pub(super) fn subset(first: &[String], second: &[String]) -> bool {
 }
 
 /// Return supported filesystems.
-pub fn probe_filesystems() -> Vec<String> {
+pub(crate) fn probe_filesystems() -> Vec<String> {
     vec![String::from("xfs"), String::from("ext4")]
 }
 
@@ -122,7 +122,7 @@ fn show(options: &[String]) -> String {
 }
 
 /// Mount a device to a directory (mountpoint)
-pub fn filesystem_mount(
+pub(crate) fn filesystem_mount(
     device: &str,
     target: &str,
     fstype: &str,
@@ -157,7 +157,7 @@ pub fn filesystem_mount(
 
 /// Unmount a device from a directory (mountpoint)
 /// Should not be used for removing bind mounts.
-pub fn filesystem_unmount(target: &str) -> Result<(), Error> {
+pub(crate) fn filesystem_unmount(target: &str) -> Result<(), Error> {
     let mut flags = UnmountFlags::empty();
 
     flags.insert(UnmountFlags::DETACH);
@@ -171,7 +171,7 @@ pub fn filesystem_unmount(target: &str) -> Result<(), Error> {
 
 /// Bind mount a source path to a target path.
 /// Supports both directories and files.
-pub fn bind_mount(source: &str, target: &str, file: bool) -> Result<Mount, Error> {
+pub(crate) fn bind_mount(source: &str, target: &str, file: bool) -> Result<Mount, Error> {
     let mut flags = MountFlags::empty();
 
     flags.insert(MountFlags::BIND);
@@ -189,7 +189,7 @@ pub fn bind_mount(source: &str, target: &str, file: bool) -> Result<Mount, Error
 
 /// Bind remount a path to modify mount options.
 /// Assumes that target has already been bind mounted.
-pub fn bind_remount(target: &str, options: &[String]) -> Result<Mount, Error> {
+pub(crate) fn bind_remount(target: &str, options: &[String]) -> Result<Mount, Error> {
     let mut flags = MountFlags::empty();
 
     let (readonly, value) = parse(options);
@@ -221,7 +221,7 @@ pub fn bind_remount(target: &str, options: &[String]) -> Result<Mount, Error> {
 
 /// Unmounts a path that has previously been bind mounted.
 /// Should not be used for unmounting devices.
-pub fn bind_unmount(target: &str) -> Result<(), Error> {
+pub(crate) fn bind_unmount(target: &str) -> Result<(), Error> {
     let flags = UnmountFlags::empty();
 
     unmount(target, flags)?;
@@ -232,7 +232,11 @@ pub fn bind_unmount(target: &str) -> Result<(), Error> {
 }
 
 /// Mount a block device
-pub fn blockdevice_mount(source: &str, target: &str, readonly: bool) -> Result<Mount, Error> {
+pub(crate) fn blockdevice_mount(
+    source: &str,
+    target: &str,
+    readonly: bool,
+) -> Result<Mount, Error> {
     debug!("Mounting {} ...", source);
 
     let mut flags = MountFlags::empty();
@@ -254,7 +258,7 @@ pub fn blockdevice_mount(source: &str, target: &str, readonly: bool) -> Result<M
 }
 
 /// Unmount a block device.
-pub fn blockdevice_unmount(target: &str) -> Result<(), Error> {
+pub(crate) fn blockdevice_unmount(target: &str) -> Result<(), Error> {
     let flags = UnmountFlags::empty();
 
     debug!("Unmounting block device {} (flags={:?}) ...", target, flags);

--- a/control-plane/csi-driver/node/src/node.rs
+++ b/control-plane/csi-driver/node/src/node.rs
@@ -20,9 +20,20 @@ use crate::{
 };
 
 #[derive(Clone, Debug)]
-pub struct Node {
-    pub node_name: String,
-    pub filesystems: Vec<String>,
+/// Node structure
+pub(crate) struct Node {
+    node_name: String,
+    filesystems: Vec<String>,
+}
+
+impl Node {
+    /// create new node
+    pub(crate) fn new(node_name: String, filesystems: Vec<String>) -> Node {
+        Self {
+            node_name,
+            filesystems,
+        }
+    }
 }
 
 const ATTACH_TIMEOUT_INTERVAL: Duration = Duration::from_millis(100);
@@ -111,7 +122,6 @@ async fn detach(uuid: &Uuid, errheader: String) -> Result<(), Status> {
     Ok(())
 }
 
-impl Node {}
 #[tonic::async_trait]
 impl node_server::Node for Node {
     async fn node_get_info(

--- a/control-plane/csi-driver/node/src/nodeplugin_grpc.rs
+++ b/control-plane/csi-driver/node/src/nodeplugin_grpc.rs
@@ -12,14 +12,14 @@ use io_engine_node_plugin::{
 use nodeplugin_svc::{find_volume, freeze_volume, unfreeze_volume, ServiceError, TypeOfMount};
 use tonic::{transport::Server, Code, Request, Response, Status};
 
-pub mod io_engine_node_plugin {
+pub(crate) mod io_engine_node_plugin {
     #![allow(clippy::derive_partial_eq_without_eq)]
     #![allow(clippy::upper_case_acronyms)]
     tonic::include_proto!("ioenginenodeplugin");
 }
 
 #[derive(Debug, Default)]
-pub struct IoEngineNodePluginSvc {}
+pub(crate) struct IoEngineNodePluginSvc {}
 
 impl From<ServiceError> for Status {
     fn from(err: ServiceError) -> Self {
@@ -78,10 +78,10 @@ impl IoEngineNodePlugin for IoEngineNodePluginSvc {
     }
 }
 
-pub struct IoEngineNodePluginGrpcServer {}
+pub(crate) struct IoEngineNodePluginGrpcServer {}
 
 impl IoEngineNodePluginGrpcServer {
-    pub async fn run(endpoint: std::net::SocketAddr) -> Result<(), ()> {
+    pub(crate) async fn run(endpoint: std::net::SocketAddr) -> Result<(), ()> {
         info!(
             "IoEngine node plugin gRPC server configured at address {:?}",
             endpoint


### PR DESCRIPTION
- Accessibility topology will not be used for data-placement.
- Remove use of explicit topology, as it restricts usage of new node, rebuilds.
- Remove code around `local` flag
- Resolves https://github.com/openebs/mayastor/issues/1154

Signed-off-by: Abhinandan Purkait <abhinandan.purkait@mayadata.io>