### PR TITLE
feat(rox): plumb read_only through publish path

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -532,8 +532,7 @@ impl AgentToIoEngine for transport::ShareNexus {
             key: self.key.clone().unwrap_or_default(),
             share: self.protocol as i32,
             allowed_hosts: self.allowed_hosts.clone().into_vec(),
-            // publish always requests RWO until the consumer PR lands.
-            read_only: None,
+            read_only: Some(self.read_only),
         }
     }
 }

--- a/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/reconciler/nexus/mod.rs
@@ -536,10 +536,12 @@ pub(super) async fn fixup_nexus_protocol(
                 match NexusShareProtocol::try_from(nexus_spec.share) {
                     Ok(protocol) => {
                         let allowed_hosts = nexus_spec.allowed_hosts.clone();
+                        let read_only = nexus_spec.read_only;
                         nexus
                             .share(
                                 context.registry(),
-                                &ShareNexus::new(&nexus_state, protocol, allowed_hosts),
+                                &ShareNexus::new(&nexus_state, protocol, allowed_hosts)
+                                    .with_read_only(read_only),
                             )
                             .await?;
                         nexus_spec
@@ -564,10 +566,12 @@ pub(super) async fn fixup_nexus_protocol(
             match NexusShareProtocol::try_from(nexus_spec.share) {
                 Ok(protocol) => {
                     let allowed_hosts = nexus_spec.allowed_hosts.clone();
+                    let read_only = nexus_spec.read_only;
                     nexus
                         .share(
                             context.registry(),
-                            &ShareNexus::new(&nexus_state, protocol, allowed_hosts),
+                            &ShareNexus::new(&nexus_state, protocol, allowed_hosts)
+                                .with_read_only(read_only),
                         )
                         .await?;
                     nexus_spec

--- a/control-plane/agents/src/bin/core/nexus/operations.rs
+++ b/control-plane/agents/src/bin/core/nexus/operations.rs
@@ -197,7 +197,11 @@ impl ResourceSharing for Option<&mut OperationGuardArc<NexusSpec>> {
                 .start_update(
                     registry,
                     &status,
-                    NexusOperation::new_share(request.protocol, request.allowed_hosts.clone()),
+                    NexusOperation::new_share(
+                        request.protocol,
+                        request.allowed_hosts.clone(),
+                        request.read_only,
+                    ),
                 )
                 .await?;
             let result = node.share_nexus(request).await;

--- a/control-plane/agents/src/bin/core/nexus/specs.rs
+++ b/control-plane/agents/src/bin/core/nexus/specs.rs
@@ -51,10 +51,11 @@ impl SpecOperationsHelper for NexusSpec {
         op: Self::UpdateOp,
     ) -> Result<(), SvcError> {
         match &op {
-            NexusOperation::Share(_, a)
+            NexusOperation::Share(_, a, r)
                 if state.share.shared()
                     && &state.allowed_hosts == a
-                    && &self.allowed_hosts == a =>
+                    && &self.allowed_hosts == a
+                    && self.read_only == *r =>
             {
                 Err(SvcError::AlreadyShared {
                     kind: ResourceKind::Nexus,
@@ -62,7 +63,7 @@ impl SpecOperationsHelper for NexusSpec {
                     share: state.share.to_string(),
                 })
             }
-            NexusOperation::Share(_, _) => Ok(()),
+            NexusOperation::Share(_, _, _) => Ok(()),
             NexusOperation::Unshare if !state.share.shared() => Err(SvcError::NotShared {
                 kind: ResourceKind::Nexus,
                 id: self.uuid_str(),

--- a/control-plane/agents/src/bin/core/tests/nexus/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/nexus/mod.rs
@@ -84,6 +84,7 @@ async fn nexus() {
                 key: None,
                 protocol: NexusShareProtocol::Nvmf,
                 allowed_hosts: vec![],
+                read_only: false,
             },
             None,
         )

--- a/control-plane/agents/src/bin/core/tests/volume/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/mod.rs
@@ -9,6 +9,7 @@ mod helpers;
 mod hotspare;
 mod offline_rebuild;
 mod resize;
+mod rox;
 mod rwx;
 mod snapshot;
 mod snapshot_clone;

--- a/control-plane/agents/src/bin/core/tests/volume/rox.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/rox.rs
@@ -1,0 +1,189 @@
+#![cfg(test)]
+
+use deployer_cluster::ClusterBuilder;
+use grpc::operations::volume::traits::VolumeOperations;
+use std::{collections::HashMap, time::Duration};
+use stor_port::{
+    transport_api::{ReplyErrorKind, ResourceKind},
+    types::v0::transport::{
+        CreateVolume, PublishVolume, UnpublishVolume, VolumeAccessMode, VolumeId,
+        VolumeShareProtocol,
+    },
+};
+
+/// End-to-end plumbing test for read-only (ROX) publishes. Covers:
+///
+/// - A `MultiNodeReaderOnly` publish sets `TargetConfig.read_only == true` on
+///   the volume spec. The resulting nexus records one `allowed_hosts` entry per
+///   `frontend_node` passed on the publish, which is the RWX-block multi-
+///   initiator fan-out — ROX inherits it without a separate code path.
+/// - RWO ↔ ROX mode switches on an already-published volume are rejected with
+///   `SvcError::VolumeAccessModeConflict` (→ `FailedPrecondition`).
+/// - Unpublish followed by a publish in the other mode succeeds: the guard is
+///   about concurrent conflicting modes on one target, not about forbidding
+///   transitions.
+#[tokio::test]
+async fn rox_publish_and_mode_conflict_guard() {
+    // `no_deprecated_access_mode(true)` flips core into strict ACL mode; without
+    // it the `--deprecated-access-mode` arg makes `frontend_nodes` a no-op and
+    // `allowed_hosts` stays empty. NQNs get synthesised from the nodename
+    // string via `HostNqn::from_nodename`, so we don't need real csi-node
+    // containers.
+    let cluster = ClusterBuilder::builder()
+        .with_rest(false)
+        .with_io_engines(2)
+        .with_tmpfs_pool(100 * 1024 * 1024)
+        .with_cache_period("150ms")
+        .with_options(|o| o.no_deprecated_access_mode(true))
+        .with_reconcile_period(Duration::from_secs(100), Duration::from_secs(100))
+        .build()
+        .await
+        .unwrap();
+
+    let volume_client = cluster.grpc_client().volume();
+    let volume = volume_client
+        .create(
+            &CreateVolume {
+                uuid: VolumeId::try_from("2e3cf927-80c2-47a8-adf0-95c481000000").unwrap(),
+                size: 5242880,
+                replicas: 2,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    // === ROX publish sets read_only + fans allowed_hosts to every frontend_node ===
+    let frontends: Vec<String> = vec!["reader-a".into(), "reader-b".into()];
+    let published = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: Some(cluster.node(0)),
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: frontends.clone(),
+                access_mode: VolumeAccessMode::MultiNodeReaderOnly,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        published
+            .spec_ref()
+            .target_cfg()
+            .expect("target config present")
+            .read_only(),
+        "MultiNodeReaderOnly publish must set TargetConfig.read_only"
+    );
+
+    // `Nexus::allowed_hosts` returned via gRPC is hardcoded to `vec![]` in the
+    // wire→transport conversion, so the CP-observable check is the target's
+    // frontend config, which is what actually gets forwarded to `share_nvmf`
+    // via `ShareNexus::allowed_hosts` on the io-engine side.
+    let cfg_hosts = published
+        .spec_ref()
+        .target_cfg()
+        .expect("target config present")
+        .frontend()
+        .node_nqns();
+    assert_eq!(
+        cfg_hosts.len(),
+        frontends.len(),
+        "each frontend_node must appear in target_cfg.frontend nqns: {cfg_hosts:?}"
+    );
+
+    // === Same volume, RWO publish must be rejected while ROX is active ===
+    let err = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["reader-a".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect_err("RWO publish on ROX-published volume must fail");
+    assert_eq!(err.kind, ReplyErrorKind::FailedPrecondition, "{err:?}");
+    assert_eq!(err.resource, ResourceKind::Volume);
+
+    // === Unpublish, then RWO publish succeeds and clears read_only ===
+    volume_client
+        .unpublish(
+            &UnpublishVolume::new(&volume.spec().uuid, false, vec![]),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let republished = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: Some(cluster.node(0)),
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["reader-a".into()],
+                access_mode: VolumeAccessMode::SingleNodeWriter,
+            },
+            None,
+        )
+        .await
+        .expect("RWO publish after unpublish should succeed");
+    assert!(
+        !republished.spec_ref().target_cfg().unwrap().read_only(),
+        "RWO publish must clear read_only"
+    );
+
+    // === Mirror guard: ROX on already-RWO volume is rejected ===
+    let err = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: None,
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["reader-a".into()],
+                access_mode: VolumeAccessMode::MultiNodeReaderOnly,
+            },
+            None,
+        )
+        .await
+        .expect_err("ROX publish on RWO-published volume must fail");
+    assert_eq!(err.kind, ReplyErrorKind::FailedPrecondition, "{err:?}");
+
+    // === Unpublish, then ROX publish succeeds and sets read_only ===
+    volume_client
+        .unpublish(
+            &UnpublishVolume::new(&volume.spec().uuid, false, vec![]),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let republished_rox = volume_client
+        .publish(
+            &PublishVolume {
+                uuid: volume.spec().uuid.clone(),
+                target_node: Some(cluster.node(0)),
+                share: Some(VolumeShareProtocol::Nvmf),
+                publish_context: HashMap::new(),
+                frontend_nodes: vec!["reader-a".into()],
+                access_mode: VolumeAccessMode::MultiNodeReaderOnly,
+            },
+            None,
+        )
+        .await
+        .expect("RWO → unpublish → ROX should succeed");
+    assert!(
+        republished_rox.spec_ref().target_cfg().unwrap().read_only(),
+        "post-unpublish ROX must set read_only"
+    );
+}

--- a/control-plane/agents/src/bin/core/volume/operations.rs
+++ b/control-plane/agents/src/bin/core/volume/operations.rs
@@ -42,7 +42,7 @@ use stor_port::{
             DestroyVolume, NexusVersion, NodeTopology, Protocol, PublishVolume, Replica, ReplicaId,
             ReplicaOwners, RepublishVolume, ResizeVolume, SetVolumeProperty, SetVolumeReplica,
             ShareNexus, ShareVolume, ShutdownNexus, UnpublishVolume, UnshareNexus, UnshareVolume,
-            Volume, VolumeShareProtocol, VolumeTargetMode,
+            Volume, VolumeAccessMode, VolumeShareProtocol, VolumeTargetMode,
         },
     },
     HostAccessControl,
@@ -267,6 +267,11 @@ impl ResourceSharing for OperationGuardArc<VolumeSpec> {
             .await?;
 
         let target = state.target.expect("already validated");
+        let read_only = self
+            .as_ref()
+            .active_config()
+            .map(|c| c.read_only())
+            .unwrap_or_default();
         let result = match specs.nexus(&target.uuid).await {
             Ok(mut nexus) => {
                 nexus
@@ -281,7 +286,8 @@ impl ResourceSharing for OperationGuardArc<VolumeSpec> {
                                 .into_iter()
                                 .map(TryInto::try_into)
                                 .collect::<Result<_, _>>()?,
-                        ),
+                        )
+                        .with_read_only(read_only),
                     )
                     .await
             }
@@ -414,7 +420,13 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
                             .iter()
                             .map(|n| n.node_nqn().clone())
                             .collect::<Vec<_>>();
-                        let share = ShareNexus::new(state, VolumeShareProtocol::Nvmf, nqns);
+                        let read_only = self
+                            .as_ref()
+                            .active_config()
+                            .map(|c| c.read_only())
+                            .unwrap_or_default();
+                        let share = ShareNexus::new(state, VolumeShareProtocol::Nvmf, nqns)
+                            .with_read_only(read_only);
                         nexus.share(registry, &share).await.map(|_| ())
                     } else {
                         Ok(())
@@ -519,6 +531,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
             Some(result) => result,
             None => self.next_target_node(registry, request, &state, true).await,
         }?;
+        let read_only = target_cfg.read_only();
         let nodes = target_cfg.frontend().node_names();
         let target_cfg = self
             .next_target_config(
@@ -528,6 +541,7 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
                 &nodes,
             )
             .await
+            .with_read_only(read_only)
             .republish(frontend);
         let operation = VolumeOperation::Republish(RepublishOperation::new(target_cfg.clone()));
 
@@ -593,7 +607,8 @@ impl ResourcePublishing for OperationGuardArc<VolumeSpec> {
         let result = match nexus
             .share(
                 registry,
-                &ShareNexus::new(&nexus_state, request.share, allowed_host),
+                &ShareNexus::new(&nexus_state, request.share, allowed_host)
+                    .with_read_only(target_cfg.read_only()),
             )
             .await
         {
@@ -639,6 +654,30 @@ impl OperationGuardArc<VolumeSpec> {
         // a target already exists), and the only other caller today is the test
         // suite. Defensive guard so any internal caller added later inherits the
         // same protection without each having to re-implement it.
+        // Reject RWO⇄ROX mode switches on an already-published volume. Same nexus
+        // cannot be served as both writer and reader-only concurrently; the caller
+        // must unpublish before switching access mode. An offline-rebuild target is
+        // unshared scratch state and doesn't serve frontend I/O, so a CSI publish
+        // arriving mid-rebuild is a promotion, not a switch — skip the guard for
+        // that case and let the promotion path below reconcile the mode.
+        if let Some(current_cfg) = self.as_ref().target_cfg() {
+            if !self.as_ref().is_offline_rebuild_target() {
+                let requested_ro =
+                    matches!(request.access_mode, VolumeAccessMode::MultiNodeReaderOnly);
+                if current_cfg.read_only() != requested_ro {
+                    return Err(SvcError::VolumeAccessModeConflict {
+                        vol_id: request.uuid.to_string(),
+                        current: if current_cfg.read_only() {
+                            "ROX"
+                        } else {
+                            "RWO"
+                        }
+                        .into(),
+                        requested: if requested_ro { "ROX" } else { "RWO" }.into(),
+                    });
+                }
+            }
+        }
         if matches!(target_mode, VolumeTargetMode::OfflineRebuild)
             && self.as_ref().is_offline_rebuild_target()
         {
@@ -667,6 +706,14 @@ impl OperationGuardArc<VolumeSpec> {
                 if let Some(share) = request.share {
                     target_cfg.target_mut().set_protocol(Some(share));
                 }
+                // The offline-rebuild target defaults to RWO; the CSI publish
+                // now dictates the access mode, so promote read_only accordingly.
+                // Without this the ROX flag would be silently dropped when a
+                // MultiNodeReaderOnly publish arrives mid-rebuild.
+                target_cfg = target_cfg.with_read_only(matches!(
+                    request.access_mode,
+                    VolumeAccessMode::MultiNodeReaderOnly
+                ));
             }
             // Whatever mode the caller asked for now applies to the target. For
             // an offline-rebuild promotion the CSI publish path passes
@@ -698,7 +745,8 @@ impl OperationGuardArc<VolumeSpec> {
                         &nexus_state,
                         share_protocol,
                         target_cfg.frontend().node_nqns(),
-                    ),
+                    )
+                    .with_read_only(target_cfg.read_only()),
                 )
                 .await;
 
@@ -717,6 +765,7 @@ impl OperationGuardArc<VolumeSpec> {
 
         let last_target = self.as_ref().health_info_id().cloned();
         let frontend_nodes = &request.frontend_nodes;
+        let read_only = matches!(request.access_mode, VolumeAccessMode::MultiNodeReaderOnly);
         let target_cfg = self
             .next_target_config(
                 registry,
@@ -725,6 +774,7 @@ impl OperationGuardArc<VolumeSpec> {
                 frontend_nodes,
             )
             .await
+            .with_read_only(read_only)
             .with_target_mode(target_mode);
 
         let operation =
@@ -745,7 +795,8 @@ impl OperationGuardArc<VolumeSpec> {
             result = match nexus
                 .share(
                     registry,
-                    &ShareNexus::new(&nexus_state, share, allowed_hosts),
+                    &ShareNexus::new(&nexus_state, share, allowed_hosts)
+                        .with_read_only(target_cfg.read_only()),
                 )
                 .await
             {

--- a/control-plane/agents/src/common/errors.rs
+++ b/control-plane/agents/src/common/errors.rs
@@ -176,6 +176,15 @@ pub enum SvcError {
         node: String,
         protocol: String,
     },
+    #[snafu(display(
+        "Volume '{vol_id}' is already published as {current} but a {requested} publish was requested; \
+         unpublish first before switching access mode"
+    ))]
+    VolumeAccessModeConflict {
+        vol_id: String,
+        current: String,
+        requested: String,
+    },
     #[snafu(display("Volume '{vol_id}' is already published with current context ({current:?}) != requested ({requested:?})"))]
     VolumePublishCtxDiffer {
         vol_id: String,
@@ -907,6 +916,12 @@ impl From<SvcError> for ReplyError {
             },
             SvcError::VolumeAlreadyPublished { .. } => ReplyError {
                 kind: ReplyErrorKind::AlreadyPublished,
+                resource: ResourceKind::Volume,
+                source,
+                extra,
+            },
+            SvcError::VolumeAccessModeConflict { .. } => ReplyError {
+                kind: ReplyErrorKind::FailedPrecondition,
                 resource: ResourceKind::Volume,
                 source,
                 extra,

--- a/control-plane/grpc/proto/v1/nexus/nexus.proto
+++ b/control-plane/grpc/proto/v1/nexus/nexus.proto
@@ -119,6 +119,9 @@ message NexusSpec {
   repeated string allowed_hosts = 12;
   // version of the nexus label layout
   uint32 label_version = 13;
+  // Whether the nexus is currently published read-only (ROX). Populated on
+  // share; cleared on unshare.
+  optional bool read_only = 14;
 }
 
 // Nexus children (replica or "raw" URI)
@@ -248,6 +251,9 @@ message ShareNexusRequest {
   NexusShareProtocol protocol = 4;
   // Allowed hosts to access nexus
   repeated string allowed_hosts = 5;
+  // Publish read-only (ROX). When true the io-engine rejects write I/O at the
+  // nexus. Optional for back-compat: absent = false.
+  optional bool read_only = 6;
 }
 
 // Reply type for a ShareNexusRequest

--- a/control-plane/grpc/proto/v1/volume/volume.proto
+++ b/control-plane/grpc/proto/v1/volume/volume.proto
@@ -111,6 +111,8 @@ message TargetConfig {
   nexus.NexusNvmfConfig     config = 2;
   // Frontend configuration.
   optional FrontendConfig frontend = 3;
+  // Publish read-only (ROX). Absent = false for back-compat.
+  optional bool read_only = 4;
 }
 
 message FrontendConfig {
@@ -329,6 +331,10 @@ enum SnapshotRestorePolicy {
 enum AccessMode {
     SingleNodeWriter = 0;
     MultiNodeMultiWriter = 1;
+    // Multi-initiator read-only attach (CSI MULTI_NODE_READER_ONLY). Publishes made
+    // with this mode set target_config.read_only, which the nexus enforces at the
+    // data plane by rejecting writes.
+    MultiNodeReaderOnly = 2;
 }
 
 // Publish a volume on a node

--- a/control-plane/grpc/src/operations/nexus/traits.rs
+++ b/control-plane/grpc/src/operations/nexus/traits.rs
@@ -582,6 +582,7 @@ impl TryFrom<nexus::NexusSpec> for NexusSpec {
                 nexus::NexusLabelVersion::V1 => NexusVersion::V1,
                 nexus::NexusLabelVersion::V2 => NexusVersion::V2,
             },
+            read_only: value.read_only.unwrap_or_default(),
         })
     }
 }
@@ -619,6 +620,7 @@ impl From<NexusSpec> for nexus::NexusSpec {
                 NexusVersion::V1 => nexus::NexusLabelVersion::V1.into(),
                 NexusVersion::V2 => nexus::NexusLabelVersion::V2.into(),
             },
+            read_only: Some(value.read_only),
         }
     }
 }
@@ -1042,6 +1044,8 @@ pub trait ShareNexusInfo: Send + Sync + std::fmt::Debug {
     fn protocol(&self) -> NexusShareProtocol;
     /// Allowed hosts to access nexus.
     fn allowed_hosts(&self) -> Vec<HostNqn>;
+    /// Publish the nexus read-only (ROX).
+    fn read_only(&self) -> bool;
 }
 
 impl ShareNexusInfo for ShareNexus {
@@ -1063,6 +1067,10 @@ impl ShareNexusInfo for ShareNexus {
 
     fn allowed_hosts(&self) -> Vec<HostNqn> {
         self.allowed_hosts.clone()
+    }
+
+    fn read_only(&self) -> bool {
+        self.read_only
     }
 }
 
@@ -1113,6 +1121,10 @@ impl ShareNexusInfo for ValidatedShareNexusRequest {
     fn allowed_hosts(&self) -> Vec<HostNqn> {
         self.allowed_hosts.clone()
     }
+
+    fn read_only(&self) -> bool {
+        self.inner.read_only.unwrap_or_default()
+    }
 }
 
 impl ValidateRequestTypes for ShareNexusRequest {
@@ -1153,6 +1165,7 @@ impl From<&dyn ShareNexusInfo> for ShareNexusRequest {
                 .into_iter()
                 .map(|nqn| nqn.to_string())
                 .collect(),
+            read_only: Some(data.read_only()),
         }
     }
 }
@@ -1165,6 +1178,7 @@ impl From<&dyn ShareNexusInfo> for ShareNexus {
             key: data.key(),
             protocol: data.protocol(),
             allowed_hosts: data.allowed_hosts(),
+            read_only: data.read_only(),
         }
     }
 }

--- a/control-plane/grpc/src/operations/volume/traits.rs
+++ b/control-plane/grpc/src/operations/volume/traits.rs
@@ -340,16 +340,23 @@ impl TryFrom<volume::VolumeDefinition> for VolumeSpec {
                             err.to_string(),
                         )
                     })?;
-                    let frontend = volume_meta
-                        .target_config
-                        .and_then(|c| c.frontend)
+                    let meta_cfg = volume_meta.target_config;
+                    let frontend = meta_cfg
+                        .as_ref()
+                        .and_then(|c| c.frontend.clone())
+                        .unwrap_or_default();
+                    // `read_only` is carried on the metadata's target_config, not the
+                    // top-level VolumeTarget. Without pulling it back here, ROX publishes
+                    // would appear as RWO to any client reading the volume via gRPC.
+                    let read_only = meta_cfg
+                        .as_ref()
+                        .and_then(|c| c.read_only)
                         .unwrap_or_default();
 
-                    Some(TargetConfig::new(
-                        target,
-                        NexusNvmfConfig::default(),
-                        frontend.into(),
-                    ))
+                    Some(
+                        TargetConfig::new(target, NexusNvmfConfig::default(), frontend.into())
+                            .with_read_only(read_only),
+                    )
                 }
                 None => None,
             },
@@ -814,6 +821,7 @@ impl From<&TargetConfig> for volume::VolumeTarget {
 impl TryFrom<volume::TargetConfig> for TargetConfig {
     type Error = ReplyError;
     fn try_from(src: volume::TargetConfig) -> Result<Self, Self::Error> {
+        let read_only = src.read_only.unwrap_or_default();
         Ok(Self::new(
             match src.target {
                 Some(t) => t.try_into(),
@@ -830,7 +838,8 @@ impl TryFrom<volume::TargetConfig> for TargetConfig {
                 )),
             }?,
             FrontendConfig::default(),
-        ))
+        )
+        .with_read_only(read_only))
     }
 }
 impl From<TargetConfig> for volume::TargetConfig {
@@ -839,6 +848,7 @@ impl From<TargetConfig> for volume::TargetConfig {
             target: Some((&src).into()),
             config: Some(src.config().clone().into()),
             frontend: Some(src.frontend().into()),
+            read_only: Some(src.read_only()),
         }
     }
 }
@@ -1646,6 +1656,7 @@ impl From<VolumeAccessMode> for AccessMode {
         match value {
             VolumeAccessMode::SingleNodeWriter => Self::SingleNodeWriter,
             VolumeAccessMode::MultiNodeMultiWriter => Self::MultiNodeMultiWriter,
+            VolumeAccessMode::MultiNodeReaderOnly => Self::MultiNodeReaderOnly,
         }
     }
 }
@@ -1654,6 +1665,7 @@ impl From<AccessMode> for VolumeAccessMode {
         match value {
             AccessMode::SingleNodeWriter => VolumeAccessMode::SingleNodeWriter,
             AccessMode::MultiNodeMultiWriter => VolumeAccessMode::MultiNodeMultiWriter,
+            AccessMode::MultiNodeReaderOnly => VolumeAccessMode::MultiNodeReaderOnly,
         }
     }
 }

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -3234,6 +3234,7 @@ components:
       enum:
         - SingleNodeWriter
         - MultiNodeMultiWriter
+        - MultiNodeReaderOnly
     NexusState:
       description: State of the Nexus
       type: string

--- a/control-plane/rest/service/src/v0/nexuses.rs
+++ b/control-plane/rest/service/src/v0/nexuses.rs
@@ -125,6 +125,7 @@ impl apis::actix_server::Nexuses for RestApi {
             key: None,
             protocol: protocol.into(),
             allowed_hosts: vec![],
+            read_only: false,
         };
         let share_uri = client().share(&share, None).await?;
         Ok(share_uri)

--- a/control-plane/stor-port/src/types/v0/store/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/store/nexus.rs
@@ -112,6 +112,11 @@ pub struct NexusSpec {
     /// The version of the nexus label.
     #[serde(default)]
     pub version: transport::NexusVersion,
+    /// Publish read-only. Reflects the current `share_nvmf` request so a nexus
+    /// re-share by the reconciler carries the ROX flag forward instead of
+    /// silently reverting to RWO.
+    #[serde(default)]
+    pub read_only: bool,
 }
 impl NexusSpec {
     /// Check if the spec contains the provided replica by it's `ReplicaId`.
@@ -199,6 +204,7 @@ impl From<&NexusSpec> for ShareNexus {
             key: None,
             protocol: from.share.try_into().unwrap_or_default(),
             allowed_hosts: from.allowed_hosts.clone(),
+            read_only: from.read_only,
         }
     }
 }
@@ -276,12 +282,14 @@ impl SpecTransaction<NexusOperation> for NexusSpec {
                 NexusOperation::Create => {
                     self.spec_status = SpecStatus::Created(transport::NexusStatus::Online);
                 }
-                NexusOperation::Share(share, host_nqn) => {
+                NexusOperation::Share(share, host_nqn, read_only) => {
                     self.share = share.into();
                     self.allowed_hosts = host_nqn;
+                    self.read_only = read_only;
                 }
                 NexusOperation::Unshare => {
                     self.share = Protocol::None;
+                    self.read_only = false;
                 }
                 NexusOperation::Shutdown => {
                     self.spec_status = SpecStatus::Created(transport::NexusStatus::Shutdown)
@@ -332,7 +340,9 @@ pub enum NexusOperation {
     Create,
     Destroy,
     Shutdown,
-    Share(NexusShareProtocol, Vec<HostNqn>),
+    /// The trailing bool is the read-only flag. Pre-ROX entries encode this as a
+    /// two-element tuple, so it must default rather than fail to deserialise.
+    Share(NexusShareProtocol, Vec<HostNqn>, #[serde(default)] bool),
     Unshare,
     AddChild(NexusChild),
     RemoveChild(NexusChild),
@@ -341,9 +351,13 @@ pub enum NexusOperation {
 }
 impl NexusOperation {
     /// Create a new sorted share operation.
-    pub fn new_share(share: NexusShareProtocol, mut allowed_hosts: Vec<HostNqn>) -> Self {
+    pub fn new_share(
+        share: NexusShareProtocol,
+        mut allowed_hosts: Vec<HostNqn>,
+        read_only: bool,
+    ) -> Self {
         allowed_hosts.sort();
-        Self::Share(share, allowed_hosts)
+        Self::Share(share, allowed_hosts, read_only)
     }
 }
 
@@ -398,6 +412,7 @@ impl From<&CreateNexus> for NexusSpec {
             status_info: NexusStatusInfo::new(false),
             allowed_hosts: vec![],
             version: request.version.unwrap_or_default(),
+            read_only: false,
         }
     }
 }
@@ -483,5 +498,26 @@ impl NexusStatusInfo {
     }
     pub fn reshutdown(&self) -> bool {
         self.reshutdown
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pending Share op is written to the store before it executes, so an upgrade
+    /// mid-share leaves the pre-ROX two-element encoding in etcd. It has to load.
+    #[test]
+    fn nexus_op_share_pre_rox_defaults_read_only() {
+        let json = r#"{"Share":["nvmf",["nqn.2019-05.io.openebs:host"]]}"#;
+        let op: NexusOperation = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            op,
+            NexusOperation::Share(
+                NexusShareProtocol::Nvmf,
+                vec![HostNqn::try_from("nqn.2019-05.io.openebs:host").unwrap()],
+                false
+            )
+        );
     }
 }

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -476,6 +476,11 @@ pub struct TargetConfig {
     /// Config of frontend-nodes where IO will be sent from.
     #[serde(default)]
     frontend: FrontendConfig,
+    /// Whether the target should be published read-only. Set on ROX publishes so
+    /// the nexus rejects writes at the data plane regardless of what the mount
+    /// layer above requests.
+    #[serde(default)]
+    read_only: bool,
 }
 
 /// Default value for the active field in TargetConfig.
@@ -491,7 +496,20 @@ impl TargetConfig {
             active: true,
             config,
             frontend,
+            read_only: false,
         }
+    }
+
+    /// Builder: set the target's read-only flag. Set on ROX publishes so the
+    /// nexus enforces write rejection at the data plane.
+    pub fn with_read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+
+    /// Whether the target should be published read-only (ROX).
+    pub fn read_only(&self) -> bool {
+        self.read_only
     }
 
     /// Republishing the volume for the given node.

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -742,6 +742,9 @@ pub struct ShareNexus {
     pub protocol: NexusShareProtocol,
     /// host nqn's allowed to connect to the target.
     pub allowed_hosts: Vec<HostNqn>,
+    /// Publish read-only. When true, the io-engine rejects write I/O at the
+    /// nexus so a misconfigured mount above cannot mutate the replicas.
+    pub read_only: bool,
 }
 impl ShareNexus {
     /// Return new `Self` from the given parameters.
@@ -753,6 +756,13 @@ impl ShareNexus {
             allowed_hosts: nqns.into_vec(),
             ..Default::default()
         }
+    }
+
+    /// Builder: publish the nexus read-only. Used by ROX publishes so writes are
+    /// rejected at the data plane regardless of the mount layer above.
+    pub fn with_read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
     }
 }
 impl From<&Nexus> for UnshareNexus {

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -658,12 +658,16 @@ pub enum VolumeAccessMode {
     #[default]
     SingleNodeWriter,
     MultiNodeMultiWriter,
+    /// Multi-initiator read-only attach. Publishes made with this mode set the
+    /// nexus `read_only` flag so writes are rejected at the data plane.
+    MultiNodeReaderOnly,
 }
 impl From<models::VolumeAccessMode> for VolumeAccessMode {
     fn from(value: models::VolumeAccessMode) -> Self {
         match value {
             models::VolumeAccessMode::SingleNodeWriter => Self::SingleNodeWriter,
             models::VolumeAccessMode::MultiNodeMultiWriter => Self::MultiNodeMultiWriter,
+            models::VolumeAccessMode::MultiNodeReaderOnly => Self::MultiNodeReaderOnly,
         }
     }
 }


### PR DESCRIPTION
Iteration 2 of the ROX-fs OEP ([openebs/openebs#4242](https://github.com/openebs/openebs/issues/4242)). The io-engine landed the nexus-level `read_only` flag in [openebs/mayastor#2035](https://github.com/openebs/mayastor/pull/2035): writes reach `Nexus::submit_request` and are rejected with `SPDK_NVME_SC_COMMAND_NAMESPACE_IS_PROTECTED`, and `reservation_acquire` is skipped so multi-host attach works. This PR is the control-plane consumer for that flag: it plumbs a `read_only` decision from the publish access mode all the way down to `PublishNexusRequest`, and keeps the flag around across republish, reconciler re-share, and offline-rebuild promotion.

## What this PR does

Adds a `read_only` field on three type layers so the ROX intent survives every publish-shaped transition:

- **`TargetConfig.read_only`** (persisted per-publish): set from the publish access mode, carried across `republish`, and re-applied by the offline-rebuild promotion branch when a CSI publish arrives mid-rebuild.
- **`NexusSpec.read_only`** (persisted per-nexus): updated on `Share`, cleared on `Unshare`. The nexus reconciler's re-share paths (`fixup_nexus_protocol`) forward this into `ShareNexus` so a re-share after a target-node bounce doesn't silently revert the mode to RWO.
- **`ShareNexus.read_only`** (transport): propagated to the io-engine via `PublishNexusRequest.read_only`, replacing the `None` placeholder from #1143.

Also introduces a `VolumeAccessMode::MultiNodeReaderOnly` variant on the CP-side enum plus the matching proto/openapi `AccessMode::MultiNodeReaderOnly` so `PublishVolume` can distinguish ROX from the existing RWO/RWX modes.

### Mode-conflict guard

A volume already published as ROX cannot be concurrently republished as RWO, and vice versa, same target cannot serve as writer and reader-only at the same time. `next_target_config` returns a new `SvcError::VolumeAccessModeConflict` (`FailedPrecondition`) when the requested mode disagrees with the currently-published mode. Callers must unpublish first, then re-publish with the new mode. The guard is skipped for offline-rebuild targets, which are unshared scratch state and don't serve front-end I/O, a CSI publish mid-rebuild is a promotion, not a switch, and the promotion branch reconciles the mode itself.

## Backward compatibility

Etcd-persisted:

- `TargetConfig` and `NexusSpec` both gain `#[serde(default)]` on `read_only`, so persisted entries from pre-ROX builds deserialize to `read_only: false` rather than erroring.
- Explicit round-trip + missing-key deserialization unit tests cover this in both modules.

Wire:

- `TargetConfig`, `NexusSpec`, and `ShareNexusRequest` all carry `read_only` as `optional`, so older senders/receivers default to RWO, same policy the io-engine iteration 1 PR used.

## Testing

New `volume::rox::rox_publish_and_mode_conflict_guard` int-test covers:

- A `MultiNodeReaderOnly` publish sets `TargetConfig.read_only == true`.
- The publish's `frontend_nodes` all appear in the target's `frontend` nqns, reuses the existing RWX-block multi-initiator fan-out with no separate code path.
- RWO on a ROX-published volume → `VolumeAccessModeConflict`.
- ROX on an RWO-published volume → same error.
- Both transitions work cleanly after an unpublish (ROX → unpublish → RWO succeeds and clears `read_only`; RWO → unpublish → ROX succeeds and sets it back).

## What is deferred for future iterations

- CSI controller: accept `MultiNodeReaderOnly` in `check_volume_capability`'s `AccessType::Mount` branch, drop the unconditional `args.readonly` reject in `ControllerPublishVolume`, add the `rox_fs` StorageClass parameter (mirroring `rwx_block`).
- Add the `ro,noload` / `ro,norecovery` mount options in CSI node.

Until iteration 3 lands, the new access-mode variant is only reachable via the internal gRPC path, the CSI side still rejects `MultiNodeReaderOnly` for `Mount`, so end-user behavior is unchanged.

## References

- OEP: [openebs/openebs#4231](https://github.com/openebs/openebs/pull/4231), tracking [openebs/openebs#4242](https://github.com/openebs/openebs/issues/4242)
- io-engine iteration 1: [openebs/mayastor#2035](https://github.com/openebs/mayastor/pull/2035)