### PR TITLE
feat(deployer): add the csi-node plugin to the deployer

### DIFF
--- a/control-plane/csi-driver/Cargo.toml
+++ b/control-plane/csi-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "csi-driver"
-description = "CSI controller"
+description = "CSI Driver"
 version = "1.0.0"
 edition = "2021"
 

--- a/control-plane/csi-driver/node/src/main.rs
+++ b/control-plane/csi-driver/node/src/main.rs
@@ -135,7 +135,8 @@ async fn main() -> Result<(), String> {
                 .long("grpc-endpoint")
                 .value_name("NAME")
                 .help("ip address where this instance runs, and optionally the gRPC port")
-                .required(true)
+                .default_value("0.0.0.0")
+                .required(false)
                 .takes_value(true),
         )
         .arg(

--- a/deployer/bin/src/deployer.rs
+++ b/deployer/bin/src/deployer.rs
@@ -1,18 +1,18 @@
 use deployer_lib::CliArgs;
 use structopt::StructOpt;
 
-const RUST_LOG_QUIET_DEFAULTS: &str =
+const RUST_LOG_SILENCE_DEFAULTS: &str =
     "h2=info,hyper=info,tower_buffer=info,tower=info,rustls=info,reqwest=info,mio=info,tokio_util=info,async_io=info,polling=info,tonic=info,want=info,bollard=info,common_lib=warn";
 fn rust_log_add_quiet_defaults(
     current: Option<tracing_subscriber::EnvFilter>,
 ) -> tracing_subscriber::EnvFilter {
     let main = match current {
         None => {
-            format!("info,{}", RUST_LOG_QUIET_DEFAULTS)
+            format!("info,{}", RUST_LOG_SILENCE_DEFAULTS)
         }
         Some(level) => match level.to_string().as_str() {
             "debug" | "trace" => {
-                format!("{},{}", level, RUST_LOG_QUIET_DEFAULTS)
+                format!("{},{}", level, RUST_LOG_SILENCE_DEFAULTS)
             }
             _ => return level,
         },

--- a/deployer/src/infra/csi_controller.rs
+++ b/deployer/src/infra/csi_controller.rs
@@ -8,17 +8,17 @@ use tower::service_fn;
 
 use rpc::csi::{identity_client::IdentityClient, GetPluginInfoRequest};
 
-const CSI_SOCKET: &str = "/var/tmp/csi.sock";
+const CSI_SOCKET: &str = "/var/tmp/csi-controller.sock";
 
 #[async_trait]
-impl ComponentAction for Csi {
+impl ComponentAction for CsiController {
     fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
-        Ok(if !options.csi {
+        Ok(if !options.csi_controller {
             cfg
         } else {
             if options.build {
                 std::process::Command::new("cargo")
-                    .args(&["build", "-p", "csi-controller", "--bin", "csi-controller"])
+                    .args(&["build", "-p", "csi-driver", "--bin", "csi-controller"])
                     .status()?;
             }
 
@@ -45,14 +45,14 @@ impl ComponentAction for Csi {
         })
     }
     async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
-        if options.csi {
+        if options.csi_controller {
             cfg.start("csi-controller").await?;
         }
         Ok(())
     }
 
     async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
-        if !options.csi {
+        if !options.csi_controller {
             return Ok(());
         }
 

--- a/deployer/src/infra/csi_node.rs
+++ b/deployer/src/infra/csi_node.rs
@@ -1,0 +1,181 @@
+use super::*;
+use tokio::{
+    net::UnixStream,
+    time::{sleep, Duration},
+};
+use tonic::transport::{Endpoint, Uri};
+use tower::service_fn;
+
+use crate::IoEngine;
+use rpc::csi::{identity_client::IdentityClient, GetPluginInfoRequest};
+
+const CSI_NODE: &str = "csi-node";
+
+#[async_trait]
+impl ComponentAction for CsiNode {
+    fn configure(&self, options: &StartOptions, mut cfg: Builder) -> Result<Builder, Error> {
+        Ok(if !options.csi_node {
+            cfg
+        } else {
+            if options.build {
+                std::process::Command::new("cargo")
+                    .args(&["build", "-p", "csi-driver", "--bin", CSI_NODE])
+                    .status()?;
+            }
+
+            let local_nodes = if options.local_nodes {
+                options.io_engines
+            } else {
+                0
+            };
+
+            for i in 0 .. local_nodes {
+                cfg = CsiNode::with_local_node(i, options, cfg);
+            }
+
+            for i in 0 .. options.app_nodes() {
+                cfg = CsiNode::with_app_node(i, cfg);
+            }
+            cfg
+        })
+    }
+    async fn start(&self, options: &StartOptions, cfg: &ComposeTest) -> Result<(), Error> {
+        if options.csi_node {
+            let local_nodes = if options.local_nodes {
+                options.io_engines
+            } else {
+                0
+            };
+
+            for i in 0 .. local_nodes {
+                let container_name = Self::local_container_name(&IoEngine::name(i, options));
+                cfg.start(&container_name).await?;
+            }
+
+            for i in 0 .. options.app_nodes() {
+                cfg.start(&Self::container_name(i)).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn wait_on(&self, options: &StartOptions, _cfg: &ComposeTest) -> Result<(), Error> {
+        if !options.csi_node {
+            return Ok(());
+        }
+
+        let local_nodes = if options.local_nodes {
+            options.io_engines
+        } else {
+            0
+        };
+
+        for i in 0 .. local_nodes {
+            CsiNode::wait_local_node(i, options).await?;
+        }
+
+        for i in 0 .. options.app_nodes() {
+            CsiNode::wait_app_node(i).await?;
+        }
+
+        Ok(())
+    }
+}
+
+impl CsiNode {
+    fn name(i: u32) -> String {
+        format!("app-node-{}", i + 1)
+    }
+    fn container_name(i: u32) -> String {
+        format!("{}-{}", CSI_NODE, i + 1)
+    }
+    fn local_container_name(io_engine: &str) -> String {
+        format!("{}-{}", CSI_NODE, io_engine)
+    }
+    fn socket(node_name: &str) -> String {
+        format!("/var/tmp/csi-{}.sock", node_name)
+    }
+    fn with_app_node(index: u32, cfg: Builder) -> Builder {
+        let container_name = Self::container_name(index);
+        let node_name = Self::name(index);
+        let socket = Self::socket(&node_name);
+
+        Self::with_node(&container_name, &node_name, &socket, cfg)
+    }
+    fn with_local_node(index: u32, options: &StartOptions, cfg: Builder) -> Builder {
+        let container_name = Self::local_container_name(&IoEngine::name(index, options));
+        let node_name = IoEngine::name(index, options);
+        let socket = Self::socket(&node_name);
+
+        Self::with_node(&container_name, &node_name, &socket, cfg)
+    }
+    fn with_node(container_name: &str, node_name: &str, socket: &str, cfg: Builder) -> Builder {
+        let binary = Binary::from_dbg(CSI_NODE)
+            .with_args(vec!["--nvme-nr-io-queues", "1"])
+            .with_args(vec!["--node-name", node_name])
+            // Make sure that CSI socket is always under shared directory
+            // regardless of what its default value is.
+            .with_args(vec!["--csi-socket", socket]);
+
+        let path = format!(
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:{}",
+            env!("PATH")
+        );
+
+        cfg.add_container_spec(
+            ContainerSpec::from_binary(container_name, binary)
+                .with_bypass_default_mounts(true)
+                .with_bind("/var/tmp", "/var/tmp")
+                .with_bind("/dev", "/dev:ro")
+                .with_bind("/run/udev", "/run/udev:ro")
+                .with_env("PATH", path.as_str())
+                .with_privileged(Some(true)),
+        )
+    }
+    async fn wait_app_node(index: u32) -> Result<(), Error> {
+        let node_name = Self::name(index);
+        let socket = Self::socket(&node_name);
+
+        Self::wait_node(&socket).await
+    }
+    async fn wait_local_node(index: u32, options: &StartOptions) -> Result<(), Error> {
+        let node_name = Self::local_container_name(&IoEngine::name(index, options));
+        let socket = Self::socket(&node_name);
+
+        Self::wait_node(&socket).await
+    }
+    async fn wait_node(socket: &str) -> Result<(), Error> {
+        // Step 1: Wait till CSI node's gRPC server is registered and is ready
+        // to serve API requests.
+        let endpoint =
+            Endpoint::try_from("http://[::]:50051")?.connect_timeout(Duration::from_millis(150));
+
+        let channel = loop {
+            let socket = socket.to_string();
+            match endpoint
+                .connect_with_connector(service_fn(move |_: Uri| {
+                    UnixStream::connect(socket.to_string())
+                }))
+                .await
+            {
+                Ok(channel) => break channel,
+                Err(_) => sleep(Duration::from_millis(150)).await,
+            }
+        };
+
+        let mut client = IdentityClient::new(channel);
+
+        // Step 2: Make sure we can perform a successful RPC call.
+        loop {
+            match client
+                .get_plugin_info(GetPluginInfoRequest::default())
+                .await
+            {
+                Ok(_) => break,
+                Err(_) => sleep(Duration::from_millis(150)).await,
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -1,5 +1,6 @@
 mod core;
-mod csi;
+mod csi_controller;
+mod csi_node;
 pub mod dns;
 mod elastic;
 mod empty;
@@ -403,17 +404,18 @@ impl Drop for TraceFn {
 // Component Name and bootstrap ordering
 // from lower to high
 impl_component! {
-    Empty,      0,
-    Jaeger,     0,
-    Dns,        1,
-    Etcd,       1,
-    Elastic,    1,
-    Kibana,     1,
-    Core,       3,
-    JsonGrpc,   3,
-    Rest,       3,
-    IoEngine,   4,
-    Csi,        5,
+    Empty,         0,
+    Jaeger,        0,
+    Dns,           1,
+    Etcd,          1,
+    Elastic,       1,
+    Kibana,        1,
+    Core,          3,
+    JsonGrpc,      3,
+    Rest,          3,
+    IoEngine,      4,
+    CsiNode,       5,
+    CsiController, 5,
 }
 
 // Message Bus Control Plane Agents

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -74,8 +74,8 @@ pub fn default_agents() -> &'static str {
 pub struct StartOptions {
     /// Use the following Control Plane Agents
     /// Specify one agent at a time or as a list.
-    /// ( "" for no agents )
-    /// todo: specify start arguments, eg: Node="-v"
+    /// ( "" for no agents ).
+    /// todo: specify start arguments, eg: Node="-v".
     #[structopt(
         short,
         long,
@@ -85,43 +85,55 @@ pub struct StartOptions {
     )]
     pub agents: Vec<ControlPlaneAgent>,
 
-    /// Kubernetes Config file if using operators
+    /// Kubernetes Config file if using operators.
     /// [default: "~/.kube/config"]
     #[structopt(long)]
     pub kube_config: Option<String>,
 
-    /// Use a base image for the binary components (eg: alpine:latest)
+    /// Use a base image for the binary components (eg: alpine:latest).
     #[structopt(long)]
     pub base_image: Option<String>,
 
-    /// Use the jaegertracing service
+    /// Use the jaegertracing service.
     #[structopt(short, long)]
     pub jaeger: bool,
 
-    /// Use an external jaegertracing collector
+    /// Use an external jaegertracing collector.
     #[structopt(long, env = "EXTERNAL_JAEGER")]
     pub external_jaeger: Option<String>,
 
-    /// Use the elasticsearch service
+    /// Use the elasticsearch service.
     #[structopt(short, long)]
     pub elastic: bool,
 
     /// Use the kibana service.
-    /// Note: the index pattern is only created when used in conjunction with `wait_timeout`
+    /// Note: the index pattern is only created when used in conjunction with `wait_timeout`.
     #[structopt(short, long)]
     pub kibana: bool,
 
-    /// Disable the REST Server
+    /// Disable the REST Server.
     #[structopt(long)]
     pub no_rest: bool,
 
-    /// Enable the CSI Controller
+    /// Enable the CSI Controller plugin.
     #[structopt(long)]
-    pub csi: bool,
+    pub csi_controller: bool,
+
+    /// Enable the CSI Node plugin.
+    #[structopt(long)]
+    pub csi_node: bool,
+
+    /// Use `N` csi-node instances
+    #[structopt(long, requires = "csi-node")]
+    pub app_nodes: Option<u32>,
+
+    /// Run csi-node instances on io-engine nodes.
+    #[structopt(short, long, requires = "csi-node")]
+    pub local_nodes: bool,
 
     /// Rest Path to JSON Web KEY file used for authenticating REST requests.
     /// Otherwise, no authentication is used
-    #[structopt(long, conflicts_with = "no_rest")]
+    #[structopt(long, conflicts_with = "no-rest")]
     pub rest_jwk: Option<String>,
 
     /// Use `N` io_engine instances
@@ -130,7 +142,7 @@ pub struct StartOptions {
     #[structopt(short, long, default_value = "1")]
     pub io_engines: u32,
 
-    /// Use the following docker image for the io_engine instances
+    /// Use the following docker image for the io_engine instances.
     #[structopt(long, env = "IO_ENGINE_IMAGE", default_value = utils::IO_ENGINE_IMAGE)]
     pub io_engine_image: String,
 
@@ -138,8 +150,8 @@ pub struct StartOptions {
     #[structopt(long, default_value = "ifnotpresent")]
     pub image_pull_policy: composer::ImagePullPolicy,
 
-    /// Use the following runnable binary for the io_engine instances
-    #[structopt(long, env = "IO_ENGINE_BIN", conflicts_with = "io_engine_image")]
+    /// Use the following runnable binary for the io_engine instances.
+    #[structopt(long, env = "IO_ENGINE_BIN", conflicts_with = "io-engine-image")]
     pub io_engine_bin: Option<String>,
 
     /// Add host block devices to the io_engine containers as a docker bind mount
@@ -153,38 +165,38 @@ pub struct StartOptions {
     #[structopt(long)]
     pub io_engine_isolate: bool,
 
-    /// Add the following environment variables to the io_engine containers
+    /// Add the following environment variables to the io_engine containers.
     #[structopt(long, env = "IO_ENGINE_ENV", value_delimiter=",", parse(try_from_str = utils::tracing_telemetry::parse_key_value))]
     pub io_engine_env: Option<Vec<KeyValue>>,
 
-    /// Add the following environment variables to the agent containers
+    /// Add the following environment variables to the agent containers.
     #[structopt(long, env = "AGENTS_ENV", value_delimiter=",", parse(try_from_str = utils::tracing_telemetry::parse_key_value))]
     pub agents_env: Option<Vec<KeyValue>>,
 
-    /// Add the following environment variables to the rest container
+    /// Add the following environment variables to the rest container.
     #[structopt(long, env = "REST_ENV", value_delimiter=",", parse(try_from_str = utils::tracing_telemetry::parse_key_value))]
     pub rest_env: Option<Vec<KeyValue>>,
 
-    /// Cargo Build each component before deploying
+    /// Cargo Build each component before deploying.
     #[structopt(short, long)]
     pub build: bool,
 
-    /// Cargo Build the workspace before deploying
+    /// Cargo Build the workspace before deploying.
     #[structopt(long)]
     pub build_all: bool,
 
-    /// Use a dns resolver for the cluster: defreitas/dns-proxy-server
-    /// Note this messes with your /etc/resolv.conf so use at your own risk
+    /// Use a dns resolver for the cluster: defreitas/dns-proxy-server.
+    /// Note this messes with your /etc/resolv.conf so use at your own risk.
     #[structopt(long)]
     pub dns: bool,
 
-    /// Show information from the cluster after creation
+    /// Show information from the cluster after creation.
     #[structopt(short, long)]
     pub show_info: bool,
 
     /// Name of the cluster - currently only one allowed at a time.
     /// Note: Does not quite work as intended, as we haven't figured out how to bridge between
-    /// different networks
+    /// different networks.
     #[structopt(short, long, default_value = DEFAULT_CLUSTER_LABEL)]
     pub cluster_label: ClusterLabel,
 
@@ -193,49 +205,49 @@ pub struct StartOptions {
     #[structopt(long)]
     pub cluster_uid: Option<ClusterUid>,
 
-    /// Disable the etcd service
+    /// Disable the etcd service.
     #[structopt(long)]
     pub no_etcd: bool,
 
     /// The period at which the registry updates its cache of all
-    /// resources from all nodes
+    /// resources from all nodes.
     #[structopt(long)]
     pub cache_period: Option<humantime::Duration>,
 
-    /// Override the node's deadline for the Core Agent
+    /// Override the node's deadline for the Core Agent.
     #[structopt(long)]
     pub node_deadline: Option<humantime::Duration>,
 
-    /// Override the base request timeout for GRPC requests
+    /// Override the base request timeout for GRPC requests.
     #[structopt(long)]
     pub request_timeout: Option<humantime::Duration>,
 
-    /// Override the node's connection timeout
+    /// Override the node's connection timeout.
     #[structopt(long)]
     pub node_conn_timeout: Option<humantime::Duration>,
 
-    /// Don't use minimum timeouts for specific requests
+    /// Don't use minimum timeouts for specific requests.
     #[structopt(long)]
     no_min_timeouts: bool,
 
-    /// Override the core agent's store operation timeout
+    /// Override the core agent's store operation timeout.
     #[structopt(long)]
     pub store_timeout: Option<humantime::Duration>,
 
     /// Override the core agent's lease lock ttl for the persistent store after which it'll loose
-    /// the exclusive access to the store
+    /// the exclusive access to the store.
     #[structopt(long)]
     pub store_lease_ttl: Option<humantime::Duration>,
 
-    /// Override the core agent's reconcile period
+    /// Override the core agent's reconcile period.
     #[structopt(long)]
     pub reconcile_period: Option<humantime::Duration>,
 
-    /// Override the core agent's reconcile idle period
+    /// Override the core agent's reconcile idle period.
     #[structopt(long)]
     pub reconcile_idle_period: Option<humantime::Duration>,
 
-    /// Override the core agent's reconcile idle period
+    /// Override the core agent's reconcile idle period.
     #[structopt(long, env = "OTEL_BSP_MAX_EXPORT_BATCH_SIZE")]
     pub otel_max_batch_size: Option<String>,
 
@@ -250,11 +262,11 @@ pub struct StartOptions {
     #[structopt(short, long)]
     pub reuse_cluster: bool,
 
-    /// Set the developer delayed env flag of the io_engine reactor
+    /// Set the developer delayed env flag of the io_engine reactor.
     #[structopt(short, long)]
     pub developer_delayed: bool,
 
-    /// Add process service tags to the traces
+    /// Add process service tags to the traces.
     #[structopt(short, long, env = "TRACING_TAGS", value_delimiter=",", parse(try_from_str = utils::tracing_telemetry::parse_key_value))]
     tracing_tags: Vec<KeyValue>,
 
@@ -349,7 +361,7 @@ impl StartOptions {
     }
     #[must_use]
     pub fn with_csi(mut self, enabled: bool) -> Self {
-        self.csi = enabled;
+        self.csi_controller = enabled;
         self
     }
     #[must_use]
@@ -420,6 +432,13 @@ impl StartOptions {
     pub fn with_max_rebuilds(mut self, max: Option<u32>) -> Self {
         self.max_rebuilds = max;
         self
+    }
+    pub(crate) fn app_nodes(&self) -> u32 {
+        if self.csi_node {
+            self.app_nodes.unwrap_or(1)
+        } else {
+            0
+        }
     }
 }
 
@@ -512,7 +531,9 @@ impl ListOptions {
             .build()
             .await?;
 
-        for component in cfg.list_cluster_containers().await? {
+        let containers = cfg.list_cluster_containers().await?;
+        let mut components = Vec::with_capacity(containers.len());
+        for component in containers {
             let ip = match component.network_settings.clone() {
                 None => None,
                 Some(networks) => match networks.networks {
@@ -523,16 +544,19 @@ impl ListOptions {
                     },
                 },
             };
-            println!(
-                "[{}] [{}] {}",
-                component
-                    .names
-                    .unwrap_or_default()
-                    .first()
-                    .unwrap_or(&"?".to_string()),
-                ip.unwrap_or_default(),
-                option_str(component.command),
-            );
+            let name = component
+                .names
+                .unwrap_or_default()
+                .first()
+                .cloned()
+                .unwrap_or_else(|| "?".to_string());
+            let ip = ip.unwrap_or_default();
+            let command = option_str(component.command);
+            components.push((name, ip, command));
+        }
+        components.sort_by_key(|a| a.0.clone());
+        for (name, ip, command) in components {
+            println!("[{}] [{}] {}", name, ip, command,);
         }
         Ok(())
     }

--- a/shell.nix
+++ b/shell.nix
@@ -41,6 +41,7 @@ mkShell {
     tini
     utillinux
     which
+    e2fsprogs
   ] ++ pkgs.lib.optional (!norust) rust_chan.${rust-profile};
 
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";

--- a/tests/bdd/common/deployer.py
+++ b/tests/bdd/common/deployer.py
@@ -8,7 +8,8 @@ from dataclasses import dataclass
 class StartOptions:
     io_engines: int = 1
     wait: str = "10s"
-    csi: bool = False
+    csi_controller: bool = False
+    csi_node: bool = False
     reconcile_period: str = ""
     cache_period: str = ""
     io_engine_env: str = ""
@@ -27,8 +28,10 @@ class StartOptions:
             "--wait-timeout",
             self.wait,
         ]
-        if self.csi:
-            args.append("--csi")
+        if self.csi_controller:
+            args.append("--csi-controller")
+        if self.csi_node:
+            args.append("--csi-node")
         if self.jaeger:
             args.append("--jaeger")
         if len(self.reconcile_period) > 0:
@@ -59,7 +62,8 @@ class Deployer(object):
     def start(
         io_engines=2,
         wait="10s",
-        csi=False,
+        csi_controller=False,
+        csi_node=False,
         reconcile_period="",
         cache_period="",
         io_engine_env="",
@@ -72,11 +76,13 @@ class Deployer(object):
         options = StartOptions(
             io_engines,
             wait,
-            csi=csi,
+            csi_controller=csi_controller,
+            csi_node=csi_node,
             reconcile_period=reconcile_period,
             cache_period=cache_period,
             io_engine_env=io_engine_env,
             agents_env=agents_env,
+            rest_env=rest_env,
             node_deadline=node_deadline,
             jaeger=jaeger,
             max_rebuilds=max_rebuilds,

--- a/tests/bdd/features/csi/controller/test_controller.py
+++ b/tests/bdd/features/csi/controller/test_controller.py
@@ -47,8 +47,10 @@ IO_ENGINE_SELECTOR_VALUE = "io-engine"
 
 @pytest.fixture(scope="module")
 def setup():
-    Deployer.start(2, csi=True)
-    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi.sock"], check=True)
+    Deployer.start(2, csi_controller=True)
+    subprocess.run(
+        ["sudo", "chmod", "go+rw", "/var/tmp/csi-controller.sock"], check=True
+    )
 
     # Create 2 pools.
     pool_labels = {"openebs.io/created-by": "operator-diskpool"}
@@ -73,7 +75,7 @@ def setup():
 
 
 def csi_rpc_handle():
-    return CsiHandle("unix:///var/tmp/csi.sock")
+    return CsiHandle("unix:///var/tmp/csi-controller.sock")
 
 
 @scenario("controller.feature", "get controller capabilities")

--- a/tests/bdd/features/csi/controller/test_identity.py
+++ b/tests/bdd/features/csi/controller/test_identity.py
@@ -18,8 +18,10 @@ from common.apiclient import ApiClient
 
 @pytest.fixture(scope="module")
 def setup():
-    Deployer.start(1, csi=True)
-    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi.sock"], check=True)
+    Deployer.start(1, csi_controller=True)
+    subprocess.run(
+        ["sudo", "chmod", "go+rw", "/var/tmp/csi-controller.sock"], check=True
+    )
     yield
     Deployer.stop()
 
@@ -51,7 +53,7 @@ def test_probe_rest_not_accessible(setup):
 
 
 def csi_rpc_handle():
-    return CsiHandle("unix:///var/tmp/csi.sock")
+    return CsiHandle("unix:///var/tmp/csi-controller.sock")
 
 
 @given("a running CSI controller plugin", target_fixture="csi_instance")

--- a/tests/bdd/features/csi/node/test_csi.py
+++ b/tests/bdd/features/csi/node/test_csi.py
@@ -35,7 +35,7 @@ def start_csi_plugin(setup, staging_target_path):
         result["status"] = proc.returncode
 
     try:
-        subprocess.run(["sudo", "rm", "/var/tmp/csi.sock"], check=True)
+        subprocess.run(["sudo", "rm", "/var/tmp/csi-node.sock"], check=True)
     except:
         pass
 
@@ -48,7 +48,7 @@ def start_csi_plugin(setup, staging_target_path):
         args=[
             "sudo",
             os.environ["WORKSPACE_ROOT"] + "/target/debug/csi-node",
-            "--csi-socket=/var/tmp/csi.sock",
+            "--csi-socket=/var/tmp/csi-node.sock",
             "--grpc-endpoint=0.0.0.0",
             "--node-name=msn-test",
             "--nvme-nr-io-queues=1",
@@ -89,13 +89,13 @@ def setup():
 
 @pytest.fixture(scope="module")
 def fix_socket_permissions(start_csi_plugin):
-    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi.sock"], check=True)
+    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi-node.sock"], check=True)
     yield
 
 
 @pytest.fixture(scope="module")
 def csi_instance(start_csi_plugin, fix_socket_permissions):
-    yield CsiHandle("unix:///var/tmp/csi.sock")
+    yield CsiHandle("unix:///var/tmp/csi-node.sock")
 
 
 def test_plugin_info(csi_instance):

--- a/tests/bdd/features/csi/node/test_csi.py
+++ b/tests/bdd/features/csi/node/test_csi.py
@@ -1,7 +1,6 @@
 import os
 import pytest
 import subprocess
-import threading
 import time
 
 import grpc
@@ -27,52 +26,8 @@ def get_uuid(n):
 
 
 @pytest.fixture(scope="module")
-def start_csi_plugin(setup, staging_target_path):
-    def monitor(proc, result):
-        stdout, stderr = proc.communicate()
-        result["stdout"] = stdout.decode()
-        result["stderr"] = stderr.decode()
-        result["status"] = proc.returncode
-
-    try:
-        subprocess.run(["sudo", "rm", "/var/tmp/csi-node.sock"], check=True)
-    except:
-        pass
-
-    try:
-        subprocess.run(["sudo", "umount", staging_target_path], check=True)
-    except:
-        pass
-
-    proc = subprocess.Popen(
-        args=[
-            "sudo",
-            os.environ["WORKSPACE_ROOT"] + "/target/debug/csi-node",
-            "--csi-socket=/var/tmp/csi-node.sock",
-            "--grpc-endpoint=0.0.0.0",
-            "--node-name=msn-test",
-            "--nvme-nr-io-queues=1",
-            "-v",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    result = {}
-    handler = threading.Thread(target=monitor, args=[proc, result])
-    handler.start()
-    time.sleep(1)
-    yield
-    subprocess.run(["sudo", "pkill", "csi-node"], check=True)
-    handler.join()
-    print("[CSI] exit status: %d" % (result["status"]))
-    print(result["stdout"])
-    print(result["stderr"])
-
-
-@pytest.fixture(scope="module")
 def setup():
-    Deployer.start(1, jaeger=True)
+    Deployer.start(1, csi_node=True)
 
     # Create 2 pools.
     pool_labels = {"openebs.io/created-by": "operator-diskpool"}
@@ -88,14 +43,16 @@ def setup():
 
 
 @pytest.fixture(scope="module")
-def fix_socket_permissions(start_csi_plugin):
-    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi-node.sock"], check=True)
+def fix_socket_permissions(setup):
+    subprocess.run(
+        ["sudo", "chmod", "go+rw", "/var/tmp/csi-app-node-1.sock"], check=True
+    )
     yield
 
 
 @pytest.fixture(scope="module")
-def csi_instance(start_csi_plugin, fix_socket_permissions):
-    yield CsiHandle("unix:///var/tmp/csi-node.sock")
+def csi_instance(setup, fix_socket_permissions):
+    yield CsiHandle("unix:///var/tmp/csi-app-node-1.sock")
 
 
 def test_plugin_info(csi_instance):
@@ -120,7 +77,7 @@ def test_probe(csi_instance):
 
 def test_node_info(csi_instance):
     info = csi_instance.node.NodeGetInfo(pb.NodeGetInfoRequest())
-    assert info.node_id == "msn-test"
+    assert info.node_id == "app-node-1"
     assert info.max_volumes_per_node == 0
 
 
@@ -162,16 +119,16 @@ def share_type(request):
 
 @pytest.fixture(scope="module")
 def staging_target_path():
-    yield "/tmp/staging/mount"
+    yield "/var/tmp/staging/mount"
 
 
 @pytest.fixture
 def target_path():
     try:
-        os.mkdir("/tmp/publish")
+        os.mkdir("/var/tmp/publish")
     except FileExistsError:
         pass
-    yield "/tmp/publish/mount"
+    yield "/var/tmp/publish/mount"
 
 
 @pytest.fixture(params=["ext4", "xfs"])

--- a/tests/bdd/features/csi/node/test_identity.py
+++ b/tests/bdd/features/csi/node/test_identity.py
@@ -28,13 +28,13 @@ def setup():
         result["status"] = proc.returncode
 
     try:
-        subprocess.run(["sudo", "rm", "/var/tmp/csi.sock"], check=True)
+        subprocess.run(["sudo", "rm", "/var/tmp/csi-node.sock"], check=True)
     except:
         pass
     proc = subprocess.Popen(
         args=[
             os.environ["WORKSPACE_ROOT"] + "/target/debug/csi-node",
-            "--csi-socket=/var/tmp/csi.sock",
+            "--csi-socket=/var/tmp/csi-node.sock",
             "--grpc-endpoint=0.0.0.0",
             "--node-name=msn-test",
             "--nvme-nr-io-queues=1",
@@ -67,7 +67,7 @@ def test_plugin_capabilities():
 
 
 def csi_rpc_handle():
-    return CsiHandle("unix:///var/tmp/csi.sock")
+    return CsiHandle("unix:///var/tmp/csi-node.sock")
 
 
 @given("a running CSI node plugin", target_fixture="csi_instance")

--- a/tests/bdd/features/csi/node/test_identity.py
+++ b/tests/bdd/features/csi/node/test_identity.py
@@ -16,44 +16,13 @@ import csi_pb2 as pb
 
 from common.csi import CsiHandle
 from common.deployer import Deployer
-from common.apiclient import ApiClient
 
 
 @pytest.fixture(scope="module")
 def setup():
-    def monitor(proc, result):
-        stdout, stderr = proc.communicate()
-        result["stdout"] = stdout.decode()
-        result["stderr"] = stderr.decode()
-        result["status"] = proc.returncode
-
-    try:
-        subprocess.run(["sudo", "rm", "/var/tmp/csi-node.sock"], check=True)
-    except:
-        pass
-    proc = subprocess.Popen(
-        args=[
-            os.environ["WORKSPACE_ROOT"] + "/target/debug/csi-node",
-            "--csi-socket=/var/tmp/csi-node.sock",
-            "--grpc-endpoint=0.0.0.0",
-            "--node-name=msn-test",
-            "--nvme-nr-io-queues=1",
-            "-v",
-        ],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-
-    result = {}
-    handler = threading.Thread(target=monitor, args=[proc, result])
-    handler.start()
-    time.sleep(1)
+    Deployer.start(1, csi_node=True)
     yield
-    subprocess.run(["sudo", "pkill", "csi-node"], check=True)
-    handler.join()
-    print("[CSI] exit status: %d" % (result["status"]))
-    print(result["stdout"])
-    print(result["stderr"])
+    Deployer.stop()
 
 
 @scenario("identity.feature", "get plugin information")
@@ -66,12 +35,20 @@ def test_plugin_capabilities():
     """get plugin capabilities"""
 
 
+@pytest.fixture(scope="module")
+def fix_socket_permissions(setup):
+    subprocess.run(
+        ["sudo", "chmod", "go+rw", "/var/tmp/csi-app-node-1.sock"], check=True
+    )
+    yield
+
+
 def csi_rpc_handle():
-    return CsiHandle("unix:///var/tmp/csi-node.sock")
+    return CsiHandle("unix:///var/tmp/csi-app-node-1.sock")
 
 
 @given("a running CSI node plugin", target_fixture="csi_instance")
-def a_csi_plugin():
+def a_csi_plugin(fix_socket_permissions):
     return csi_rpc_handle()
 
 

--- a/tests/bdd/features/csi/node/test_node.py
+++ b/tests/bdd/features/csi/node/test_node.py
@@ -99,7 +99,7 @@ def start_csi_plugin(setup):
         result["status"] = proc.returncode
 
     try:
-        subprocess.run(["sudo", "rm", "/var/tmp/csi.sock"], check=True)
+        subprocess.run(["sudo", "rm", "/var/tmp/csi-node.sock"], check=True)
     except:
         pass
 
@@ -107,7 +107,7 @@ def start_csi_plugin(setup):
         args=[
             "sudo",
             os.environ["WORKSPACE_ROOT"] + "/target/debug/csi-node",
-            "--csi-socket=/var/tmp/csi.sock",
+            "--csi-socket=/var/tmp/csi-node.sock",
             "--grpc-endpoint=0.0.0.0",
             "--node-name=msn-test",
             "--nvme-nr-io-queues=1",
@@ -148,13 +148,13 @@ def setup():
 
 @pytest.fixture(scope="module")
 def fix_socket_permissions(start_csi_plugin):
-    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi.sock"], check=True)
+    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi-node.sock"], check=True)
     yield
 
 
 @pytest.fixture(scope="module")
 def csi_instance(start_csi_plugin, fix_socket_permissions):
-    yield CsiHandle("unix:///var/tmp/csi.sock")
+    yield CsiHandle("unix:///var/tmp/csi-node.sock")
 
 
 @pytest.fixture

--- a/tests/bdd/features/csi/node/test_parameters.py
+++ b/tests/bdd/features/csi/node/test_parameters.py
@@ -129,7 +129,7 @@ def start_csi_plugin(setup, io_queues, staging_target_path):
         args=[
             "sudo",
             os.environ["WORKSPACE_ROOT"] + "/target/debug/csi-node",
-            "--csi-socket=/var/tmp/csi.sock",
+            "--csi-socket=/var/tmp/csi-node.sock",
             "--grpc-endpoint=0.0.0.0",
             "--node-name=msn-test",
             f"--nvme-nr-io-queues={io_queues}",
@@ -169,10 +169,10 @@ def setup():
 
 @pytest.fixture
 def fix_socket_permissions(start_csi_plugin):
-    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi.sock"], check=True)
+    subprocess.run(["sudo", "chmod", "go+rw", "/var/tmp/csi-node.sock"], check=True)
     yield
 
 
 @pytest.fixture
 def csi_instance(start_csi_plugin, fix_socket_permissions):
-    yield CsiHandle("unix:///var/tmp/csi.sock")
+    yield CsiHandle("unix:///var/tmp/csi-node.sock")

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -46,7 +46,7 @@ use tracing::dispatcher::DefaultGuard;
 use tracing_subscriber::{filter::Directive, layer::SubscriberExt, EnvFilter, Registry};
 use utils::tracing_telemetry::default_tracing_tags;
 
-const RUST_LOG_QUIET_DEFAULTS: &str =
+const RUST_LOG_SILENCE_DEFAULTS: &str =
     "h2=info,hyper=info,tower_buffer=info,tower=info,rustls=info,reqwest=info,tokio_util=info,async_io=info,polling=info,tonic=info,want=info,mio=info,bollard=info,composer=info";
 
 #[tokio::test]
@@ -482,7 +482,7 @@ impl ClusterBuilder {
             "trace" => "trace",
             _ => return current,
         };
-        let logs = format!("{},{}", main, RUST_LOG_QUIET_DEFAULTS);
+        let logs = format!("{},{}", main, RUST_LOG_SILENCE_DEFAULTS);
         tracing_subscriber::EnvFilter::new(logs)
     }
     /// Enable/Disable jaeger tracing.

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -51,5 +51,5 @@ pub const DEFAULT_JSON_GRPC_CLIENT_ADDR: &str = "https://jsongrpc:50052";
 pub const DEFAULT_GRPC_CLIENT_CONCURRENCY: usize = 25;
 
 /// The default quiet filters in addition to `RUST_LOG`.
-pub const RUST_LOG_QUIET_DEFAULTS: &str =
+pub const RUST_LOG_SILENCE_DEFAULTS: &str =
     "actix_web=info,actix_server=info,h2=info,hyper=info,tower_buffer=info,tower=info,rustls=info,reqwest=info,tokio_util=info,async_io=info,polling=info,tonic=info,want=info,mio=info";

--- a/utils/utils-lib/src/tracing_telemetry.rs
+++ b/utils/utils-lib/src/tracing_telemetry.rs
@@ -40,20 +40,20 @@ pub fn set_jaeger_env() {
     }
 }
 
-/// Mix the `RUST_LOG` `EnvFilter` with `RUST_LOG_QUIET`.
+/// Mix the `RUST_LOG` `EnvFilter` with `RUST_LOG_SILENCE`.
 /// This is useful when we want to bulk-silence certain crates by default.
 pub fn rust_log_add_quiet_defaults(
     current: tracing_subscriber::EnvFilter,
 ) -> tracing_subscriber::EnvFilter {
-    let rust_log_quiets = std::env::var("RUST_LOG_QUIETS");
-    let quiets = match &rust_log_quiets {
+    let rust_log_silence = std::env::var("RUST_LOG_SILENCE");
+    let silence = match &rust_log_silence {
         Ok(quiets) => quiets.as_str(),
-        Err(_) => super::constants::RUST_LOG_QUIET_DEFAULTS,
+        Err(_) => super::constants::RUST_LOG_SILENCE_DEFAULTS,
     };
 
-    tracing_subscriber::EnvFilter::try_new(match quiets.is_empty() {
+    tracing_subscriber::EnvFilter::try_new(match silence.is_empty() {
         true => current.to_string(),
-        false => format!("{},{}", current, quiets),
+        false => format!("{},{}", current, silence),
     })
     .unwrap()
 }


### PR DESCRIPTION
feat(deployer): add the csi-node plugin to the deployer

The csi-node originally came from the data-plane repo and so was never part of the deployer.

---

test(bdd): deploy the csi-node using the deployer

---

refactor: name silence log env var more appropriately

Rename quiet to silence, which seems more appropriate.