### PR TITLE
chore: update to latest openapi client with custom client support

### DIFF
--- a/nix/pkgs/openapi-generator/default.nix
+++ b/nix/pkgs/openapi-generator/default.nix
@@ -2,7 +2,7 @@
 
 let
   src = fetchFromGitHub (lib.importJSON ./source.json);
-  version = "5.2.1-${src.rev}";
+  version = "6.1.0-${src.rev}";
 
   # perform fake build to make a fixed-output derivation out of the files downloaded from maven central
   deps = stdenv.mkDerivation {
@@ -24,7 +24,7 @@ let
       "find $out/.m2 -type f -regex '.+\\(\\.lastUpdated\\|resolver-status\\.properties\\|_remote\\.repositories\\)' -delete";
     outputHashAlgo = "sha256";
     outputHashMode = "recursive";
-    outputHash = "0f30vfvqrwa4gdgid9c94kvv83yfrgpx6ii1npjxspdawqr3whrj";
+    outputHash = "sha256-MieSA5Y8u35H1xdP27A+YDekyyQ6CThNXOjQ82ArM7U=";
   };
 
 in

--- a/nix/pkgs/openapi-generator/source.json
+++ b/nix/pkgs/openapi-generator/source.json
@@ -1,6 +1,6 @@
 {
   "owner": "openebs",
   "repo": "openapi-generator",
-  "rev": "f777b27f504acb4b2290b41c15d8faf06cc29eb6",
-  "sha256": "1iywhic5wn7gbalsibzli6hz73y5i14h23597psm38ginlny1khr"
+  "rev": "c864540ca9653eb7d05c6da59706096c8ce81f16",
+  "sha256": "1p17g3nnl810vps59ab0w1x9s4d4cbqann5plmm6ky1ydirpvx37"
 }

--- a/scripts/rust/generate-openapi-bindings.sh
+++ b/scripts/rust/generate-openapi-bindings.sh
@@ -56,7 +56,7 @@ fi
 tmpd=$(mktemp -d /tmp/openapi-gen-XXXXXXX)
 
 # Generate a new openapi crate
-openapi-generator-cli generate -i "$SPEC" -g rust-mayastor -o "$tmpd" --additional-properties actixWebVersion="4.0.0-beta.8" --additional-properties actixWebTelemetryVersion='"0.11.0-beta.4"'
+openapi-generator-cli generate -i "$SPEC" -g rust-mayastor -o "$tmpd"
 ( cd "$tmpd"; rm -rf api; rm -rf .* 2>/dev/null || true )
 
 if [[ $default_toml = "no" ]]; then


### PR DESCRIPTION
This allows us to pass custom tower clients which might be useful for building proxies, etc.

Signed-off-by: Tiago Castro <tiagolobocastro@gmail.com>