### PR TITLE
add pool drain record

### DIFF
--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -107,6 +107,117 @@ message Metadata {
   // Note that this number may not match the volume-snapshots api, as it will include all snapshots,
   // configured to reside in the pool, sometimes even the failed ones until such time they are deleted.
   optional uint64 snap_count = 4;
+  // Populated when drain request is submitted.
+  // Stores states driving the drain procedure.
+  optional PoolDrainRecord drain_record = 5;
+}
+
+// Record of an in-progress pool drain, driving the drain procedure and tracking its progress.
+message PoolDrainRecord {
+  // Current phase of the drain state machine.
+  DrainPhase phase = 1;
+  // Why pool is in the aforementioned phase.
+  optional PhaseReason phase_reason = 2;
+  // Statistics about the pool's usage at the time the drain was requested, and a live snapshot
+  // of its current usage.
+  optional PoolDrainStatistics drain_statistics = 3;
+  // In-flight replica moves for this drain.
+  repeated DrainConfig replica_moves = 4;
+}
+
+// Why the pool is in its current drain phase.
+enum PhaseReason {
+  // The pool is waiting for a slot to start draining, as the number of concurrent
+  // drains is capped cluster-wide.
+  WaitingForSlot = 0;
+  // The pool is degraded and cannot safely drain without risking data loss.
+  OfflinePool = 1;
+  // The pool has a single replica that cannot be safely evicted without risking data loss.
+  SingleReplicaUnsafeEviction = 2;
+  // The node containing pool is back but pool is cordoned for import, so it cannot be drained.
+  ImportCordoned = 3;
+  // Snapshots are left behind due to user chosen drain policy.
+  SnapshotsRetained = 4;
+}
+
+// Contains the reason for unwinding a spare replica, which is used to determine how
+// to proceed with the drain procedure.
+enum UnwindSpare {
+  // The drain was aborted (`DrainPhase → Aborted`): remove the spare and end the
+  // move, keeping `draining_replica` where it is.
+  Abort = 0;
+  // The pool hosting the still-rebuilding spare has itself entered a drain: remove
+  // the spare and let this move place a fresh one on another eligible pool.
+  Respare = 1;
+}
+
+// Configuration of a single replica move carried out as part of a pool drain.
+message DrainConfig {
+  // When this move first attempted to place its spare.
+  optional google.protobuf.Timestamp placement_started_at = 1;
+  // Id of the volume draining_replica belongs to.
+  string volume = 2;
+  // Id of the pool draining_replica belongs to.
+  string pool = 3;
+  // Id of the draining replica. It's None when it's evacuated successfully.
+  optional string draining_replica = 4;
+  // Id of the spare replica created as part of drain procedure.
+  optional SpareReplica spare_replica = 5;
+  // Why a move's over-replicated spare is being removed.
+  optional UnwindSpare unwind_spare = 6;
+}
+
+// Spare replica reference for this drain.
+message SpareReplica {
+  // Replica Id of the spare, if placed.
+  optional string replica_id = 1;
+}
+
+// The phase of the pool drain state machine.
+enum DrainPhase {
+  // Could not determine the actual drain state.
+  DrainUnknown = 0;
+  // The drain has been admitted and the pool self-cordoned, but no replica has been moved yet:
+  // the pool is waiting for a slot.
+  Queued = 1;
+  // Replicas are actively being evacuated, each one rebuilt onto a spare replica elsewhere
+  // before the copy on this pool is dropped.
+  Draining = 2;
+  // All replicas are evacuated from this pool from the volume's perspective, but replicas are
+  // pending cleanup on the pool itself.
+  AwaitingCleanup = 3;
+  // The user has cancelled the drain and the control plane is undoing the changes it made.
+  // Transient rather than terminal: once cleanup completes the drain record is cleared and the
+  // self-cordon dropped. A new drain is rejected while the pool is in this phase.
+  DrainAborted = 4;
+  // Transitioned from Draining when we can't make any progress on drain operation. Awaiting on
+  // state change or user intervention to continue.
+  PartiallyDrained = 5;
+  // The pool has reached zero allocation: all replicas evacuated and no snapshots left behind,
+  // either because there were none or because they were destroyed under --accept-snapshot-loss.
+  Drained = 6;
+}
+
+/// Gets applied when the pool transitions into Draining state.
+message PoolDrainStatistics {
+  // The initial usage stats of the pool when the pool transitions into Draining state.
+  PoolUsage initial = 1;
+  // A live pool usage snapshot, as the drain's progress counterpart to `initial`.
+  // `None` when the pool has no reported state (node offline / not imported): progress is
+  // then unknown, not zero.
+  optional PoolUsage current = 2;
+}
+
+message PoolUsage {
+  // How many replicas in the pool.
+  uint64 repl_count = 1;
+  // How many replica-snapshots in the pool.
+  uint64 snap_count = 2;
+  // Used bytes from the pool.
+  uint64 used = 3;
+  // Total size of pool replicas.
+  // Unset when the pool state does not report a commitment.
+  optional uint64 committed = 4;
 }
 
 // User specification of a pool.

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -13,19 +13,20 @@ use stor_port::{
     transport_api::{v0::Pools, ReplyError, ResourceKind},
     types::v0::{
         store::pool::{
-            CordonDrainState, CordonedState, DrainPolicy, DrainSpec, Encryption, EncryptionSecret,
-            PoolLabel, PoolMetadata, PoolRuntimeMetadata, PoolSpec, PoolSpecStatus, PoolUSpec,
-            SnapshotPolicy, POOL_BS_CLUSTER_SIZE_DEFAULT,
+            CordonDrainState, CordonedState, DrainConfig, DrainPhase, DrainPolicy, DrainSpec,
+            Encryption, EncryptionSecret, PhaseReason, PoolDrainRecord, PoolLabel, PoolMetadata,
+            PoolPersistedMetadata, PoolRuntimeMetadata, PoolSpec, PoolSpecStatus, PoolUSpec,
+            PoolUsage, SnapshotPolicy, SpareReplica, UnwindSpare, POOL_BS_CLUSTER_SIZE_DEFAULT,
         },
         transport::{
             CreatePool, CtrlPoolState, DestroyPool, DiskInfo, ExpandPool, Filter, LabelPool,
             NodeId, Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolDef, PoolDeleteResult,
             PoolDeviceUri, PoolDiag, PoolDiskError, PoolError, PoolErrorCode, PoolErrorInfo,
-            PoolId, PoolState, PoolStatus, SnapshotLossDetail, SnapshotLossInfo, UnlabelPool,
-            VolumeId, VolumeLossDetail, VolumeLossInfo,
+            PoolId, PoolState, PoolStatus, ReplicaId, SnapshotLossDetail, SnapshotLossInfo,
+            UnlabelPool, VolumeId, VolumeLossDetail, VolumeLossInfo,
         },
     },
-    IntoOption, IntoVec,
+    IntoOption, IntoVec, TryIntoOption, TryIntoVec,
 };
 
 struct ExternalType<T>(T);
@@ -210,7 +211,9 @@ impl TryFrom<pool::PoolDefinition> for PoolSpec {
                 max_expansion: None,
             },
             metadata: PoolMetadata {
-                persisted: Default::default(),
+                persisted: PoolPersistedMetadata {
+                    drain_record: pool_meta.drain_record.try_into_opt()?,
+                },
                 runtime: PoolRuntimeMetadata {
                     diag: None,
                     replica_count: pool_meta.repl_count,
@@ -578,7 +581,216 @@ impl From<PoolDef> for pool::PoolDefinition {
                 spec_status: spec_status as i32,
                 repl_count: pool_def.replica_count,
                 snap_count: pool_def.snapshot_count,
+                drain_record: pool_def.persisted_metadata.drain_record.into_opt(),
             }),
+        }
+    }
+}
+
+impl From<PoolDrainRecord> for pool::PoolDrainRecord {
+    fn from(value: PoolDrainRecord) -> Self {
+        Self {
+            phase: pool::DrainPhase::from(value.phase) as i32,
+            phase_reason: value
+                .phase_reason
+                .map(|reason| pool::PhaseReason::from(reason) as i32),
+            drain_statistics: Some(pool::PoolDrainStatistics {
+                initial: value.initial_stats.into_opt(),
+                current: None,
+            }),
+            replica_moves: value.replica_moves.into_vec(),
+        }
+    }
+}
+
+impl From<DrainConfig> for pool::DrainConfig {
+    fn from(value: DrainConfig) -> Self {
+        Self {
+            placement_started_at: value.placement_started_at.map(prost_types::Timestamp::from),
+            volume: value.volume.to_string(),
+            pool: value.pool.to_string(),
+            draining_replica: value.draining_replica.map(|replica| replica.to_string()),
+            spare_replica: value.spare_replica.into_opt(),
+            unwind_spare: value
+                .unwind_spare
+                .map(|unwind| pool::UnwindSpare::from(unwind) as i32),
+        }
+    }
+}
+
+impl From<SpareReplica> for pool::SpareReplica {
+    fn from(value: SpareReplica) -> Self {
+        Self {
+            replica_id: value.replica_id.map(|replica| replica.to_string()),
+        }
+    }
+}
+
+impl From<UnwindSpare> for pool::UnwindSpare {
+    fn from(value: UnwindSpare) -> Self {
+        match value {
+            UnwindSpare::Abort => Self::Abort,
+            UnwindSpare::Respare => Self::Respare,
+        }
+    }
+}
+
+impl From<PoolUsage> for pool::PoolUsage {
+    fn from(value: PoolUsage) -> Self {
+        Self {
+            repl_count: value.repl_count,
+            snap_count: value.snap_count,
+            used: value.used,
+            committed: value.committed,
+        }
+    }
+}
+
+impl From<DrainPhase> for pool::DrainPhase {
+    fn from(value: DrainPhase) -> Self {
+        match value {
+            DrainPhase::Unknown => Self::DrainUnknown,
+            DrainPhase::Queued => Self::Queued,
+            DrainPhase::Draining => Self::Draining,
+            DrainPhase::AwaitingCleanup => Self::AwaitingCleanup,
+            DrainPhase::Aborted => Self::DrainAborted,
+            DrainPhase::PartiallyDrained => Self::PartiallyDrained,
+            DrainPhase::Drained => Self::Drained,
+        }
+    }
+}
+
+impl TryFrom<pool::PoolDrainRecord> for PoolDrainRecord {
+    type Error = ReplyError;
+    fn try_from(value: pool::PoolDrainRecord) -> Result<Self, Self::Error> {
+        let phase = pool::DrainPhase::try_from(value.phase).map_err(|error| {
+            ReplyError::invalid_argument(
+                ResourceKind::Pool,
+                "pool.metadata.drain_record.phase",
+                error.to_string(),
+            )
+        })?;
+        let initial_stats = value
+            .drain_statistics
+            .and_then(|statistics| statistics.initial);
+        Ok(Self {
+            phase: phase.into(),
+            phase_reason: value
+                .phase_reason
+                .and_then(|reason| pool::PhaseReason::try_from(reason).ok())
+                .map(Into::into),
+            initial_stats: initial_stats.into_opt(),
+            replica_moves: value.replica_moves.try_into_vec()?,
+        })
+    }
+}
+
+impl From<PhaseReason> for pool::PhaseReason {
+    fn from(value: PhaseReason) -> Self {
+        match value {
+            PhaseReason::WaitingForSlot => Self::WaitingForSlot,
+            PhaseReason::OfflinePool => Self::OfflinePool,
+            PhaseReason::SingleReplicaUnsafeEviction => Self::SingleReplicaUnsafeEviction,
+            PhaseReason::ImportCordoned => Self::ImportCordoned,
+            PhaseReason::SnapshotsRetained => Self::SnapshotsRetained,
+        }
+    }
+}
+
+impl From<pool::PhaseReason> for PhaseReason {
+    fn from(value: pool::PhaseReason) -> Self {
+        match value {
+            pool::PhaseReason::WaitingForSlot => Self::WaitingForSlot,
+            pool::PhaseReason::OfflinePool => Self::OfflinePool,
+            pool::PhaseReason::SingleReplicaUnsafeEviction => Self::SingleReplicaUnsafeEviction,
+            pool::PhaseReason::ImportCordoned => Self::ImportCordoned,
+            pool::PhaseReason::SnapshotsRetained => Self::SnapshotsRetained,
+        }
+    }
+}
+
+impl From<pool::DrainPhase> for DrainPhase {
+    fn from(value: pool::DrainPhase) -> Self {
+        match value {
+            pool::DrainPhase::DrainUnknown => Self::Unknown,
+            pool::DrainPhase::Queued => Self::Queued,
+            pool::DrainPhase::Draining => Self::Draining,
+            pool::DrainPhase::AwaitingCleanup => Self::AwaitingCleanup,
+            pool::DrainPhase::DrainAborted => Self::Aborted,
+            pool::DrainPhase::PartiallyDrained => Self::PartiallyDrained,
+            pool::DrainPhase::Drained => Self::Drained,
+        }
+    }
+}
+
+impl From<pool::PoolUsage> for PoolUsage {
+    fn from(value: pool::PoolUsage) -> Self {
+        Self {
+            repl_count: value.repl_count,
+            snap_count: value.snap_count,
+            used: value.used,
+            committed: value.committed,
+        }
+    }
+}
+
+impl TryFrom<pool::DrainConfig> for DrainConfig {
+    type Error = ReplyError;
+    fn try_from(value: pool::DrainConfig) -> Result<Self, Self::Error> {
+        let placement_started_at = value
+            .placement_started_at
+            .map(std::time::SystemTime::try_from)
+            .transpose()
+            .map_err(|error| {
+                ReplyError::invalid_argument(
+                    ResourceKind::Pool,
+                    "pool.metadata.drain_record.replica_moves.pool_drain.placement_started_at",
+                    error.to_string(),
+                )
+            })?;
+        let unwind_spare = value
+            .unwind_spare
+            .map(|unwind| {
+                pool::UnwindSpare::try_from(unwind).map_err(|error| {
+                    ReplyError::invalid_argument(
+                        ResourceKind::Pool,
+                        "pool.metadata.drain_record.replica_moves.pool_drain.unwind_spare",
+                        error.to_string(),
+                    )
+                })
+            })
+            .transpose()?;
+        Ok(Self {
+            placement_started_at,
+            volume: VolumeId::try_from(StringValue(Some(value.volume)))?,
+            pool: PoolId::from(value.pool),
+            draining_replica: value
+                .draining_replica
+                .map(|replica| ReplicaId::try_from(StringValue(Some(replica))))
+                .transpose()?,
+            spare_replica: value.spare_replica.try_into_opt()?,
+            unwind_spare: unwind_spare.into_opt(),
+        })
+    }
+}
+
+impl TryFrom<pool::SpareReplica> for SpareReplica {
+    type Error = ReplyError;
+    fn try_from(value: pool::SpareReplica) -> Result<Self, Self::Error> {
+        Ok(Self {
+            replica_id: value
+                .replica_id
+                .map(|replica| ReplicaId::try_from(StringValue(Some(replica))))
+                .transpose()?,
+        })
+    }
+}
+
+impl From<pool::UnwindSpare> for UnwindSpare {
+    fn from(value: pool::UnwindSpare) -> Self {
+        match value {
+            pool::UnwindSpare::Abort => Self::Abort,
+            pool::UnwindSpare::Respare => Self::Respare,
         }
     }
 }
@@ -707,13 +919,23 @@ impl From<PoolError> for pool::ProbeError {
 
 impl From<Pool> for pool::Pool {
     fn from(pool: Pool) -> Self {
+        let current_usage = pool.current_usage();
         let state = pool.state;
         let (def, diag) = match pool.config {
             None => (None, None),
             Some(cfg) => (Some(cfg.definition), cfg.diag),
         };
+        let mut definition = def.into_opt();
+        if let Some(statistics) = definition
+            .as_mut()
+            .and_then(|def: &mut pool::PoolDefinition| def.metadata.as_mut())
+            .and_then(|meta| meta.drain_record.as_mut())
+            .and_then(|record| record.drain_statistics.as_mut())
+        {
+            statistics.current = current_usage.into_opt();
+        }
         pool::Pool {
-            definition: def.into_opt(),
+            definition,
             state: state.map(|p| p.state).into_opt(),
             diag: diag.into_opt(),
         }

--- a/control-plane/stor-port/src/types/v0/store/pool.rs
+++ b/control-plane/stor-port/src/types/v0/store/pool.rs
@@ -2,12 +2,15 @@
 
 use crate::{
     types::v0::{
-        openapi::{models, models::PoolSpecEncryption},
+        openapi::models::{self, PoolSpecEncryption},
         store::{
             definitions::{ObjectKey, StorableObject, StorableObjectType},
             AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
-        transport::{self, CreatePool, ImportPool, NodeId, PoolDeviceUri, PoolDiag, PoolId},
+        transport::{
+            self, CreatePool, ImportPool, NodeId, PoolDeviceUri, PoolDiag, PoolId, ReplicaId,
+            VolumeId,
+        },
     },
     IntoOption,
 };
@@ -198,8 +201,115 @@ pub struct PoolMetadata {
 
 /// Pool meta information.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-pub struct PoolPersistedMetadata {}
+pub struct PoolPersistedMetadata {
+    /// Populated when drain request is submitted.
+    /// Stores states driving the drain procedure.
+    #[serde(default, skip_serializing_if = "super::is_default")]
+    pub drain_record: Option<PoolDrainRecord>,
+}
 
+/// Record of an in-progress pool drain, driving the drain procedure and tracking its progress.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct PoolDrainRecord {
+    /// Current phase of the drain state machine.
+    pub phase: DrainPhase,
+    /// Why pool is in the aforementioned phase.
+    pub phase_reason: Option<PhaseReason>,
+    /// The initial usage stats of the pool when the pool transitions into Draining state.
+    pub initial_stats: Option<PoolUsage>,
+    /// In-flight replica moves for this drain.
+    pub replica_moves: Vec<DrainConfig>,
+}
+
+/// Why the pool is in its current drain phase.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum PhaseReason {
+    /// The pool is waiting for a slot to start draining, as the number of concurrent drains is
+    /// capped cluster-wide.
+    WaitingForSlot,
+    /// The pool is degraded and cannot safely drain without risking data loss.
+    OfflinePool,
+    /// The pool has a single replica that cannot be safely evicted without risking data loss.
+    SingleReplicaUnsafeEviction,
+    /// The node containing pool is back but pool is cordoned for import, so it cannot be drained.
+    ImportCordoned,
+    /// Snapshots are left behind due to user chosen drain policy.
+    SnapshotsRetained,
+}
+
+/// The phase of the pool drain state machine.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub enum DrainPhase {
+    /// Could not determine the actual drain state.
+    Unknown,
+    /// The drain has been admitted and the pool is self-cordoned, but no replica has been moved
+    /// yet, the pool is waiting for a concurrency slot.
+    Queued,
+    /// Replicas are actively being evacuated.
+    Draining,
+    /// All replicas are evacuated from this pool from the volume's perspective, but replicas are
+    /// pending cleanup on the pool itself.
+    AwaitingCleanup,
+    /// Transitioned from Draining when we can't make any progress on drain operation. Awaiting on
+    /// state change or user intervention to continue.
+    PartiallyDrained,
+    /// The pool has reached zero allocation/commitment: all replicas were evacuated and no
+    /// snapshots are left behind.
+    Drained,
+    /// The user has cancelled the drain and the control plane is undoing the changes the drain
+    /// made, unwinding in-flight moves and their spare replicas.
+    Aborted,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct PoolUsage {
+    /// Number of replicas present on pool.
+    pub repl_count: u64,
+    /// Number of snapshots present on pool.
+    pub snap_count: u64,
+    /// Used capacity, in bytes.
+    pub used: u64,
+    /// Committed capacity, in bytes.
+    /// `None` when the pool state does not report a commitment.
+    pub committed: Option<u64>,
+}
+
+/// Configuration of a single replica move carried out as part of a pool drain.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct DrainConfig {
+    /// When this move first attempted to place its spare.
+    pub placement_started_at: Option<SystemTime>,
+    /// Id of the volume draining_replica belongs to.
+    pub volume: VolumeId,
+    /// Id of the pool draining_replica belongs to.
+    pub pool: PoolId,
+    /// Id of the draining replica. It's None when it's evacuated successfully.
+    pub draining_replica: Option<ReplicaId>,
+    /// Id of the spare replica created as part of drain procedure.
+    pub spare_replica: Option<SpareReplica>,
+    /// Why a move's over-replicated spare is being removed.
+    #[serde(skip)]
+    pub unwind_spare: Option<UnwindSpare>,
+}
+
+/// Spare replica reference for this drain.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct SpareReplica {
+    /// Replica Id of the spare, if placed.
+    pub replica_id: Option<ReplicaId>,
+}
+
+/// Contains the reason for unwinding a spare replica, which is used to determine how to proceed with
+/// the drain procedure.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UnwindSpare {
+    /// The drain was aborted (`DrainPhase → Aborted`): remove the spare and end the
+    /// move, keeping `draining_replica` where it is.
+    Abort,
+    /// The pool hosting the still-rebuilding spare has itself entered a drain: remove
+    /// the spare and let this move place a fresh one on another eligible pool.
+    Respare,
+}
 /// Runtime pool information.
 #[derive(Debug, Clone, PartialEq, Default)]
 pub struct PoolRuntimeMetadata {

--- a/control-plane/stor-port/src/types/v0/store/volume.rs
+++ b/control-plane/stor-port/src/types/v0/store/volume.rs
@@ -6,7 +6,7 @@ use crate::{
         store::{
             definitions::{ObjectKey, StorableObject, StorableObjectType},
             nexus_persistence::VolumeHealthKey,
-            pool::{default_pool_cluster_size, POOL_BS_CLUSTER_SIZE_DEFAULT},
+            pool::{default_pool_cluster_size, DrainConfig, POOL_BS_CLUSTER_SIZE_DEFAULT},
             AsOperationSequencer, OperationSequence, SpecStatus, SpecTransaction,
         },
         transport::{
@@ -429,6 +429,8 @@ pub struct VolumeRuntimeMetadata {
     /// Degraded; used to enforce the grace period before starting a rebuild.
     /// Tied to the volume's lifetime so it goes away when the volume is deleted.
     offline_rebuild_degraded_since: Option<std::time::Instant>,
+    /// Configuration for the replica move operation, if any.
+    replica_move: Option<ReplicaMoveRequester>,
 }
 impl VolumeRuntimeMetadata {
     /// Check if there's any snapshot.
@@ -457,6 +459,14 @@ impl VolumeRuntimeMetadata {
     pub fn clear_offline_rebuild_degraded(&mut self) {
         self.offline_rebuild_degraded_since = None;
     }
+}
+
+/// The entity on whose behalf a replica move is being carried out, along with the move
+/// configuration specific to it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ReplicaMoveRequester {
+    /// The move was requested by a pool drain.
+    PoolDrain(DrainConfig),
 }
 
 /// The volume's Nvmf Configuration.

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -2,7 +2,8 @@ use super::*;
 
 use crate::{
     types::v0::store::pool::{
-        Encryption, EncryptionSecret, PoolLabel, PoolRuntimeMetadata, PoolSpec, PoolUSpec,
+        Encryption, EncryptionSecret, PoolLabel, PoolPersistedMetadata, PoolRuntimeMetadata,
+        PoolSpec, PoolUSpec, PoolUsage,
     },
     IntoOption,
 };
@@ -532,6 +533,7 @@ pub struct PoolDef {
     pub replica_count: Option<u64>,
     /// How many snapshots are owned by the pool.
     pub snapshot_count: Option<u64>,
+    pub persisted_metadata: PoolPersistedMetadata,
 }
 
 /// User configuration with user specification and metadata information.
@@ -559,6 +561,7 @@ impl From<PoolSpec> for PoolConfig {
                 spec: value.spec,
                 replica_count: value.metadata.runtime.replica_count,
                 snapshot_count: value.metadata.runtime.snapshot_count,
+                persisted_metadata: value.metadata.persisted,
             },
             diag: value.metadata.runtime.diag,
         }
@@ -620,6 +623,17 @@ impl Pool {
     /// Get the pool diagnostics.
     pub fn diag(&self) -> Option<&PoolDiag> {
         self.config.as_ref()?.diag.as_ref()
+    }
+    /// Get a live pool usage statistics, if available.
+    pub fn current_usage(&self) -> Option<PoolUsage> {
+        let state = self.state.as_ref()?;
+        let def = self.config.as_ref().map(|config| &config.definition);
+        Some(PoolUsage {
+            repl_count: def.and_then(|def| def.replica_count)?,
+            snap_count: def.and_then(|def| def.snapshot_count)?,
+            used: state.used,
+            committed: state.committed,
+        })
     }
     /// Get the pool identification.
     pub fn id(&self) -> &PoolId {


### PR DESCRIPTION
This PR Introduces the persisted state that will drive the pool drain procedure.

There is no rest changes yet. only core type and gRPC changes.

