### PR TITLE
feat(grpc): support TLS across the agent gRPC stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,6 +749,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cert-watcher"
+version = "0.1.0"
+dependencies = [
+ "inotify",
+ "tracing",
+]
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,17 +1729,27 @@ dependencies = [
 name = "grpc"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "cert-watcher",
  "events-api",
+ "futures",
+ "http 1.1.0",
  "humantime",
+ "hyper-util",
  "once_cell",
  "opentelemetry",
  "opentelemetry-http",
  "prost",
  "prost-types",
+ "rcgen",
  "rpc",
+ "rustls",
+ "rustls-pemfile",
  "serde_json",
  "stor-port",
  "tokio",
+ "tokio-rustls",
+ "tokio-stream",
  "tonic",
  "tonic-build",
  "tower",
@@ -2670,7 +2688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2966,6 +2984,7 @@ version = "1.0.0"
 dependencies = [
  "actix-web",
  "async-trait",
+ "cert-watcher",
  "dyn-clonable",
  "futures",
  "http-body",
@@ -2974,7 +2993,6 @@ dependencies = [
  "hyper-body",
  "hyper-rustls",
  "hyper-util",
- "inotify",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-otlp",
@@ -3625,13 +3643,13 @@ dependencies = [
  "actix-web",
  "anyhow",
  "async-trait",
+ "cert-watcher",
  "clap",
  "deployer-cluster",
  "futures",
  "grpc",
  "http 1.1.0",
  "humantime",
- "inotify",
  "jsonwebtoken",
  "num_cpus",
  "once_cell",
@@ -4526,12 +4544,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "rustls-pki-types",
  "tokio",
 ]
 
@@ -4626,6 +4643,7 @@ dependencies = [
  "prost",
  "socket2 0.5.7",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",
@@ -4961,6 +4979,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "regex",
+ "rustls",
  "strum",
  "strum_macros",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,7 +259,7 @@ dependencies = [
  "tokio",
  "tokio-udev",
  "tonic",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "url",
  "utils",
@@ -497,11 +497,10 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.7"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504e3947307ac8326a5437504c517c4b56716c9d98fac0028c2acc7ca47d70ae"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "async-trait",
  "axum-core",
  "bytes",
  "futures-util",
@@ -514,29 +513,26 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "sync_wrapper",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.4.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
- "async-trait",
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.1.0",
  "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -1107,7 +1103,7 @@ dependencies = [
  "strum_macros",
  "tokio",
  "tonic",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-subscriber",
  "utils",
@@ -1135,7 +1131,7 @@ dependencies = [
  "stor-port",
  "tokio",
  "tonic",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1372,9 +1368,9 @@ dependencies = [
 
 [[package]]
 name = "etcd-client"
-version = "0.14.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bde3ce50a626efeb1caa9ab1083972d178bebb55ca627639c8ded507dfcbde"
+checksum = "88365f1a5671eb2f7fc240adb216786bc6494b38ce15f1d26ad6eaa303d5e822"
 dependencies = [
  "http 1.1.0",
  "prost",
@@ -1382,7 +1378,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tonic-build",
- "tower 0.4.13",
+ "tower",
  "tower-service",
 ]
 
@@ -1738,7 +1734,7 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-opentelemetry",
  "utils",
@@ -1957,7 +1953,7 @@ version = "0.1.0"
 dependencies = [
  "http-body-util",
  "hyper",
- "tower 0.5.3",
+ "tower",
 ]
 
 [[package]]
@@ -2541,7 +2537,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
 ]
@@ -2593,7 +2589,7 @@ dependencies = [
  "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2610,7 +2606,7 @@ dependencies = [
  "kube-forward",
  "openapi",
  "thiserror 1.0.68",
- "tower 0.5.3",
+ "tower",
  "url",
  "utils",
 ]
@@ -2769,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
@@ -2991,7 +2987,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-opentelemetry",
@@ -3008,23 +3004,23 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570074cc999d1a58184080966e5bd3bf3a9a4af650c3b05047c2621e7405cd17"
+checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
 dependencies = [
  "futures-core",
  "futures-sink",
  "js-sys",
- "once_cell",
  "pin-project-lite",
- "thiserror 1.0.68",
+ "thiserror 2.0.20",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6351496aeaa49d7c267fb480678d85d1cd30c5edb20b497c48c56f62a8c14b99"
+checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3034,27 +3030,26 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e1f9c8b032d4f635c730c0efcf731d5e2530ea13fa8bef7939ddc8420696bd"
+checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
- "async-trait",
- "futures-core",
  "http 1.1.0",
  "opentelemetry",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror 1.0.68",
+ "thiserror 2.0.20",
  "tokio",
  "tonic",
+ "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.26.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9d3968ce3aefdcca5c27e3c4ea4391b37547726a70893aab52d3de95d5f8b34"
+checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3064,29 +3059,24 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db945c1eaea8ac6a9677185357480d215bb6999faa9f691d0c4d4d641eab7a09"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.26.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c627d9f4c9cdc1f21a29ee4bfbd6028fcb8bcf2a857b43f3abdf72c9c862f3"
+checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
 dependencies = [
- "async-trait",
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.9.5",
  "serde_json",
- "thiserror 1.0.68",
- "tokio",
- "tokio-stream",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -3620,7 +3610,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -4618,11 +4608,10 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
  "base64 0.22.1",
@@ -4640,7 +4629,7 @@ dependencies = [
  "socket2 0.5.7",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4648,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.12.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -4662,33 +4651,15 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.6.0",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
  "tokio-util",
@@ -4711,7 +4682,7 @@ dependencies = [
  "http-body",
  "mime",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4744,9 +4715,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-actix-web"
-version = "0.7.14"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b87073920bcce23e9f5cb0d2671e9f01d6803bb5229c159b2f5ce6806d73ffc"
+checksum = "2f28f45dd524790b44a7b372f7c3aec04a3af6b42d494e861b67de654cb25a5e"
 dependencies = [
  "actix-web",
  "mutually_exclusive_features",
@@ -4798,9 +4769,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc58af5d3f6c5811462cabb3289aec0093f7338e367e5a33d28c0433b3c7360b"
+checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
 dependencies = [
  "js-sys",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3042,7 +3042,6 @@ dependencies = [
  "thiserror 2.0.20",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]
@@ -3075,7 +3074,6 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.5",
- "serde_json",
  "thiserror 2.0.20",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "utils/weighted-scoring",
     "utils/deployer-cluster",
     "utils/hyper-body",
+    "utils/cert-watcher",
     "tests/io-engine",
     "utils/bundle-sim",
     "utils/event-consumer",
@@ -61,6 +62,7 @@ composer = { path = "./utils/dependencies/composer", default-features = false }
 
 rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 rustls-pemfile = "2.2.0"
+tokio-rustls = "0.26.2"
 webpki = "0.22.4"
 tokio-native-tls = "0.3.1"
 rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }
@@ -147,6 +149,7 @@ tower-http = { version = "0.6", features = ["trace", "map-response-body", "auth"
 hyper-util = "0.1.10"
 hyper = { version = "1.5.0", default-features = false, features = ["client", "http1", "http2"] }
 hyper-body = { path = "./utils/hyper-body" }
+cert-watcher = { path = "./utils/cert-watcher" }
 http-body-util = { version = "0.1.3", default-features = false }
 hyper-rustls = { version = "0.27.3", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,8 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-actix-web = { version = "0.7.19", features = ["opentelemetry_0_30"] }
 tracing-opentelemetry = { version = "0.31.0" }
 opentelemetry = { version = "0.30.0" }
-opentelemetry-otlp = { version = "0.30.0", default-features = false, features = ["grpc-tonic", "trace", "internal-logs"] }
-opentelemetry_sdk = { version = "0.30.0" }
+opentelemetry-otlp = { version = "0.30.0", default-features = false, features = ["grpc-tonic", "trace"] }
+opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["trace"] }
 opentelemetry-http = { version = "0.30.0" }
 opentelemetry-semantic-conventions = "0.30.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,13 +81,13 @@ inotify = { version = "0.11.0", default-features = false }
 # tracing and telemetry
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing-actix-web = { version = "0.7.14", features = ["opentelemetry_0_26"] }
-tracing-opentelemetry = { version = "0.27.0" }
-opentelemetry = { version = "0.26.0" }
-opentelemetry-otlp = { version = "0.26.0" }
-opentelemetry_sdk = { version = "0.26.0" }
-opentelemetry-http = { version = "0.26.0" }
-opentelemetry-semantic-conventions = "0.26.0"
+tracing-actix-web = { version = "0.7.19", features = ["opentelemetry_0_30"] }
+tracing-opentelemetry = { version = "0.31.0" }
+opentelemetry = { version = "0.30.0" }
+opentelemetry-otlp = { version = "0.30.0", default-features = false, features = ["grpc-tonic", "trace", "internal-logs"] }
+opentelemetry_sdk = { version = "0.30.0" }
+opentelemetry-http = { version = "0.30.0" }
+opentelemetry-semantic-conventions = "0.30.0"
 
 paste = "1.0.15"
 once_cell = "1.20.2"
@@ -134,8 +134,8 @@ strum = "0.26.3"
 strum_macros = "0.26.4"
 heck = "0.5.0"
 
-tonic = "0.12.3"
-tonic-build = "0.12.3"
+tonic = { version = "0.13.1", features = ["tls-aws-lc"] }
+tonic-build = "0.13.1"
 prost-types = "0.13.3"
 prost = "0.13.2"
 prost-derive = "0.13.3"
@@ -164,4 +164,4 @@ k8s-openapi = { version = "0.24.0", default-features = false, features = ["v1_28
 kube = { version = "0.99.0", default-features = false, features = ["runtime", "derive", "client", "rustls-tls", "aws-lc-rs"] }
 schemars = { version = "0.8.21" }
 async-nats = { version = "0.47.0", default-features = false, features = ["aws-lc-rs", "jetstream"] }
-etcd-client = "0.14.0"
+etcd-client = "0.16.1"

--- a/control-plane/agents/src/bin/core/controller/io_engine/client.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/client.rs
@@ -30,10 +30,13 @@ pub(crate) struct GrpcContext {
     api_version: ApiVersion,
     /// Simulated io-engine node.
     sim: bool,
+    /// Whether the io-engine gRPC server expects TLS connections.
+    tls: bool,
 }
 
 impl GrpcContext {
     /// Return a new `Self` from the given parameters.
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         lock: Arc<tokio::sync::Mutex<()>>,
         node: &NodeId,
@@ -42,6 +45,7 @@ impl GrpcContext {
         request: Option<MessageId>,
         api_version: ApiVersion,
         sim: bool,
+        tls: bool,
     ) -> Result<Self, SvcError> {
         let uri = http::uri::Uri::builder()
             .scheme("http")
@@ -70,6 +74,7 @@ impl GrpcContext {
             comms_timeouts: comms_timeouts.clone(),
             api_version,
             sim,
+            tls,
         })
     }
     /// Override the timeout config in the context for the given request.
@@ -107,6 +112,19 @@ impl GrpcContext {
             endpoint = endpoint.user_agent(self.node().as_str()).unwrap();
         }
         endpoint
+    }
+    /// Connect a tonic `Channel` to this node.
+    /// Uses auto-TLS (certificate verification bypassed) when the io-engine advertises gRPC TLS
+    /// support in its registration, otherwise a plaintext connection.
+    pub(crate) async fn connect_channel(
+        &self,
+    ) -> Result<tonic::transport::Channel, tonic::transport::Error> {
+        let endpoint = self.tonic_endpoint();
+        if self.tls {
+            grpc::tls::auto_tls_connect(&endpoint).await
+        } else {
+            endpoint.connect().await
+        }
     }
     /// Get the node identifier.
     pub(crate) fn node(&self) -> &NodeId {

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/mod.rs
@@ -32,12 +32,11 @@ impl RpcClient {
         })
     }
     async fn make_client(context: &GrpcContext) -> Result<IoEngineClientV0<Channel>, SvcError> {
-        IoEngineClientV0::connect(context.tonic_endpoint())
-            .await
-            .context(GrpcConnect {
-                node_id: context.node().to_owned(),
-                endpoint: context.endpoint().to_string(),
-            })
+        let channel = context.connect_channel().await.context(GrpcConnect {
+            node_id: context.node().to_owned(),
+            endpoint: context.endpoint().to_string(),
+        })?;
+        Ok(IoEngineClientV0::new(channel))
     }
     async fn fetcher_client(&self) -> Result<Self, SvcError> {
         let mut context = self.context.clone();

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/mod.rs
@@ -41,14 +41,10 @@ pub(crate) struct RpcClient {
 impl RpcClient {
     /// Create a new grpc client with a context.
     pub(crate) async fn new(context: &GrpcContext) -> Result<Self, SvcError> {
-        let channel = context
-            .tonic_endpoint()
-            .connect()
-            .await
-            .context(GrpcConnect {
-                node_id: context.node().to_owned(),
-                endpoint: context.endpoint().to_string(),
-            })?;
+        let channel = context.connect_channel().await.context(GrpcConnect {
+            node_id: context.node().to_owned(),
+            endpoint: context.endpoint().to_string(),
+        })?;
 
         Ok(Self {
             host: HostClient::new(channel.clone()),

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/snap_rebuild.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/snap_rebuild.rs
@@ -135,6 +135,7 @@ mod test {
             None,
             ApiVersion::V1,
             false,
+            false,
         )
         .unwrap();
         let io_engine = GrpcClient::new(&ctx).await.unwrap();

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -122,6 +122,18 @@ pub(crate) struct CliArgs {
     /// (supports the http/https schema)
     #[clap(long, short, default_value = DEFAULT_GRPC_SERVER_ADDR)]
     pub(crate) grpc_server_addr: SocketAddr,
+    /// Path to the TLS server certificate chain for the Core gRPC server.
+    #[clap(long = "grpc-tls-cert-file", requires = "grpc_tls_key_file")]
+    grpc_tls_cert_file: Option<std::path::PathBuf>,
+    /// Path to the TLS server private key for the Core gRPC server.
+    #[clap(long = "grpc-tls-key-file", requires = "grpc_tls_cert_file")]
+    grpc_tls_key_file: Option<std::path::PathBuf>,
+    /// Path to the CA bundle used to authenticate Core gRPC clients.
+    #[clap(long = "grpc-tls-ca-file")]
+    grpc_tls_ca_file: Option<std::path::PathBuf>,
+    /// Auto-generate an ephemeral self-signed certificate for the Core gRPC server.
+    #[clap(long = "grpc-auto-tls", conflicts_with_all = ["grpc_tls_cert_file", "grpc_tls_key_file", "grpc_tls_ca_file"])]
+    grpc_auto_tls: bool,
     /// The maximum number of system-wide rebuilds permitted at any given time.
     /// If `None` do not limit the number of rebuilds.
     #[clap(long)]
@@ -196,6 +208,19 @@ impl CliArgs {
     fn args() -> Self {
         CliArgs::parse()
     }
+
+    fn grpc_tls(&self) -> anyhow::Result<Option<grpc::tls::TlsConfig>> {
+        match (&self.grpc_tls_cert_file, &self.grpc_tls_key_file) {
+            (None, None) => Ok(None),
+            (Some(certificate), Some(private_key)) => grpc::tls::TlsConfig::new(
+                self.grpc_tls_ca_file.clone(),
+                Some(certificate.clone()),
+                Some(private_key.clone()),
+            )
+            .map(Some),
+            _ => unreachable!("clap requires the gRPC TLS certificate and private key together"),
+        }
+    }
 }
 
 /// Cluster wide thin provisioning parameters.
@@ -256,6 +281,7 @@ fn value_parse_percent(value: &str) -> Result<u64, ParseIntError> {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    utils::init_rustls_crypto_provider();
     let cli_args = CliArgs::args();
     utils::print_package_info!();
     println!("Using options: {cli_args:?}");
@@ -273,6 +299,9 @@ async fn main() -> anyhow::Result<()> {
 async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
     stor_port::platform::init_cluster_info_or_panic().await;
     let sim_args: Option<SimArgs> = (&cli_args).try_into()?;
+    let grpc_tls = cli_args.grpc_tls()?;
+    let grpc_auto_tls = cli_args.grpc_auto_tls;
+    let grpc_server_addr = cli_args.grpc_server_addr;
     let registry = controller::registry::Registry::new(
         cli_args.cache_period.into(),
         cli_args.store.clone(),
@@ -314,7 +343,7 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
             ),
         )
         .with_shared_state(registry.clone())
-        .with_shared_state(cli_args.grpc_server_addr)
+        .with_shared_state(grpc_server_addr)
         .configure_async(node::configure)
         .await
         .configure(pool::configure)
@@ -325,9 +354,25 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
         .configure(app_node::configure);
 
     registry.start().await;
-    let result = service.run_err(cli_args.grpc_server_addr).await;
+    let result = run_grpc_server(service, grpc_server_addr, grpc_auto_tls, grpc_tls).await;
     registry.stop().await;
     utils::tracing_telemetry::flush_traces();
     result?;
     Ok(())
+}
+
+async fn run_grpc_server(
+    service: agents::Service,
+    socket: SocketAddr,
+    auto_tls: bool,
+    tls: Option<grpc::tls::TlsConfig>,
+) -> Result<(), agents::ServiceError> {
+    match (auto_tls, tls) {
+        // Core sits at a mixed-version boundary: io-engines register here and may still be
+        // plaintext during a rolling upgrade, so its listener sniffs and accepts both transports.
+        (true, None) => service.run_auto_tls_err(socket, true).await,
+        (true, Some(_)) => unreachable!("clap prevents combining gRPC TLS files and auto TLS"),
+        (false, Some(tls)) => service.run_tls_err(socket, tls, true).await,
+        (false, None) => service.run_err(socket).await,
+    }
 }

--- a/control-plane/agents/src/bin/core/main.rs
+++ b/control-plane/agents/src/bin/core/main.rs
@@ -307,10 +307,11 @@ async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
 
     let service = agents::Service::builder()
         .with_shared_state(
-            utils::tracing_telemetry::global::tracer_provider()
-                .tracer_builder("core-agent")
-                .with_version(env!("CARGO_PKG_VERSION"))
-                .build(),
+            utils::tracing_telemetry::global::tracer_provider().tracer_with_scope(
+                opentelemetry::InstrumentationScope::builder("core-agent")
+                    .with_version(env!("CARGO_PKG_VERSION"))
+                    .build(),
+            ),
         )
         .with_shared_state(registry.clone())
         .with_shared_state(cli_args.grpc_server_addr)

--- a/control-plane/agents/src/bin/core/node/mod.rs
+++ b/control-plane/agents/src/bin/core/node/mod.rs
@@ -21,12 +21,16 @@ use stor_port::{
 pub(crate) async fn configure(builder: agents::ServiceEmpty) -> Service {
     let node_service = create_node_service(&builder).await;
     let node_grpc_service = NodeServer::new(Arc::new(node_service.clone()));
-    let registration_service = RegistrationServer::new(Arc::new(node_service));
+    let registration_service = registration_service(node_service);
 
     builder
         .with_service(node_grpc_service.into_grpc_server())
         .with_service(registration_service.clone().into_v1_grpc_server())
         .with_service(registration_service.into_v1_alpha_grpc_server())
+}
+
+fn registration_service(node_service: service::Service) -> RegistrationServer {
+    RegistrationServer::new(Arc::new(node_service))
 }
 
 async fn create_node_service<S>(builder: &Service<S>) -> service::Service {

--- a/control-plane/agents/src/bin/core/node/service.rs
+++ b/control-plane/agents/src/bin/core/node/service.rs
@@ -216,7 +216,10 @@ impl Service {
                         api_versions: None,
                         instance_uuid: None,
                         node_nqn: node.node_nqn().clone(),
-                        features: None,
+                        // Carry the persisted features so the gRPC transport (http/https) for the
+                        // initial liveness probe matches what the io-engine last advertised. The
+                        // features are refreshed from the probe result immediately afterwards.
+                        features: node.features().clone(),
                         bugfixes: None,
                         version: None,
                     },

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -269,6 +269,20 @@ impl NodeWrapper {
         }
     }
 
+    /// Whether the io-engine advertises gRPC TLS support in its registration.
+    /// Simulated nodes never use TLS. Defaults to plaintext when the capability is not advertised,
+    /// which preserves compatibility with older io-engines and rolling upgrades.
+    fn node_grpc_tls(&self) -> bool {
+        if self.sim_socket.is_some() {
+            return false;
+        }
+        self.node_state()
+            .features
+            .as_ref()
+            .and_then(|features| features.grpc_tls)
+            .unwrap_or(false)
+    }
+
     /// Get `GrpcContext` for this node.
     /// It will be used to execute the `request` operation.
     pub(crate) fn grpc_context_ext(&self, request: MessageId) -> Result<GrpcContext, SvcError> {
@@ -281,6 +295,7 @@ impl NodeWrapper {
                 Some(request),
                 api_version,
                 self.sim_socket.is_some(),
+                self.node_grpc_tls(),
             )?)
         } else {
             Err(SvcError::InvalidApiVersion { api_version: None })
@@ -301,6 +316,7 @@ impl NodeWrapper {
                 None,
                 api_version,
                 self.sim_socket.is_some(),
+                self.node_grpc_tls(),
             )?)
         } else {
             Err(SvcError::InvalidApiVersion { api_version: None })
@@ -318,6 +334,7 @@ impl NodeWrapper {
                 None,
                 api_version,
                 self.sim_socket.is_some(),
+                self.node_grpc_tls(),
             )?)
         } else {
             Err(SvcError::InvalidApiVersion { api_version: None })

--- a/control-plane/agents/src/bin/core/tests/deserializer.rs
+++ b/control-plane/agents/src/bin/core/tests/deserializer.rs
@@ -233,6 +233,7 @@ fn test_deserialization_v1_to_v2() {
                     rdma_capable_io_engine: Some(true),
                     diskpool_encryption: None,
                     nexus_label_version: NexusVersion::V1,
+                    grpc_tls: None,
                 }),
                 None,
                 None,

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -338,6 +338,7 @@ async fn snapshot_timeout() {
         .with_reconcile_period(Duration::from_secs(10), Duration::from_secs(10))
         .with_req_timeouts(req_timeout, req_timeout)
         .with_grpc_timeouts(grpc_timeout_opts(grpc_timeout))
+        .with_grpc_tls(false)
         .build()
         .await
         .unwrap();

--- a/control-plane/agents/src/bin/core/tests/watch/mod.rs
+++ b/control-plane/agents/src/bin/core/tests/watch/mod.rs
@@ -12,7 +12,7 @@ use stor_port::{
     },
 };
 use tokio::net::{TcpListener, TcpStream};
-use tonic::body::BoxBody;
+use tonic::body::Body;
 
 static CALLBACK: OnceCell<tokio::sync::mpsc::Sender<()>> = OnceCell::new();
 
@@ -33,9 +33,9 @@ async fn setup_watch(client: &dyn VolumeOperations) -> (Volume, tokio::sync::mps
     let (s, r) = tokio::sync::mpsc::channel(1);
     CALLBACK.set(s).unwrap();
 
-    async fn notify(_req: Request<hyper::body::Incoming>) -> Result<Response<BoxBody>, Infallible> {
+    async fn notify(_req: Request<hyper::body::Incoming>) -> Result<Response<Body>, Infallible> {
         CALLBACK.get().cloned().unwrap().send(()).await.unwrap();
-        Ok(Response::new(BoxBody::default()))
+        Ok(Response::new(Body::default()))
     }
 
     let addr = SocketAddr::from(([10, 1, 0, 1], 8082));

--- a/control-plane/agents/src/bin/ha/cluster/main.rs
+++ b/control-plane/agents/src/bin/ha/cluster/main.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use grpc::client::CoreClient;
 use http::Uri;
 use once_cell::sync::OnceCell;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 use tracing::info;
 use utils::{
     package_description,
@@ -34,6 +34,19 @@ struct Cli {
     /// Core gRPC server URL or address.
     #[clap(long, short, default_value = DEFAULT_GRPC_CLIENT_ADDR)]
     core_grpc: Uri,
+    /// Path to the CA bundle used to verify Core and HA Node Agent gRPC servers and authenticate
+    /// HA Cluster Agent gRPC clients.
+    #[clap(long = "grpc-tls-ca-file")]
+    grpc_tls_ca_file: Option<PathBuf>,
+    /// Path to the TLS certificate used by the HA Cluster Agent gRPC server and client.
+    #[clap(long = "grpc-tls-cert-file", requires = "grpc_tls_key_file")]
+    grpc_tls_cert_file: Option<PathBuf>,
+    /// Path to the TLS private key used by the HA Cluster Agent gRPC server and client.
+    #[clap(long = "grpc-tls-key-file", requires = "grpc_tls_cert_file")]
+    grpc_tls_key_file: Option<PathBuf>,
+    /// Auto-generate an ephemeral self-signed certificate for the HA Cluster Agent gRPC server.
+    #[clap(long = "grpc-auto-tls", conflicts_with_all = ["grpc_tls_ca_file", "grpc_tls_cert_file", "grpc_tls_key_file"])]
+    grpc_auto_tls: bool,
 
     /// Sends opentelemetry spans to the Jaeger endpoint agent.
     #[clap(long, short)]
@@ -68,16 +81,41 @@ impl Cli {
     fn args() -> Self {
         Cli::parse()
     }
+
+    fn grpc_tls(&self) -> anyhow::Result<Option<grpc::tls::TlsConfig>> {
+        if self.grpc_tls_ca_file.is_some() && self.grpc_tls_cert_file.is_none() {
+            anyhow::bail!(
+                "a TLS-enabled HA Cluster Agent requires both gRPC TLS certificate and private key files"
+            );
+        }
+        let tls = grpc::tls::TlsConfig::new(
+            self.grpc_tls_ca_file.clone(),
+            self.grpc_tls_cert_file.clone(),
+            self.grpc_tls_key_file.clone(),
+        )?;
+        Ok(tls.enabled().then_some(tls))
+    }
 }
 
 /// Once cell static variable to store the grpc client and initialize once at startup.
 pub static CORE_CLIENT: OnceCell<CoreClient> = OnceCell::new();
+pub static GRPC_TLS: OnceCell<Option<grpc::tls::TlsConfig>> = OnceCell::new();
+pub static GRPC_AUTO_TLS: OnceCell<bool> = OnceCell::new();
 
 /// Get Core gRPC Client
 pub(crate) fn core_grpc<'a>() -> &'a CoreClient {
     CORE_CLIENT
         .get()
         .expect("gRPC Core Client should have been initialised")
+}
+
+pub(crate) fn grpc_tls() -> Option<grpc::tls::TlsConfig> {
+    GRPC_TLS.get().cloned().flatten()
+}
+
+/// Whether the HA Node Agent gRPC servers are dialled over TLS (file-backed or auto-TLS).
+pub(crate) fn grpc_tls_enabled() -> bool {
+    grpc_tls().is_some() || GRPC_AUTO_TLS.get().copied().unwrap_or(false)
 }
 
 fn initialize_tracing(args: &Cli) {
@@ -93,15 +131,30 @@ fn initialize_tracing(args: &Cli) {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    utils::init_rustls_crypto_provider();
     utils::print_package_info!();
     let cli = Cli::args();
     println!("Using options: {cli:?}");
     initialize_tracing(&cli);
 
-    // Initialise the core client to be used in rest
+    let grpc_tls = cli.grpc_tls()?;
+    let grpc_auto_tls = cli.grpc_auto_tls;
+    if grpc_tls.is_some() && cli.core_grpc.scheme_str() != Some("https") {
+        anyhow::bail!("a TLS-enabled Core gRPC client requires an https:// URL");
+    }
+    let core_client = match grpc_tls.clone() {
+        Some(tls) => CoreClient::new_with_tls(cli.core_grpc.clone(), None, tls).await?,
+        None => CoreClient::new(cli.core_grpc.clone(), None).await,
+    };
     CORE_CLIENT
-        .set(CoreClient::new(cli.core_grpc, None).await)
+        .set(core_client)
         .ok()
+        .expect("Expect to be initialised only once");
+    GRPC_TLS
+        .set(grpc_tls.clone())
+        .expect("Expect to be initialised only once");
+    GRPC_AUTO_TLS
+        .set(grpc_auto_tls)
         .expect("Expect to be initialised only once");
 
     let store = etcd::EtcdStore::new(cli.store, cli.store_timeout.into()).await?;
@@ -114,9 +167,10 @@ async fn main() -> anyhow::Result<()> {
     mover.send_switchover_req(entries).await?;
 
     info!("Starting cluster-agent server");
-    let result = server::ClusterAgent::new(cli.grpc_endpoint, node_list, mover)
-        .run()
-        .await;
+    let result =
+        server::ClusterAgent::new(cli.grpc_endpoint, grpc_tls, grpc_auto_tls, node_list, mover)
+            .run()
+            .await;
     utils::tracing_telemetry::flush_traces();
     result?;
 

--- a/control-plane/agents/src/bin/ha/cluster/server.rs
+++ b/control-plane/agents/src/bin/ha/cluster/server.rs
@@ -15,15 +15,25 @@ use stor_port::{
 /// High-level object that represents HA Cluster agent gRPC server.
 pub(crate) struct ClusterAgent {
     endpoint: SocketAddr,
+    tls: Option<grpc::tls::TlsConfig>,
+    auto_tls: bool,
     nodes: NodeList,
     mover: VolumeMover,
 }
 
 impl ClusterAgent {
     /// Returns a new `Self` with the given parameters.
-    pub(crate) fn new(endpoint: SocketAddr, nodes: NodeList, mover: VolumeMover) -> Self {
+    pub(crate) fn new(
+        endpoint: SocketAddr,
+        tls: Option<grpc::tls::TlsConfig>,
+        auto_tls: bool,
+        nodes: NodeList,
+        mover: VolumeMover,
+    ) -> Self {
         ClusterAgent {
             endpoint,
+            tls,
+            auto_tls,
             nodes,
             mover,
         }
@@ -34,10 +44,13 @@ impl ClusterAgent {
             nodes: self.nodes,
             mover: self.mover,
         }));
-        agents::Service::builder()
-            .with_service(r.into_grpc_server())
-            .run_err(self.endpoint)
-            .await
+        let service = agents::Service::builder().with_service(r.into_grpc_server());
+        match (self.auto_tls, self.tls) {
+            (true, None) => service.run_auto_tls_err(self.endpoint, false).await,
+            (true, Some(_)) => unreachable!("clap prevents combining gRPC TLS files and auto TLS"),
+            (false, Some(tls)) => service.run_tls_err(self.endpoint, tls, false).await,
+            (false, None) => service.run_err(self.endpoint).await,
+        }
     }
 }
 

--- a/control-plane/agents/src/bin/ha/cluster/switchover.rs
+++ b/control-plane/agents/src/bin/ha/cluster/switchover.rs
@@ -178,7 +178,11 @@ impl SwitchOverRequest {
 
     fn node_uri(&self) -> Result<Uri, http::Error> {
         Uri::builder()
-            .scheme("http")
+            .scheme(if crate::grpc_tls_enabled() {
+                "https"
+            } else {
+                "http"
+            })
             .authority(self.callback_uri.to_string())
             .path_and_query("")
             .build()
@@ -266,7 +270,17 @@ impl SwitchOverRequest {
             return;
         };
         if let Some(new_path) = self.new_path.clone() {
-            let node_client = NodeAgentClient::new(uri, None).await;
+            let node_client = match crate::grpc_tls() {
+                Some(tls) => NodeAgentClient::new_with_tls(uri, None, tls).await,
+                None => Ok(NodeAgentClient::new(uri, None).await),
+            };
+            let node_client = match node_client {
+                Ok(client) => client,
+                Err(error) => {
+                    tracing::error!(%error, "Failed to create HA Node Agent client");
+                    return;
+                }
+            };
             let request = GetController::new(new_path);
             if let Err(error) = match node_client.get_nvme_controller(&request, None).await {
                 Ok(target_addresses) => {
@@ -426,7 +440,10 @@ impl SwitchOverRequest {
             new_path,
             self.publish_context.clone(),
         );
-        let client = NodeAgentClient::new(uri, None).await;
+        let client = match crate::grpc_tls() {
+            Some(tls) => NodeAgentClient::new_with_tls(uri, None, tls).await?,
+            None => NodeAgentClient::new(uri, None).await,
+        };
         match client.replace_path(&replace_request, None).await {
             Ok(_) => Ok(()),
             Err(error) if error.kind == ReplyErrorKind::FailedPrecondition => {

--- a/control-plane/agents/src/bin/ha/node/main.rs
+++ b/control-plane/agents/src/bin/ha/node/main.rs
@@ -39,6 +39,16 @@ struct Cli {
     /// HA Cluster Agent URL or address to connect to the services.
     #[clap(long, short, default_value = DEFAULT_CLUSTER_AGENT_CLIENT_ADDR)]
     cluster_agent: Uri,
+    /// Path to the CA bundle used to verify the HA Cluster Agent and authenticate HA Node Agent
+    /// gRPC clients.
+    #[clap(long = "grpc-tls-ca-file")]
+    grpc_tls_ca_file: Option<std::path::PathBuf>,
+    /// Path to the TLS certificate used by the HA Node Agent gRPC server and client.
+    #[clap(long = "grpc-tls-cert-file", requires = "grpc_tls_key_file")]
+    grpc_tls_cert_file: Option<std::path::PathBuf>,
+    /// Path to the TLS private key used by the HA Node Agent gRPC server and client.
+    #[clap(long = "grpc-tls-key-file", requires = "grpc_tls_cert_file")]
+    grpc_tls_key_file: Option<std::path::PathBuf>,
 
     /// Node name(spec.nodeName). This must be the same as provided in csi-node.
     #[clap(short, long)]
@@ -53,6 +63,9 @@ struct Cli {
 
     #[clap(long, default_value_t = DEFAULT_NODE_AGENT_SERVER_PORT)]
     grpc_port: u16,
+    /// Auto-generate an ephemeral self-signed certificate for the HA Node Agent gRPC server.
+    #[clap(long = "grpc-auto-tls", conflicts_with_all = ["grpc_tls_ca_file", "grpc_tls_cert_file", "grpc_tls_key_file"])]
+    grpc_auto_tls: bool,
 
     /// Reports this endpoint.
     #[clap(long)]
@@ -151,13 +164,34 @@ impl Cli {
             std::net::SocketAddr::new(self.grpc_ip, self.grpc_port)
         }
     }
+
+    fn grpc_tls(&self) -> anyhow::Result<Option<grpc::tls::TlsConfig>> {
+        if self.grpc_tls_ca_file.is_some() && self.grpc_tls_cert_file.is_none() {
+            anyhow::bail!(
+                "a TLS-enabled HA Node Agent requires both gRPC TLS certificate and private key files"
+            );
+        }
+        let tls = grpc::tls::TlsConfig::new(
+            self.grpc_tls_ca_file.clone(),
+            self.grpc_tls_cert_file.clone(),
+            self.grpc_tls_key_file.clone(),
+        )?;
+        if !tls.enabled() {
+            return Ok(None);
+        }
+        if self.cluster_agent.scheme_str() != Some("https") {
+            anyhow::bail!("a TLS-enabled HA Cluster Agent client requires an https:// URL");
+        }
+        Ok(Some(tls))
+    }
 }
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    utils::init_rustls_crypto_provider();
     let cli_args = Cli::args();
-
     utils::print_package_info!();
+    println!("Using options: {cli_args:?}");
 
     utils::tracing_telemetry::TracingTelemetry::builder()
         .with_writer(FmtLayer::Stdout)
@@ -168,8 +202,14 @@ async fn main() -> anyhow::Result<()> {
         .with_tracing_tags(cli_args.tracing_tags.clone())
         .init("agent-ha-node");
 
+    let client = match cli_args.grpc_tls()? {
+        Some(tls) => {
+            ClusterAgentClient::new_with_tls(cli_args.cluster_agent.clone(), None, tls).await?
+        }
+        None => ClusterAgentClient::new(cli_args.cluster_agent.clone(), None).await,
+    };
     CLUSTER_AGENT_CLIENT
-        .set(ClusterAgentClient::new(cli_args.cluster_agent.clone(), None).await)
+        .set(client)
         .ok()
         .expect("Expect to be initialized only once");
 

--- a/control-plane/agents/src/bin/ha/node/server.rs
+++ b/control-plane/agents/src/bin/ha/node/server.rs
@@ -35,6 +35,8 @@ const HA_AGENT_ERR_SOURCE: &str = "HA Node agent gRPC server";
 /// High-level object that represents HA Node agent gRPC server.
 pub(crate) struct NodeAgentApiServer {
     endpoint: SocketAddr,
+    tls: Option<grpc::tls::TlsConfig>,
+    auto_tls: bool,
     path_cache: NvmePathCache,
     path_connection_timeout: Duration,
     subsys_refresh_period: Duration,
@@ -45,6 +47,10 @@ impl NodeAgentApiServer {
     pub(crate) fn new(args: &Cli, path_cache: NvmePathCache) -> Self {
         Self {
             endpoint: args.grpc_endpoint(),
+            tls: args
+                .grpc_tls()
+                .expect("invalid HA Node Agent gRPC TLS configuration"),
+            auto_tls: args.grpc_auto_tls,
             path_cache,
             path_connection_timeout: *args.path_connection_timeout,
             subsys_refresh_period: *args.subsys_refresh_period,
@@ -64,10 +70,13 @@ impl NodeAgentApiServer {
             subsys_refresh_period=?self.subsys_refresh_period,
             "Starting gRPC server"
         );
-        agents::Service::builder()
-            .with_service(r.into_grpc_server())
-            .run_err(self.endpoint)
-            .await
+        let service = agents::Service::builder().with_service(r.into_grpc_server());
+        match (self.auto_tls, self.tls.clone()) {
+            (true, None) => service.run_auto_tls_err(self.endpoint, false).await,
+            (true, Some(_)) => unreachable!("clap prevents combining gRPC TLS files and auto TLS"),
+            (false, Some(tls)) => service.run_tls_err(self.endpoint, tls, false).await,
+            (false, None) => service.run_err(self.endpoint).await,
+        }
     }
 }
 

--- a/control-plane/agents/src/bin/jsongrpc/main.rs
+++ b/control-plane/agents/src/bin/jsongrpc/main.rs
@@ -1,7 +1,7 @@
 mod service;
 
 use crate::service::JsonGrpcSvc;
-use agents::{Service, ServiceError};
+use agents::Service;
 use clap::Parser;
 use grpc::{client::CoreClient, operations::jsongrpc::server::JsonGrpcServer};
 use http::Uri;
@@ -20,14 +20,44 @@ struct CliArgs {
     /// The CORE gRPC client URL or address to connect to the core services.
     #[clap(long, short = 'z', default_value = DEFAULT_GRPC_CLIENT_ADDR)]
     core_grpc: Uri,
+
+    /// Path to the TLS server certificate chain for the JsonGrpc gRPC server.
+    #[clap(long = "grpc-tls-cert-file", requires = "grpc_tls_key_file")]
+    grpc_tls_cert_file: Option<std::path::PathBuf>,
+    /// Path to the TLS server private key for the JsonGrpc gRPC server.
+    #[clap(long = "grpc-tls-key-file", requires = "grpc_tls_cert_file")]
+    grpc_tls_key_file: Option<std::path::PathBuf>,
+    /// Path to the CA bundle used to authenticate JsonGrpc gRPC clients.
+    #[clap(long = "grpc-tls-ca-file")]
+    grpc_tls_ca_file: Option<std::path::PathBuf>,
+    /// Auto-generate an ephemeral self-signed certificate for the JsonGrpc gRPC server.
+    #[clap(long = "grpc-auto-tls", conflicts_with_all = ["grpc_tls_cert_file", "grpc_tls_key_file", "grpc_tls_ca_file"])]
+    grpc_auto_tls: bool,
+}
+
+impl CliArgs {
+    fn grpc_tls(&self) -> anyhow::Result<Option<grpc::tls::TlsConfig>> {
+        match (&self.grpc_tls_cert_file, &self.grpc_tls_key_file) {
+            (None, None) => Ok(None),
+            (Some(certificate), Some(private_key)) => grpc::tls::TlsConfig::new(
+                self.grpc_tls_ca_file.clone(),
+                Some(certificate.clone()),
+                Some(private_key.clone()),
+            )
+            .map(Some),
+            _ => unreachable!("clap requires the gRPC TLS certificate and private key together"),
+        }
+    }
 }
 
 pub(crate) static CORE_CLIENT: OnceCell<CoreClient> = OnceCell::new();
 
 #[tokio::main]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
+    utils::init_rustls_crypto_provider();
     let cli_args = CliArgs::parse();
     utils::print_package_info!();
+    utils::tracing_telemetry::TracingTelemetry::builder().init("agent-jsongrpc");
     info!("Using options: {:?}", &cli_args);
 
     let grpc_addr = &cli_args.core_grpc;
@@ -37,27 +67,32 @@ async fn main() {
         .ok()
         .expect("Expect to be initialised only once");
 
-    server(cli_args).await;
+    server(cli_args).await
 }
 
-async fn server(cli_args: CliArgs) {
+async fn server(cli_args: CliArgs) -> anyhow::Result<()> {
     let grpc_addr = cli_args.json_grpc_server_addr;
+    let tls = cli_args.grpc_tls()?;
     let json_grpc_service = JsonGrpcServer::new(Arc::new(JsonGrpcSvc::new())).into_grpc_server();
 
-    let tonic_router = tonic::transport::Server::builder().add_service(json_grpc_service);
+    let service = Service::builder().with_service(json_grpc_service);
 
     let tonic_thread = tokio::spawn(async move {
-        tonic_router
-            .serve_with_shutdown(grpc_addr, Service::shutdown_signal())
-            .await
-            .map_err(|source| ServiceError::GrpcServer { source })
+        match (cli_args.grpc_auto_tls, tls) {
+            (true, None) => service.run_auto_tls_err(grpc_addr, false).await,
+            (true, Some(_)) => {
+                unreachable!("clap prevents combining gRPC TLS files and auto TLS")
+            }
+            (false, Some(tls)) => service.run_tls_err(grpc_addr, tls, false).await,
+            (false, None) => service.run_err(grpc_addr).await,
+        }
     });
 
-    match tonic_thread.await {
-        Err(error) => error!("Failed to wait for thread: {:?}", error),
-        Ok(Err(error)) => {
-            error!(error=?error, "Error running service thread");
-        }
+    let result = tonic_thread.await;
+    match &result {
+        Err(error) => error!("Failed to wait for thread: {error:?}"),
+        Ok(Err(error)) => error!(?error, "Error running service thread"),
         _ => {}
     }
+    Ok(result??)
 }

--- a/control-plane/agents/src/lib.rs
+++ b/control-plane/agents/src/lib.rs
@@ -24,6 +24,8 @@ pub use common::errors;
 pub enum ServiceError {
     #[snafu(display("GrpcServer error"))]
     GrpcServer { source: tonic::transport::Error },
+    #[snafu(display("Grpc TLS error"))]
+    GrpcTls { source: anyhow::Error },
 }
 
 type LayerStack = tower::layer::util::Stack<OpenTelServer, tower::layer::util::Identity>;
@@ -107,6 +109,52 @@ impl Service {
     pub async fn run_err(self, socket: SocketAddr) -> Result<(), ServiceError> {
         self.tonic_server
             .serve_with_shutdown(socket, Self::shutdown_signal())
+            .await
+            .map_err(|source| ServiceError::GrpcServer { source })
+    }
+
+    /// Runs the server over TLS, reloading certificate material for new connections after it
+    /// changes on disk.
+    ///
+    /// When `sniff` is set the listener also accepts plaintext clients on the same port, which is
+    /// only required by a server at a mixed-version boundary (e.g. core accepting registrations
+    /// from both plaintext and TLS io-engines during a rolling upgrade).
+    pub async fn run_tls_err(
+        self,
+        socket: SocketAddr,
+        tls: grpc::tls::TlsConfig,
+        sniff: bool,
+    ) -> Result<(), ServiceError> {
+        let incoming = grpc::tls::incoming(socket, tls, sniff)
+            .await
+            .map_err(|source| ServiceError::GrpcTls { source })?;
+        self.tonic_server
+            .serve_with_incoming_shutdown(incoming, Self::shutdown_signal())
+            .await
+            .map_err(|source| ServiceError::GrpcServer { source })
+    }
+
+    /// Runs the server with an ephemeral self-signed TLS certificate.
+    ///
+    /// The generated material is in-memory only and therefore is neither reloadable nor suitable
+    /// for mutual TLS authentication.
+    ///
+    /// When `sniff` is set the listener also accepts plaintext clients on the same port, which is
+    /// only required by a server at a mixed-version boundary (e.g. core accepting registrations
+    /// from both plaintext and TLS io-engines during a rolling upgrade).
+    pub async fn run_auto_tls_err(
+        self,
+        socket: SocketAddr,
+        sniff: bool,
+    ) -> Result<(), ServiceError> {
+        tracing::info!("Running gRPC server with ephemeral self-signed TLS certificate");
+        let config = grpc::tls::auto_server_config(vec!["localhost".to_string()])
+            .map_err(|source| ServiceError::GrpcTls { source })?;
+        let incoming = grpc::tls::incoming_with_server_config(socket, config, sniff)
+            .await
+            .map_err(|source| ServiceError::GrpcTls { source })?;
+        self.tonic_server
+            .serve_with_incoming_shutdown(incoming, Self::shutdown_signal())
             .await
             .map_err(|source| ServiceError::GrpcServer { source })
     }

--- a/control-plane/agents/src/lib.rs
+++ b/control-plane/agents/src/lib.rs
@@ -44,12 +44,13 @@ impl ServiceEmpty {
     pub fn with_service<S>(mut self, svc: S) -> Service
     where
         S: tower::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
+                Response = http::Response<tonic::body::Body>,
                 Error = std::convert::Infallible,
             > + tonic::server::NamedService
             + Clone
             + Send
+            + Sync
             + 'static,
         S::Future: Send + 'static,
     {
@@ -79,12 +80,13 @@ impl Service {
     pub fn with_service<S>(self, svc: S) -> Self
     where
         S: tower::Service<
-                http::Request<tonic::body::BoxBody>,
-                Response = http::Response<tonic::body::BoxBody>,
+                http::Request<tonic::body::Body>,
+                Response = http::Response<tonic::body::Body>,
                 Error = std::convert::Infallible,
             > + tonic::server::NamedService
             + Clone
             + Send
+            + Sync
             + 'static,
         S::Future: Send + 'static,
     {

--- a/control-plane/csi-driver/src/bin/controller/config.rs
+++ b/control-plane/csi-driver/src/bin/controller/config.rs
@@ -25,6 +25,10 @@ pub(crate) struct CsiControllerConfig {
     client_key_path: Option<PathBuf>,
     /// Path to a file containing the JWT bearer token for REST authentication.
     jwt: Option<PathBuf>,
+    /// File-backed TLS configuration for node plugin gRPC connections.
+    grpc_tls: Option<grpc::tls::TlsConfig>,
+    /// Connect to node plugin gRPC servers over TLS without certificate verification.
+    grpc_auto_tls: bool,
 }
 
 impl CsiControllerConfig {
@@ -65,6 +69,14 @@ impl CsiControllerConfig {
         let client_key_path: Option<&PathBuf> = args.get_one::<PathBuf>("tls-key-file");
         let jwt = args.get_one::<PathBuf>("jwt").cloned();
 
+        let grpc_tls = grpc::tls::TlsConfig::new(
+            args.get_one::<PathBuf>("grpc-tls-ca-file").cloned(),
+            args.get_one::<PathBuf>("grpc-tls-cert-file").cloned(),
+            args.get_one::<PathBuf>("grpc-tls-key-file").cloned(),
+        )?;
+        let grpc_tls = grpc_tls.enabled().then_some(grpc_tls);
+        let grpc_auto_tls = args.get_flag("grpc-auto-tls");
+
         CONFIG.get_or_init(|| Self {
             rest_endpoint: rest_endpoint.into(),
             io_timeout: io_timeout.into(),
@@ -75,6 +87,8 @@ impl CsiControllerConfig {
             client_certificate_path: client_certificate_path.cloned(),
             client_key_path: client_key_path.cloned(),
             jwt,
+            grpc_tls,
+            grpc_auto_tls,
         });
         Ok(())
     }
@@ -128,5 +142,15 @@ impl CsiControllerConfig {
     /// Path to the file containing the JWT bearer token for REST authentication.
     pub(crate) fn jwt(&self) -> &Option<PathBuf> {
         &self.jwt
+    }
+
+    /// File-backed TLS configuration for node plugin gRPC connections.
+    pub(crate) fn grpc_tls(&self) -> Option<&grpc::tls::TlsConfig> {
+        self.grpc_tls.as_ref()
+    }
+
+    /// Connect to node plugin gRPC servers over TLS without certificate verification.
+    pub(crate) fn grpc_auto_tls(&self) -> bool {
+        self.grpc_auto_tls
     }
 }

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -147,13 +147,39 @@ fn tonic_endpoint(endpoint: String) -> Result<tonic::transport::Endpoint, Status
         .concurrency_limit(utils::DEFAULT_GRPC_CLIENT_CONCURRENCY))
 }
 
+/// Connect to a node plugin gRPC server at the given `host:port` endpoint, using TLS when the
+/// controller is so configured.
+async fn node_plugin_channel(endpoint: &str) -> Result<tonic::transport::Channel, Status> {
+    let config = CsiControllerConfig::get_config();
+    if config.grpc_auto_tls() {
+        // The auto-tls connector performs the TLS handshake itself, so the endpoint uses an
+        // http scheme to stop tonic from applying (and rejecting) its own TLS logic.
+        let endpoint = tonic_endpoint(format!("http://{endpoint}"))?;
+        grpc::tls::auto_tls_connect(&endpoint)
+            .await
+            .map_err(|error| Status::unavailable(error.to_string()))
+    } else if let Some(tls) = config.grpc_tls() {
+        let tls_config = tls
+            .client_config()
+            .map_err(|error| Status::internal(error.to_string()))?;
+        tonic_endpoint(format!("https://{endpoint}"))?
+            .tls_config(tls_config)
+            .map_err(|error| Status::internal(error.to_string()))?
+            .connect()
+            .await
+            .map_err(|error| Status::unavailable(error.to_string()))
+    } else {
+        tonic_endpoint(format!("http://{endpoint}"))?
+            .connect()
+            .await
+            .map_err(|error| Status::unavailable(error.to_string()))
+    }
+}
+
 #[tracing::instrument(err, skip_all)]
 async fn issue_fs_freeze(endpoint: String, volume_id: String) -> Result<(), Status> {
     trace!("Issuing fs freeze");
-    let channel = tonic_endpoint(format!("http://{endpoint}"))?
-        .connect()
-        .await
-        .map_err(|error| Status::unavailable(error.to_string()))?;
+    let channel = node_plugin_channel(&endpoint).await?;
     let mut client = NodePluginClient::new(channel);
 
     match client
@@ -174,10 +200,7 @@ async fn issue_fs_freeze(endpoint: String, volume_id: String) -> Result<(), Stat
 #[tracing::instrument(err, skip_all)]
 async fn issue_fs_unfreeze(endpoint: String, volume_id: String) -> Result<(), Status> {
     trace!("Issuing fs unfreeze");
-    let channel = tonic_endpoint(format!("http://{endpoint}"))?
-        .connect()
-        .await
-        .map_err(|error| Status::unavailable(error.to_string()))?;
+    let channel = node_plugin_channel(&endpoint).await?;
     let mut client = NodePluginClient::new(channel);
 
     match client
@@ -203,10 +226,7 @@ async fn force_unstage(app_node: AppNode, volume_id: String) -> Result<(), Statu
         app_node.id,
         app_node.spec.endpoint
     );
-    let channel = tonic_endpoint(format!("http://{}", app_node.spec.endpoint))?
-        .connect()
-        .await
-        .map_err(|error| Status::unavailable(error.to_string()))?;
+    let channel = node_plugin_channel(&app_node.spec.endpoint).await?;
     let mut client = NodePluginClient::new(channel);
 
     client

--- a/control-plane/csi-driver/src/bin/controller/main.rs
+++ b/control-plane/csi-driver/src/bin/controller/main.rs
@@ -157,6 +157,33 @@ async fn main() -> anyhow::Result<()> {
                 .value_parser(clap::value_parser!(std::path::PathBuf))
                 .help("path to a file containing the JWT bearer token for REST authentication")
         )
+        .arg(
+            Arg::new("grpc-tls-ca-file")
+                .long("grpc-tls-ca-file")
+                .value_parser(clap::value_parser!(std::path::PathBuf))
+                .help("path to the CA certificate file used to verify node plugin gRPC servers")
+        )
+        .arg(
+            Arg::new("grpc-tls-cert-file")
+                .long("grpc-tls-cert-file")
+                .requires("grpc-tls-key-file")
+                .value_parser(clap::value_parser!(std::path::PathBuf))
+                .help("path to the TLS client certificate file used for node plugin gRPC connections")
+        )
+        .arg(
+            Arg::new("grpc-tls-key-file")
+                .long("grpc-tls-key-file")
+                .requires("grpc-tls-cert-file")
+                .value_parser(clap::value_parser!(std::path::PathBuf))
+                .help("path to the TLS client private key file used for node plugin gRPC connections")
+        )
+        .arg(
+            Arg::new("grpc-auto-tls")
+                .long("grpc-auto-tls")
+                .action(clap::ArgAction::SetTrue)
+                .conflicts_with_all(["grpc-tls-ca-file", "grpc-tls-cert-file", "grpc-tls-key-file"])
+                .help("connect to node plugin gRPC servers over TLS without certificate verification")
+        )
         .get_matches();
 
     utils::print_package_info!();

--- a/control-plane/csi-driver/src/bin/node/main_.rs
+++ b/control-plane/csi-driver/src/bin/node/main_.rs
@@ -229,6 +229,33 @@ pub(super) async fn main() -> anyhow::Result<()> {
                 .value_parser(clap::value_parser!(PathBuf))
                 .help("path to a file containing the JWT bearer token for REST authentication")
         )
+        .arg(
+            Arg::new("grpc-tls-ca-file")
+                .long("grpc-tls-ca-file")
+                .value_parser(clap::value_parser!(PathBuf))
+                .help("path to the CA certificate file for the internal node plugin gRPC server")
+        )
+        .arg(
+            Arg::new("grpc-tls-cert-file")
+                .long("grpc-tls-cert-file")
+                .value_parser(clap::value_parser!(PathBuf))
+                .requires("grpc-tls-key-file")
+                .help("path to the TLS certificate file for the internal node plugin gRPC server")
+        )
+        .arg(
+            Arg::new("grpc-tls-key-file")
+                .long("grpc-tls-key-file")
+                .value_parser(clap::value_parser!(PathBuf))
+                .requires("grpc-tls-cert-file")
+                .help("path to the TLS private key file for the internal node plugin gRPC server")
+        )
+        .arg(
+            Arg::new("grpc-auto-tls")
+                .long("grpc-auto-tls")
+                .action(clap::ArgAction::SetTrue)
+                .conflicts_with_all(["grpc-tls-ca-file", "grpc-tls-cert-file", "grpc-tls-key-file"])
+                .help("run the internal node plugin gRPC server with an ephemeral self-signed TLS certificate")
+        )
         .subcommand(
             clap::Command::new("fs-freeze")
                 .arg(
@@ -457,12 +484,26 @@ pub(super) async fn main() -> anyhow::Result<()> {
 
     let kubelet_path = matches.get_one::<String>("kubelet-path").unwrap();
 
+    // The TLS configuration of the internal node plugin gRPC server.
+    let grpc_tls = grpc::tls::TlsConfig::new(
+        matches.get_one::<PathBuf>("grpc-tls-ca-file").cloned(),
+        matches.get_one::<PathBuf>("grpc-tls-cert-file").cloned(),
+        matches.get_one::<PathBuf>("grpc-tls-key-file").cloned(),
+    )?;
+    let grpc_tls = grpc_tls.enabled().then_some(grpc_tls);
+    let grpc_auto_tls = matches.get_flag("grpc-auto-tls");
+
     // Start the CSI server, node plugin grpc server and registration loop if registration is
     // enabled.
     *crate::config::config().nvme_as_mut() = TryFrom::try_from(&matches)?;
     let (csi, grpc, registration) = tokio::join!(
         CsiServer::run(csi_socket, &matches, &rest_config)?,
-        NodePluginGrpcServer::run(grpc_sock_addr, kubelet_path.to_owned()),
+        NodePluginGrpcServer::run(
+            grpc_sock_addr,
+            kubelet_path.to_owned(),
+            grpc_tls,
+            grpc_auto_tls
+        ),
         run_registration_loop(
             node_name.clone(),
             grpc_sock_addr.to_string(),

--- a/control-plane/csi-driver/src/bin/node/nodeplugin_grpc.rs
+++ b/control-plane/csi-driver/src/bin/node/nodeplugin_grpc.rs
@@ -155,19 +155,38 @@ impl NodePluginGrpcServer {
     pub(crate) async fn run(
         endpoint: std::net::SocketAddr,
         kubelet_path: String,
+        tls: Option<grpc::tls::TlsConfig>,
+        auto_tls: bool,
     ) -> anyhow::Result<()> {
         info!(
             "node plugin gRPC server configured at address {:?}",
             endpoint
         );
-        Server::builder()
-            .add_service(NodePluginServer::new(NodePluginSvc { kubelet_path }))
-            .serve_with_shutdown(endpoint, Shutdown::wait())
-            .await
-            .map_err(|error| {
-                use stor_port::transport_api::ErrorChain;
-                error!(error = error.full_string(), "NodePluginGrpcServer failed");
-                error.into()
-            })
+        let server =
+            Server::builder().add_service(NodePluginServer::new(NodePluginSvc { kubelet_path }));
+        let result = match (auto_tls, tls) {
+            (true, _) => {
+                let config = grpc::tls::auto_server_config(vec!["localhost".to_string()])?;
+                // Only the csi-controller connects here and it is always TLS-aware, so the
+                // listener does not need to sniff for plaintext clients.
+                let incoming =
+                    grpc::tls::incoming_with_server_config(endpoint, config, false).await?;
+                server
+                    .serve_with_incoming_shutdown(incoming, Shutdown::wait())
+                    .await
+            }
+            (false, Some(tls)) => {
+                let incoming = grpc::tls::incoming(endpoint, tls, false).await?;
+                server
+                    .serve_with_incoming_shutdown(incoming, Shutdown::wait())
+                    .await
+            }
+            (false, None) => server.serve_with_shutdown(endpoint, Shutdown::wait()).await,
+        };
+        result.map_err(|error| {
+            use stor_port::transport_api::ErrorChain;
+            error!(error = error.full_string(), "NodePluginGrpcServer failed");
+            error.into()
+        })
     }
 }

--- a/control-plane/csi-driver/src/bin/node/shutdown_event.rs
+++ b/control-plane/csi-driver/src/bin/node/shutdown_event.rs
@@ -104,11 +104,10 @@ mod tests {
             }
         });
         tokio::time::sleep(Duration::from_millis(250)).await;
-        let channel =
-            tonic::transport::Endpoint::from(Uri::from_str("https://[::]:50011").unwrap())
-                .connect()
-                .await
-                .unwrap();
+        let channel = tonic::transport::Endpoint::from(Uri::from_str("http://[::]:50011").unwrap())
+            .connect()
+            .await
+            .unwrap();
         let mut cli = NodePluginClient::new(channel);
 
         // 1. schedule the first request

--- a/control-plane/grpc/Cargo.toml
+++ b/control-plane/grpc/Cargo.toml
@@ -16,6 +16,15 @@ tonic-build = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
+anyhow = { workspace = true }
+http = { workspace = true }
+futures = { workspace = true }
+hyper-util = { workspace = true, features = ["tokio"] }
+rcgen = { workspace = true }
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
+tokio-rustls = { workspace = true }
+tokio-stream = { workspace = true, features = ["net"] }
 
 tokio = { workspace = true, features = ["full"] }
 stor-port = { workspace = true }
@@ -30,6 +39,7 @@ tracing = { workspace = true }
 tower = { workspace = true, features = ["timeout", "util"] }
 serde_json = { workspace = true }
 events-api = { workspace = true }
+cert-watcher = { workspace = true }
 
 [dev-dependencies]
 once_cell = { workspace = true }

--- a/control-plane/grpc/src/client.rs
+++ b/control-plane/grpc/src/client.rs
@@ -29,7 +29,7 @@ pub struct CoreClient {
 
 impl CoreClient {
     /// generates a new CoreClient to get the individual clients
-    pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
+    pub async fn new<O: Into<Option<TimeoutOptions>> + Clone>(addr: Uri, opts: O) -> Self {
         let timeout_opts = opts.into();
         let pool_client = PoolClient::new(addr.clone(), timeout_opts.clone()).await;
         let replica_client = ReplicaClient::new(addr.clone(), timeout_opts.clone()).await;
@@ -49,6 +49,41 @@ impl CoreClient {
             nexus: nexus_client,
             watch: watch_client,
         }
+    }
+
+    /// Generates a TLS-enabled CoreClient whose certificate files are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>> + Clone>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let timeout_opts = opts.into();
+        let pool =
+            PoolClient::new_with_tls(addr.clone(), timeout_opts.clone(), tls.clone()).await?;
+        let replica =
+            ReplicaClient::new_with_tls(addr.clone(), timeout_opts.clone(), tls.clone()).await?;
+        let volume =
+            VolumeClient::new_with_tls(addr.clone(), timeout_opts.clone(), tls.clone()).await?;
+        let node =
+            NodeClient::new_with_tls(addr.clone(), timeout_opts.clone(), tls.clone()).await?;
+        let app_node =
+            AppNodeClient::new_with_tls(addr.clone(), timeout_opts.clone(), tls.clone()).await?;
+        let registry =
+            RegistryClient::new_with_tls(addr.clone(), timeout_opts.clone(), tls.clone()).await?;
+        let nexus =
+            NexusClient::new_with_tls(addr.clone(), timeout_opts.clone(), tls.clone()).await?;
+        let watch = WatchClient::new_with_tls(addr, timeout_opts, tls).await?;
+
+        Ok(Self {
+            pool,
+            replica,
+            volume,
+            node,
+            app_node,
+            registry,
+            nexus,
+            watch,
+        })
     }
     /// retrieve the corresponding pool client
     pub fn pool(&self) -> impl PoolOperations {

--- a/control-plane/grpc/src/context.rs
+++ b/control-plane/grpc/src/context.rs
@@ -5,10 +5,7 @@ use stor_port::{
     transport_api::{ClientId, MessageId},
     types::v0::transport::MessageIdVs,
 };
-use tonic::{
-    transport::{Channel, Uri},
-    IntoRequest,
-};
+use tonic::{transport::Uri, IntoRequest};
 use utils::tracing_telemetry::trace::FutureExt;
 
 use utils::DEFAULT_REQ_TIMEOUT;
@@ -133,7 +130,14 @@ impl Context {
 
     /// Create a new endpoint that connects to the provided Uri.
     /// This endpoint has default connect and request timeouts.
-    fn endpoint(&self, uri: Uri) -> tonic::transport::Endpoint {
+    fn endpoint(&self, uri: Uri, auto_tls: bool) -> tonic::transport::Endpoint {
+        let uri = if auto_tls {
+            let mut parts = uri.into_parts();
+            parts.scheme = Some(http::uri::Scheme::HTTP);
+            Uri::from_parts(parts).expect("gRPC URI is valid")
+        } else {
+            uri
+        };
         let timeout = self.base_timeout();
         tonic::transport::Endpoint::from(uri)
             // we use the same timeout for the connection so we can pass the existing nats tests
@@ -158,8 +162,8 @@ impl Context {
     }
 }
 
-/// Tonic Channel with added gRPC tracing
-pub(crate) type TracedChannel = crate::tracing::OpenTelClientService<Channel>;
+/// Tonic Channel with added gRPC tracing and TLS certificate auto-reload.
+pub(crate) type TracedChannel = crate::tracing::OpenTelClientService<crate::tls::ReloadableChannel>;
 
 /// Generic RPC Client.
 #[derive(Clone)]
@@ -172,20 +176,35 @@ impl<C: Clone> Client<C> {
     /// Creates a generic RPC client based on the provided arguments.
     /// options: Timeout options which are used for connection and request timeouts.
     /// make_client: Creates a client of the appropriate type.
-    pub(crate) async fn new<O, M>(uri: Uri, options: O, make_client: M) -> Self
+    pub(crate) async fn new<O, M>(uri: Uri, options: O, make_client: M) -> anyhow::Result<Self>
+    where
+        O: Into<Option<TimeoutOptions>>,
+        M: FnOnce(TracedChannel) -> C,
+    {
+        Self::new_with_tls(uri, options, None, make_client).await
+    }
+
+    /// Creates a generic RPC client with optional file-backed TLS configuration.
+    pub(crate) async fn new_with_tls<O, M>(
+        uri: Uri,
+        options: O,
+        tls: Option<crate::tls::TlsConfig>,
+        make_client: M,
+    ) -> anyhow::Result<Self>
     where
         O: Into<Option<TimeoutOptions>>,
         M: FnOnce(TracedChannel) -> C,
     {
         let context = Context::new(options);
-        let endpoint = context.endpoint(uri);
-        let channel = endpoint.connect_lazy();
+        let auto_tls = tls.is_none() && uri.scheme_str() == Some("https");
+        let endpoint = context.endpoint(uri, auto_tls);
+        let channel = crate::tls::ReloadableChannel::new(endpoint, tls, auto_tls)?;
 
         let channel = tower::ServiceBuilder::new()
             .layer(OpenTelClient::new())
             .service(channel);
         let client = make_client(channel);
-        Self { context, client }
+        Ok(Self { context, client })
     }
 
     /// Prepares a new `tonic::Request<T>` for the given request `R: Into<T>`.

--- a/control-plane/grpc/src/lib.rs
+++ b/control-plane/grpc/src/lib.rs
@@ -3,6 +3,7 @@ pub mod context;
 pub mod misc;
 /// All server, client implementations and the traits.
 pub mod operations;
+pub mod tls;
 pub mod tracing;
 
 /// Common module for all the misc operations.

--- a/control-plane/grpc/src/operations/app_node/client.rs
+++ b/control-plane/grpc/src/operations/app_node/client.rs
@@ -26,12 +26,34 @@ pub struct AppNodeClient {
 impl AppNodeClient {
     /// Creates a new base tonic endpoint with the timeout options and the address.
     pub async fn new<O: Into<Option<TimeoutOptions>> + Clone>(addr: Uri, opts: O) -> Self {
-        let ops_client = Client::new(addr.clone(), opts.clone(), AppNodeGrpcClient::new).await;
-        let registration_client = Client::new(addr, opts, RegistrationClient::new).await;
+        let ops_client = Client::new(addr.clone(), opts.clone(), AppNodeGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
+        let registration_client = Client::new(addr, opts, RegistrationClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self {
             ops: ops_client,
             registration: registration_client,
         }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>> + Clone>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let ops = Client::new_with_tls(
+            addr.clone(),
+            opts.clone(),
+            Some(tls.clone()),
+            AppNodeGrpcClient::new,
+        )
+        .await?;
+        let registration =
+            Client::new_with_tls(addr, opts, Some(tls), RegistrationClient::new).await?;
+        Ok(Self { ops, registration })
     }
 }
 

--- a/control-plane/grpc/src/operations/ha_node/client.rs
+++ b/control-plane/grpc/src/operations/ha_node/client.rs
@@ -22,8 +22,20 @@ pub struct ClusterAgentClient {
 impl ClusterAgentClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, HaClusterRpcClient::new).await;
+        let client = Client::new(addr, opts, HaClusterRpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), HaClusterRpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 
@@ -82,8 +94,20 @@ pub struct NodeAgentClient {
 impl NodeAgentClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, HaNodeRpcClient::new).await;
+        let client = Client::new(addr, opts, HaNodeRpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), HaNodeRpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 

--- a/control-plane/grpc/src/operations/jsongrpc/client.rs
+++ b/control-plane/grpc/src/operations/jsongrpc/client.rs
@@ -20,7 +20,9 @@ pub struct JsonGrpcClient {
 impl JsonGrpcClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, json_grpc_client::JsonGrpcClient::new).await;
+        let client = Client::new(addr, opts, json_grpc_client::JsonGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
     }
     /// Try to wait until the JsonGrpc Service is ready, up to a timeout, by using the Probe method.

--- a/control-plane/grpc/src/operations/nexus/client.rs
+++ b/control-plane/grpc/src/operations/nexus/client.rs
@@ -34,8 +34,20 @@ impl Deref for NexusClient {
 impl NexusClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, NexusGrpcClient::new).await;
+        let client = Client::new(addr, opts, NexusGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), NexusGrpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 

--- a/control-plane/grpc/src/operations/node/client.rs
+++ b/control-plane/grpc/src/operations/node/client.rs
@@ -35,8 +35,20 @@ impl Deref for NodeClient {
 impl NodeClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, NodeGrpcClient::new).await;
+        let client = Client::new(addr, opts, NodeGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), NodeGrpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 

--- a/control-plane/grpc/src/operations/pool/client.rs
+++ b/control-plane/grpc/src/operations/pool/client.rs
@@ -35,8 +35,20 @@ impl Deref for PoolClient {
 impl PoolClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, PoolGrpcClient::new).await;
+        let client = Client::new(addr, opts, PoolGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), PoolGrpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 

--- a/control-plane/grpc/src/operations/pool/mod.rs
+++ b/control-plane/grpc/src/operations/pool/mod.rs
@@ -26,9 +26,25 @@ mod test {
     type CompleteSender = Arc<Mutex<Option<Sender<(bool, Instant)>>>>;
     static COMPLETE_CHAN: OnceCell<CompleteSender> = OnceCell::new();
 
+    /// Generate an ephemeral self-signed TLS config, shared by both the client and the server, so
+    /// the client presents (and the server verifies) the same certificate (mutual TLS).
+    fn self_signed_tls(san: String) -> (crate::tls::TlsConfig, std::path::PathBuf) {
+        let cert = rcgen::generate_simple_self_signed(vec![san]).unwrap();
+        let dir = std::env::temp_dir().join(format!("grpc-timeout-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let cert_path = dir.join("cert.pem");
+        let key_path = dir.join("key.pem");
+        std::fs::write(&cert_path, cert.cert.pem()).unwrap();
+        std::fs::write(&key_path, cert.key_pair.serialize_pem()).unwrap();
+        let tls =
+            crate::tls::TlsConfig::new(Some(cert_path.clone()), Some(cert_path), Some(key_path))
+                .unwrap();
+        (tls, dir)
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn timeout() {
-        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::from(0)), 50011);
+        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 50011);
         let uri = Uri::builder()
             .scheme("https")
             .path_and_query("")
@@ -36,11 +52,17 @@ mod test {
             .build()
             .unwrap();
 
+        let (tls, tls_dir) = self_signed_tls(socket_addr.ip().to_string());
+
+        let server_tls = tls.clone();
         tokio::spawn(async move {
             let service = PoolServer::new(Arc::new(server::Server {}));
+            let incoming = crate::tls::incoming(socket_addr, server_tls, false)
+                .await
+                .unwrap();
             tonic::transport::Server::builder()
                 .add_service(service.into_grpc_server())
-                .serve(socket_addr)
+                .serve_with_incoming(incoming)
                 .await
                 .unwrap();
         });
@@ -54,7 +76,9 @@ mod test {
         *channel.lock().unwrap() = Some(sender);
 
         let timeout_opts = TimeoutOptions::new().with_req_timeout(Duration::from_secs(10));
-        let client = PoolClient::new(uri, timeout_opts).await;
+        let client = PoolClient::new_with_tls(uri, timeout_opts, tls)
+            .await
+            .unwrap();
 
         let req_timeout = Duration::from_secs(1);
         let ctx = Context::new(TimeoutOptions::new().with_req_timeout(req_timeout));
@@ -66,6 +90,8 @@ mod test {
             complete,
             timestamp - before
         );
+        // remove the temporary TLS material before the assertions, which may panic
+        std::fs::remove_dir_all(&tls_dir).unwrap();
         // client should have timed out!
         assert!(result.is_err());
         // timeout within the req_timeout, with 200ms slack

--- a/control-plane/grpc/src/operations/registration/traits.rs
+++ b/control-plane/grpc/src/operations/registration/traits.rs
@@ -129,6 +129,7 @@ impl RegisterInfo for RegisterRequest {
                 // if it's greater, then assume it's the latest version we support, which is V2.
                 _ => NexusVersion::V2,
             },
+            grpc_tls: features.grpc_tls,
         })
     }
 

--- a/control-plane/grpc/src/operations/registry/client.rs
+++ b/control-plane/grpc/src/operations/registry/client.rs
@@ -25,8 +25,20 @@ impl Deref for RegistryClient {
 impl RegistryClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, RegistryGrpcClient::new).await;
+        let client = Client::new(addr, opts, RegistryGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), RegistryGrpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 /// Implement registry operations supported by the Registry RPC client.

--- a/control-plane/grpc/src/operations/replica/client.rs
+++ b/control-plane/grpc/src/operations/replica/client.rs
@@ -37,8 +37,20 @@ impl Deref for ReplicaClient {
 impl ReplicaClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, ReplicaGrpcClient::new).await;
+        let client = Client::new(addr, opts, ReplicaGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), ReplicaGrpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 

--- a/control-plane/grpc/src/operations/volume/client.rs
+++ b/control-plane/grpc/src/operations/volume/client.rs
@@ -40,8 +40,20 @@ pub struct VolumeClient {
 impl VolumeClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, VolumeGrpcClient::new).await;
+        let client = Client::new(addr, opts, VolumeGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), VolumeGrpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 

--- a/control-plane/grpc/src/operations/watch/client.rs
+++ b/control-plane/grpc/src/operations/watch/client.rs
@@ -27,8 +27,20 @@ impl Deref for WatchClient {
 impl WatchClient {
     /// creates a new base tonic endpoint with the timeout options and the address
     pub async fn new<O: Into<Option<TimeoutOptions>>>(addr: Uri, opts: O) -> Self {
-        let client = Client::new(addr, opts, WatchGrpcClient::new).await;
+        let client = Client::new(addr, opts, WatchGrpcClient::new)
+            .await
+            .expect("a plaintext gRPC channel cannot fail to initialise");
         Self { inner: client }
+    }
+
+    /// Creates a TLS-enabled client whose certificates are reloaded after rotation.
+    pub async fn new_with_tls<O: Into<Option<TimeoutOptions>>>(
+        addr: Uri,
+        opts: O,
+        tls: crate::tls::TlsConfig,
+    ) -> anyhow::Result<Self> {
+        let client = Client::new_with_tls(addr, opts, Some(tls), WatchGrpcClient::new).await?;
+        Ok(Self { inner: client })
     }
 }
 

--- a/control-plane/grpc/src/tls.rs
+++ b/control-plane/grpc/src/tls.rs
@@ -1,0 +1,678 @@
+//! File-backed TLS configuration for gRPC transports.
+
+use futures::StreamExt;
+use hyper_util::rt::TokioIo;
+use rcgen::generate_simple_self_signed;
+use std::{
+    future::Future,
+    io,
+    net::SocketAddr,
+    path::PathBuf,
+    pin::Pin,
+    sync::{Arc, PoisonError, RwLock},
+    task::{Context as TaskContext, Poll},
+};
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    net::TcpStream,
+};
+use tokio_rustls::{server::TlsStream, TlsAcceptor, TlsConnector};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{
+    body::Body,
+    transport::{Certificate, Channel, ClientTlsConfig, Endpoint, Identity, ServerTlsConfig},
+};
+use tower::{Service, ServiceExt};
+
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer,
+        _intermediates: &[rustls::pki_types::CertificateDer],
+        _server_name: &rustls::pki_types::ServerName,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        // this is expected in auto-tls mode, so don't spam the logs with warnings
+        // tracing::warn!("gRPC server certificate verification bypassed");
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _certificate: &rustls::pki_types::CertificateDer,
+        _signature: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _certificate: &rustls::pki_types::CertificateDer,
+        _signature: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        use rustls::SignatureScheme;
+
+        vec![
+            SignatureScheme::RSA_PKCS1_SHA1,
+            SignatureScheme::ECDSA_SHA1_Legacy,
+            SignatureScheme::RSA_PKCS1_SHA256,
+            SignatureScheme::ECDSA_NISTP256_SHA256,
+            SignatureScheme::RSA_PKCS1_SHA384,
+            SignatureScheme::ECDSA_NISTP384_SHA384,
+            SignatureScheme::RSA_PKCS1_SHA512,
+            SignatureScheme::ECDSA_NISTP521_SHA512,
+            SignatureScheme::RSA_PSS_SHA256,
+            SignatureScheme::RSA_PSS_SHA384,
+            SignatureScheme::RSA_PSS_SHA512,
+            SignatureScheme::ED25519,
+            SignatureScheme::ED448,
+        ]
+    }
+}
+
+fn auto_client_config() -> rustls::ClientConfig {
+    let mut config = rustls::ClientConfig::builder()
+        .with_root_certificates(rustls::RootCertStore::empty())
+        .with_no_client_auth();
+    config
+        .dangerous()
+        .set_certificate_verifier(Arc::new(NoCertificateVerification));
+    // gRPC uses HTTP/2 as its transport, so advertise h2 via ALPN for clarity even though tonic
+    // handles this with with `assume_http2` enabled.
+    config.alpn_protocols = vec![b"h2".to_vec()];
+    config
+}
+
+/// Establish a single TLS connection to the endpoint described by `uri`, bypassing certificate
+/// verification (auto-TLS). The returned stream is wrapped for use with hyper/tonic.
+async fn auto_tls_connect_io(
+    tls: TlsConnector,
+    uri: http::Uri,
+) -> io::Result<TokioIo<tokio_rustls::client::TlsStream<TcpStream>>> {
+    let host = uri
+        .host()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "gRPC endpoint has no host"))?;
+    let port = uri.port_u16().unwrap_or(443);
+    let stream = TcpStream::connect((host, port)).await?;
+    let server_name = rustls::pki_types::ServerName::try_from(host.to_string())
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error))?;
+    tls.connect(server_name, stream)
+        .await
+        .map(TokioIo::new)
+        .map_err(io::Error::other)
+}
+
+/// Eagerly establish an auto-TLS channel to `endpoint`, bypassing certificate verification.
+///
+/// This matches the REST client's `TlsMode::Auto` behaviour and is used to connect to io-engine
+/// instances that advertise gRPC TLS support in their registration.
+pub async fn auto_tls_connect(endpoint: &Endpoint) -> Result<Channel, tonic::transport::Error> {
+    let tls = TlsConnector::from(Arc::new(auto_client_config()));
+    let connector = tower::service_fn(move |uri: http::Uri| auto_tls_connect_io(tls.clone(), uri));
+    endpoint.connect_with_connector(connector).await
+}
+
+/// TLS certificate files used by a gRPC endpoint.
+///
+/// The files are intentionally retained rather than converted into certificate bytes so callers
+/// can rebuild a configuration after certificates are rotated on disk.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct TlsConfig {
+    ca_certificate: Option<PathBuf>,
+    certificate: Option<PathBuf>,
+    private_key: Option<PathBuf>,
+}
+
+impl TlsConfig {
+    /// Create a TLS configuration from optional CA and client/server identity files.
+    pub fn new(
+        ca_certificate: Option<PathBuf>,
+        certificate: Option<PathBuf>,
+        private_key: Option<PathBuf>,
+    ) -> anyhow::Result<Self> {
+        if certificate.is_some() != private_key.is_some() {
+            anyhow::bail!("both the TLS certificate and private key files must be specified");
+        }
+
+        Ok(Self {
+            ca_certificate,
+            certificate,
+            private_key,
+        })
+    }
+
+    /// Whether TLS has been enabled for this endpoint.
+    pub fn enabled(&self) -> bool {
+        self.ca_certificate.is_some() || self.certificate.is_some()
+    }
+
+    /// Certificate files that must be watched for automatic reload.
+    pub fn paths(&self) -> Vec<PathBuf> {
+        [
+            self.ca_certificate.clone(),
+            self.certificate.clone(),
+            self.private_key.clone(),
+        ]
+        .into_iter()
+        .flatten()
+        .collect()
+    }
+
+    /// Filesystem targets to watch for certificate rotation.
+    ///
+    /// Kubernetes projected secrets replace directory entries atomically, so watch their shared
+    /// parent directory when all TLS files live below it.
+    pub fn watch_targets(&self) -> Vec<PathBuf> {
+        cert_watcher::watch_targets(self.paths())
+    }
+
+    /// Build a fresh client TLS configuration from the current certificate file contents.
+    pub fn client_config(&self) -> anyhow::Result<ClientTlsConfig> {
+        let mut config = ClientTlsConfig::new();
+
+        if let Some(ca_certificate) = &self.ca_certificate {
+            config = config.ca_certificate(Certificate::from_pem(std::fs::read(ca_certificate)?));
+        }
+        if let (Some(certificate), Some(private_key)) = (&self.certificate, &self.private_key) {
+            config = config.identity(Identity::from_pem(
+                std::fs::read(certificate)?,
+                std::fs::read(private_key)?,
+            ));
+        }
+        Ok(config)
+    }
+
+    /// Build a fresh server TLS configuration from the current certificate file contents.
+    pub fn server_config(&self) -> anyhow::Result<ServerTlsConfig> {
+        let (Some(certificate), Some(private_key)) = (&self.certificate, &self.private_key) else {
+            anyhow::bail!("a TLS server requires both certificate and private key files");
+        };
+
+        let mut config = ServerTlsConfig::new().identity(Identity::from_pem(
+            std::fs::read(certificate)?,
+            std::fs::read(private_key)?,
+        ));
+        if let Some(ca_certificate) = &self.ca_certificate {
+            config = config.client_ca_root(Certificate::from_pem(std::fs::read(ca_certificate)?));
+        }
+
+        Ok(config)
+    }
+
+    fn fingerprint(&self) -> anyhow::Result<Vec<std::time::SystemTime>> {
+        Ok(cert_watcher::fingerprint(&self.paths())?)
+    }
+}
+
+/// A Tonic channel that is replaced when its file-backed TLS material changes.
+///
+/// Existing requests retain their current channel. Requests issued after a successful reload use
+/// a fresh lazy channel, and therefore negotiate TLS with the newly loaded certificates.
+#[derive(Clone)]
+pub struct ReloadableChannel {
+    current: Arc<RwLock<Channel>>,
+}
+
+struct ChannelState {
+    endpoint: Endpoint,
+    tls: TlsConfig,
+    fingerprint: Vec<std::time::SystemTime>,
+    current: Arc<RwLock<Channel>>,
+}
+
+impl ReloadableChannel {
+    /// Build a channel from an endpoint and optional file-backed TLS configuration.
+    pub fn new(endpoint: Endpoint, tls: Option<TlsConfig>, auto_tls: bool) -> anyhow::Result<Self> {
+        let tls = tls.filter(TlsConfig::enabled);
+        let current = Arc::new(RwLock::new(Self::connect_lazy(
+            &endpoint,
+            tls.as_ref(),
+            auto_tls,
+        )?));
+
+        if let Some(tls) = tls {
+            let targets = tls.watch_targets();
+            let paths = tls.paths();
+            let state = Arc::new(RwLock::new(ChannelState {
+                fingerprint: tls.fingerprint()?,
+                endpoint,
+                tls,
+                current: current.clone(),
+            }));
+            cert_watcher::spawn("grpc-tls-cert-watcher", targets, move || {
+                Self::reload_logged(&state, &paths)
+            });
+        }
+
+        Ok(Self { current })
+    }
+
+    fn connect_lazy(
+        endpoint: &Endpoint,
+        tls: Option<&TlsConfig>,
+        auto_tls: bool,
+    ) -> anyhow::Result<Channel> {
+        if auto_tls {
+            let tls = TlsConnector::from(Arc::new(auto_client_config()));
+            let connector =
+                tower::service_fn(move |uri: http::Uri| auto_tls_connect_io(tls.clone(), uri));
+            return Ok(endpoint.connect_with_connector_lazy(connector));
+        }
+
+        let endpoint = match tls {
+            Some(tls) => endpoint.clone().tls_config(tls.client_config()?)?,
+            None => endpoint.clone(),
+        };
+        Ok(endpoint.connect_lazy())
+    }
+
+    fn channel(&self) -> Channel {
+        self.current
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    fn reload(state: &Arc<RwLock<ChannelState>>) -> anyhow::Result<bool> {
+        let state_guard = state.read().unwrap_or_else(PoisonError::into_inner);
+        let fingerprint = state_guard.tls.fingerprint()?;
+        if fingerprint == state_guard.fingerprint {
+            return Ok(false);
+        }
+        let channel = Self::connect_lazy(&state_guard.endpoint, Some(&state_guard.tls), false)?;
+        *state_guard
+            .current
+            .write()
+            .unwrap_or_else(PoisonError::into_inner) = channel;
+        drop(state_guard);
+        state
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .fingerprint = fingerprint;
+        Ok(true)
+    }
+
+    fn reload_logged(state: &Arc<RwLock<ChannelState>>, paths: &[PathBuf]) {
+        match Self::reload(state) {
+            Ok(true) => tracing::info!(?paths, "Reloaded gRPC TLS certificates"),
+            Ok(false) => {}
+            Err(error) => tracing::warn!(?paths, %error, "Failed to reload gRPC TLS certificates"),
+        }
+    }
+}
+
+type ChannelRequest = http::Request<Body>;
+type ChannelFuture = Pin<
+    Box<
+        dyn Future<
+                Output = Result<
+                    <Channel as Service<ChannelRequest>>::Response,
+                    <Channel as Service<ChannelRequest>>::Error,
+                >,
+            > + Send,
+    >,
+>;
+
+impl Service<ChannelRequest> for ReloadableChannel {
+    type Response = <Channel as Service<ChannelRequest>>::Response;
+    type Error = <Channel as Service<ChannelRequest>>::Error;
+    type Future = ChannelFuture;
+
+    fn poll_ready(&mut self, _cx: &mut TaskContext<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: ChannelRequest) -> Self::Future {
+        let channel = self.channel();
+        Box::pin(async move { channel.oneshot(request).await })
+    }
+}
+
+/// The content type of a TLS handshake record, which is the first byte of every TLS `ClientHello`.
+const TLS_HANDSHAKE_RECORD: u8 = 0x16;
+
+/// A gRPC server connection accepted on a port that serves both plaintext and TLS.
+///
+/// The transport is chosen by peeking the first byte of the stream: a TLS `ClientHello` record
+/// always starts with `0x16`, whereas cleartext HTTP/2 (h2c) starts with the connection preface
+/// `PRI * HTTP/2.0` (i.e. `0x50`). This lets a single listener accept legacy plaintext clients and
+/// TLS clients at the same time, which is what allows a non-TLS to TLS rolling upgrade.
+pub enum MaybeTlsConnection {
+    /// A plaintext connection.
+    Plain(Pin<Box<TcpStream>>),
+    /// A TLS connection.
+    Tls(Pin<Box<TlsStream<TcpStream>>>),
+}
+
+impl AsyncRead for MaybeTlsConnection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            MaybeTlsConnection::Plain(stream) => stream.as_mut().poll_read(cx, buf),
+            MaybeTlsConnection::Tls(stream) => stream.as_mut().poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for MaybeTlsConnection {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut TaskContext<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            MaybeTlsConnection::Plain(stream) => stream.as_mut().poll_write(cx, buf),
+            MaybeTlsConnection::Tls(stream) => stream.as_mut().poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            MaybeTlsConnection::Plain(stream) => stream.as_mut().poll_flush(cx),
+            MaybeTlsConnection::Tls(stream) => stream.as_mut().poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            MaybeTlsConnection::Plain(stream) => stream.as_mut().poll_shutdown(cx),
+            MaybeTlsConnection::Tls(stream) => stream.as_mut().poll_shutdown(cx),
+        }
+    }
+}
+
+impl tonic::transport::server::Connected for MaybeTlsConnection {
+    type ConnectInfo = ();
+
+    fn connect_info(&self) -> Self::ConnectInfo {}
+}
+
+/// Sniff the first byte of an accepted connection and either complete a TLS handshake or use the
+/// connection as plaintext.
+///
+/// Any failure is mapped to a recoverable error kind so a single bad connection never tears down
+/// the listener.
+async fn sniff_and_accept(
+    connection: TcpStream,
+    acceptor: TlsAcceptor,
+) -> io::Result<MaybeTlsConnection> {
+    let mut first = [0u8; 1];
+    let peeked = connection
+        .peek(&mut first)
+        .await
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    if peeked == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "connection closed before any data was received",
+        ));
+    }
+
+    if first[0] == TLS_HANDSHAKE_RECORD {
+        acceptor
+            .accept(connection)
+            .await
+            .map(|stream| MaybeTlsConnection::Tls(Box::pin(stream)))
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    } else {
+        Ok(MaybeTlsConnection::Plain(Box::pin(connection)))
+    }
+}
+
+/// Complete a TLS handshake on an accepted connection, rejecting plaintext clients.
+///
+/// Unlike [`sniff_and_accept`], this never falls back to plaintext: it is used by servers that
+/// only ever speak to TLS clients and therefore do not need to accept a mixed-transport port.
+async fn accept_tls(
+    connection: TcpStream,
+    acceptor: TlsAcceptor,
+) -> io::Result<MaybeTlsConnection> {
+    acceptor
+        .accept(connection)
+        .await
+        .map(|stream| MaybeTlsConnection::Tls(Box::pin(stream)))
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+}
+
+#[derive(Clone)]
+struct ReloadableServerTls {
+    current: Arc<RwLock<Arc<rustls::ServerConfig>>>,
+}
+
+struct ServerState {
+    tls: TlsConfig,
+    fingerprint: Vec<std::time::SystemTime>,
+    current: Arc<RwLock<Arc<rustls::ServerConfig>>>,
+}
+
+impl ReloadableServerTls {
+    fn new(tls: TlsConfig) -> anyhow::Result<Self> {
+        let current = Arc::new(RwLock::new(Arc::new(build_rustls_server_config(&tls)?)));
+        let targets = tls.watch_targets();
+        let paths = tls.paths();
+        let state = Arc::new(RwLock::new(ServerState {
+            fingerprint: tls.fingerprint()?,
+            tls,
+            current: current.clone(),
+        }));
+        cert_watcher::spawn("grpc-tls-cert-watcher", targets, move || {
+            Self::reload_logged(&state, &paths)
+        });
+        Ok(Self { current })
+    }
+
+    fn acceptor(&self) -> TlsAcceptor {
+        TlsAcceptor::from(
+            self.current
+                .read()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone(),
+        )
+    }
+
+    fn reload(state: &Arc<RwLock<ServerState>>) -> anyhow::Result<bool> {
+        let state_guard = state.read().unwrap_or_else(PoisonError::into_inner);
+        let fingerprint = state_guard.tls.fingerprint()?;
+        if fingerprint == state_guard.fingerprint {
+            return Ok(false);
+        }
+        let config = Arc::new(build_rustls_server_config(&state_guard.tls)?);
+        *state_guard
+            .current
+            .write()
+            .unwrap_or_else(PoisonError::into_inner) = config;
+        drop(state_guard);
+        state
+            .write()
+            .unwrap_or_else(PoisonError::into_inner)
+            .fingerprint = fingerprint;
+        Ok(true)
+    }
+
+    fn reload_logged(state: &Arc<RwLock<ServerState>>, targets: &[PathBuf]) {
+        match Self::reload(state) {
+            Ok(true) => tracing::info!(?targets, "Reloaded gRPC TLS certificates"),
+            Ok(false) => {}
+            Err(error) => {
+                tracing::warn!(?targets, %error, "Failed to reload gRPC TLS certificates")
+            }
+        }
+    }
+}
+
+fn build_rustls_server_config(tls: &TlsConfig) -> anyhow::Result<rustls::ServerConfig> {
+    use rustls::{server::WebPkiClientVerifier, RootCertStore};
+    use std::{fs::File, io::BufReader};
+
+    let (Some(certificate), Some(private_key)) = (&tls.certificate, &tls.private_key) else {
+        anyhow::bail!("a TLS server requires both certificate and private key files");
+    };
+    let certificates = rustls_pemfile::certs(&mut BufReader::new(File::open(certificate)?))
+        .collect::<Result<Vec<_>, _>>()?;
+    let private_key = rustls_pemfile::private_key(&mut BufReader::new(File::open(private_key)?))?
+        .ok_or_else(|| anyhow::anyhow!("no private key found in the TLS key file"))?;
+
+    let builder = rustls::ServerConfig::builder();
+    let mut config = if let Some(ca_certificate) = &tls.ca_certificate {
+        let client_ca_certificates =
+            rustls_pemfile::certs(&mut BufReader::new(File::open(ca_certificate)?))
+                .collect::<Result<Vec<_>, _>>()?;
+        let mut roots = RootCertStore::empty();
+        let (valid, _) = roots.add_parsable_certificates(client_ca_certificates);
+        if valid == 0 {
+            anyhow::bail!("no valid certificates found in the TLS client CA file");
+        }
+        builder
+            .with_client_cert_verifier(WebPkiClientVerifier::builder(Arc::new(roots)).build()?)
+            .with_single_cert(certificates, private_key)?
+    } else {
+        builder
+            .with_no_client_auth()
+            .with_single_cert(certificates, private_key)?
+    };
+
+    // gRPC uses HTTP/2 as its transport, so advertise h2 via ALPN for clarity even though tonic
+    // handles this with with `assume_http2` enabled.
+    config.alpn_protocols = vec![b"h2".to_vec()];
+
+    Ok(config)
+}
+
+/// Maximum number of connections whose TLS sniff/handshake may be in progress at once.
+///
+/// This bounds the work performed off the accept path and provides backpressure: once this many
+/// handshakes are in flight, no further connections are accepted until one completes.
+const MAX_CONCURRENT_HANDSHAKES: usize = 256;
+
+/// Accept connections and perform the TLS handshake concurrently.
+///
+/// When `sniff` is set the listener also accepts plaintext connections by peeking the first byte
+/// (see [`MaybeTlsConnection`]); otherwise plaintext clients are rejected. Only a server sitting at
+/// a mixed-version boundary (a plaintext peer and a TLS peer during a rolling upgrade) needs
+/// sniffing; every other server speaks TLS to TLS-only clients.
+///
+/// [`StreamExt::then`] drives each sniff/handshake future to completion before accepting the next
+/// connection, so a single slow or stalled peer would block every other client on the listener.
+/// [`StreamExt::buffer_unordered`] instead keeps up to [`MAX_CONCURRENT_HANDSHAKES`] handshakes in
+/// flight at once and yields whichever completes first, so no connection is held up by another.
+fn accepted_incoming(
+    listener: tokio::net::TcpListener,
+    acceptor: impl Fn() -> TlsAcceptor + Send + 'static,
+    sniff: bool,
+) -> impl futures::Stream<Item = Result<MaybeTlsConnection, io::Error>> {
+    TcpListenerStream::new(listener)
+        .map(move |connection| {
+            let acceptor = acceptor();
+            async move {
+                match connection {
+                    Ok(connection) if sniff => sniff_and_accept(connection, acceptor).await,
+                    Ok(connection) => accept_tls(connection, acceptor).await,
+                    Err(error) => Err(error),
+                }
+            }
+        })
+        .buffer_unordered(MAX_CONCURRENT_HANDSHAKES)
+}
+
+/// Bind a TCP listener and accept gRPC connections using reloadable TLS material.
+///
+/// When `sniff` is set the listener serves both TLS and plaintext connections on the same port,
+/// choosing per connection by sniffing the first byte (see [`MaybeTlsConnection`]); otherwise only
+/// TLS clients are accepted.
+pub async fn incoming(
+    socket: SocketAddr,
+    tls: TlsConfig,
+    sniff: bool,
+) -> anyhow::Result<impl futures::Stream<Item = Result<MaybeTlsConnection, io::Error>>> {
+    let listener = tokio::net::TcpListener::bind(socket).await?;
+    let tls = ReloadableServerTls::new(tls)?;
+
+    Ok(accepted_incoming(listener, move || tls.acceptor(), sniff))
+}
+
+/// Generate an ephemeral self-signed server configuration for local or test gRPC listeners.
+///
+/// Because its certificate only exists in memory, this configuration cannot be reloaded and does
+/// not support client authentication.
+pub fn auto_server_config(
+    subject_alt_names: Vec<String>,
+) -> anyhow::Result<Arc<rustls::ServerConfig>> {
+    use rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+
+    let certificate_material = generate_simple_self_signed(subject_alt_names)
+        .map_err(|error| anyhow::anyhow!("Failed to generate self-signed certificate: {error}"))?;
+    let certificate = certificate_material.cert.der().clone();
+    let private_key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+        certificate_material.key_pair.serialize_der(),
+    ));
+
+    let mut config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![certificate], private_key)?;
+    // gRPC uses HTTP/2 as its transport, so advertise h2 via ALPN for clarity even though tonic
+    // handles this with with `assume_http2` enabled.
+    config.alpn_protocols = vec![b"h2".to_vec()];
+
+    Ok(Arc::new(config))
+}
+
+/// Bind a TCP listener with an in-memory TLS server configuration.
+///
+/// When `sniff` is set the listener serves both TLS and plaintext connections on the same port,
+/// choosing per connection by sniffing the first byte (see [`MaybeTlsConnection`]); otherwise only
+/// TLS clients are accepted.
+pub async fn incoming_with_server_config(
+    socket: SocketAddr,
+    config: Arc<rustls::ServerConfig>,
+    sniff: bool,
+) -> anyhow::Result<impl futures::Stream<Item = Result<MaybeTlsConnection, io::Error>>> {
+    let listener = tokio::net::TcpListener::bind(socket).await?;
+    let acceptor = TlsAcceptor::from(config);
+
+    Ok(accepted_incoming(listener, move || acceptor.clone(), sniff))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TlsConfig;
+    use std::path::PathBuf;
+
+    #[test]
+    fn rejects_incomplete_identity() {
+        assert!(TlsConfig::new(None, Some(PathBuf::from("client.pem")), None).is_err());
+        assert!(TlsConfig::new(None, None, Some(PathBuf::from("client.key"))).is_err());
+    }
+
+    #[test]
+    fn tracks_all_tls_files() {
+        let tls = TlsConfig::new(
+            Some(PathBuf::from("ca.pem")),
+            Some(PathBuf::from("client.pem")),
+            Some(PathBuf::from("client.key")),
+        )
+        .unwrap();
+
+        assert!(tls.enabled());
+        assert_eq!(
+            tls.paths(),
+            vec![
+                PathBuf::from("ca.pem"),
+                PathBuf::from("client.pem"),
+                PathBuf::from("client.key"),
+            ]
+        );
+    }
+}

--- a/control-plane/grpc/src/tracing.rs
+++ b/control-plane/grpc/src/tracing.rs
@@ -5,10 +5,7 @@ use opentelemetry::{
 };
 use opentelemetry_http::HeaderInjector;
 use std::{future::Future, pin::Pin};
-use tonic::{
-    codegen::http::{Request, Response},
-    transport::Channel,
-};
+use tonic::codegen::http::{Request, Response};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 const HTTP_STATUS_CODE: Key = Key::from_static_str("http.status_code");
@@ -44,9 +41,17 @@ impl<S> OpenTelClientService<S> {
 type TonicClientRequest = Request<tonic::body::Body>;
 type BoxedFuture<Resp, Err> = Pin<Box<dyn Future<Output = Result<Resp, Err>> + Send>>;
 
-impl tower::Service<TonicClientRequest> for OpenTelClientService<Channel> {
-    type Response = <Channel as tower::Service<TonicClientRequest>>::Response;
-    type Error = <Channel as tower::Service<TonicClientRequest>>::Error;
+impl<S, R, E> tower::Service<TonicClientRequest> for OpenTelClientService<S>
+where
+    S: tower::Service<TonicClientRequest, Response = Response<R>, Error = E>
+        + Clone
+        + Send
+        + 'static,
+    S::Future: Send,
+    E: ToString,
+{
+    type Response = Response<R>;
+    type Error = E;
     type Future = BoxedFuture<Self::Response, Self::Error>;
 
     fn poll_ready(

--- a/control-plane/grpc/src/tracing.rs
+++ b/control-plane/grpc/src/tracing.rs
@@ -41,7 +41,7 @@ impl<S> OpenTelClientService<S> {
     }
 }
 
-type TonicClientRequest = Request<tonic::body::BoxBody>;
+type TonicClientRequest = Request<tonic::body::Body>;
 type BoxedFuture<Resp, Err> = Pin<Box<dyn Future<Output = Result<Resp, Err>> + Send>>;
 
 impl tower::Service<TonicClientRequest> for OpenTelClientService<Channel> {
@@ -115,8 +115,8 @@ impl<S> OpenTelServerService<S> {
     }
 }
 
-type TonicServerRequest = Request<tonic::body::BoxBody>;
-type TonicServerResponse = Response<tonic::body::BoxBody>;
+type TonicServerRequest = Request<tonic::body::Body>;
+type TonicServerResponse = Response<tonic::body::Body>;
 impl<S> tower::Service<TonicServerRequest> for OpenTelServerService<S>
 where
     S: tower::Service<TonicServerRequest, Response = TonicServerResponse> + Send + Clone + 'static,
@@ -139,10 +139,10 @@ where
             return http_service_call(&mut self.service, request);
         }
 
-        let tracer = global::tracer_provider()
-            .tracer_builder("grpc-server")
+        let scope = opentelemetry::InstrumentationScope::builder("grpc-server")
             .with_version(env!("CARGO_PKG_VERSION"))
             .build();
+        let tracer = global::tracer_provider().tracer_with_scope(scope);
 
         let extractor = opentelemetry_http::HeaderExtractor(request.headers());
 

--- a/control-plane/plugin/src/bin/rest-plugin/main.rs
+++ b/control-plane/plugin/src/bin/rest-plugin/main.rs
@@ -39,6 +39,7 @@ struct CliArgs {
 
 #[tokio::main]
 async fn main() {
+    utils::init_rustls_crypto_provider();
     let cli_args = CliArgs::args();
     let _trace_flush = cli_args.args.init_tracing();
     if let Err(error) = cli_args.execute().await {

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -42,10 +42,8 @@ humantime = { workspace = true }
 grpc = { path = "../grpc" }
 num_cpus = { workspace = true }
 rcgen = { workspace = true }
-
 # certificate file watching for TLS auto-reload; Linux/inotify only
-[target.'cfg(target_os = "linux")'.dependencies]
-inotify = { workspace = true }
+cert-watcher = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -20,7 +20,7 @@ rustls = { workspace = true, default-features = false }
 rustls-pemfile = { workspace = true }
 actix-web = { workspace = true }
 actix-service = { workspace = true }
-tracing-actix-web = { workspace = true, features = ["opentelemetry_0_26"] }
+tracing-actix-web = { workspace = true, features = ["opentelemetry_0_30"] }
 tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 once_cell = { workspace = true }

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -52,6 +52,15 @@ pub(crate) struct CliArgs {
     /// The CORE gRPC Server URL or address to connect to the services.
     #[clap(long, short = 'z', default_value = DEFAULT_GRPC_CLIENT_ADDR)]
     core_grpc: Uri,
+    /// Path to the CA bundle used to verify the Core gRPC server.
+    #[clap(long = "grpc-tls-ca-file")]
+    grpc_tls_ca_file: Option<PathBuf>,
+    /// Path to the TLS client certificate used for Core gRPC mTLS.
+    #[clap(long = "grpc-tls-cert-file", requires = "grpc_tls_key_file")]
+    grpc_tls_cert_file: Option<PathBuf>,
+    /// Path to the TLS client private key used for Core gRPC mTLS.
+    #[clap(long = "grpc-tls-key-file", requires = "grpc_tls_cert_file")]
+    grpc_tls_key_file: Option<PathBuf>,
 
     /// Set the frequency of probing the agent-core for a liveness check.
     #[arg(long = "core-health-freq", value_parser = humantime::parse_duration, default_value = "2m")]
@@ -137,6 +146,21 @@ impl CliArgs {
         } else {
             timeout_opts.with_min_req_timeout(RequestMinTimeout::default())
         }
+    }
+    fn grpc_tls(&self) -> anyhow::Result<Option<grpc::tls::TlsConfig>> {
+        let tls = grpc::tls::TlsConfig::new(
+            self.grpc_tls_ca_file.clone(),
+            self.grpc_tls_cert_file.clone(),
+            self.grpc_tls_key_file.clone(),
+        )?;
+
+        if !tls.enabled() {
+            return Ok(None);
+        }
+        if self.core_grpc.scheme_str() != Some("https") {
+            anyhow::bail!("a TLS-enabled gRPC client requires an https:// URL");
+        }
+        Ok(Some(tls))
     }
     fn certificates(&self) -> anyhow::Result<ServerConfig> {
         let client_ca_file = self.client_ca_file.clone();
@@ -330,6 +354,7 @@ async fn probes_only_on_insecure(
 
 #[actix_web::main]
 async fn main() -> anyhow::Result<()> {
+    utils::init_rustls_crypto_provider();
     utils::print_package_info!();
     let cli_args = CliArgs::args();
     println!("Using options: {cli_args:?}");
@@ -343,8 +368,15 @@ async fn main() -> anyhow::Result<()> {
         .init("rest-server");
 
     // Initialize the core client to be used in rest
+    let core_client = match cli_args.grpc_tls()? {
+        Some(tls) => {
+            CoreClient::new_with_tls(cli_args.core_grpc.clone(), cli_args.timeout_opts(), tls)
+                .await?
+        }
+        None => CoreClient::new(cli_args.core_grpc.clone(), cli_args.timeout_opts()).await,
+    };
     CORE_CLIENT
-        .set(CoreClient::new(cli_args.core_grpc.clone(), cli_args.timeout_opts()).await)
+        .set(core_client)
         .ok()
         .expect("Expect to be initialised only once");
 

--- a/control-plane/rest/service/src/tls.rs
+++ b/control-plane/rest/service/src/tls.rs
@@ -193,7 +193,9 @@ fn build_client_verifier(
     let ca_file = &mut BufReader::new(File::open(ca_path)?);
     let client_certs = certs(ca_file)
         .collect::<Result<Vec<_>, _>>()
-        .map_err(|_| anyhow::anyhow!("Failed to retrieve certificates from client CA file"))?;
+        .map_err(|error| {
+            anyhow::anyhow!("Failed to retrieve certificates from client CA file: {error}")
+        })?;
     if client_certs.is_empty() {
         anyhow::bail!("No certificates found in the client CA file");
     }
@@ -229,26 +231,21 @@ struct WatchContext {
 }
 
 /// Spawn the certificate watch loop on a background OS thread.
-///
-/// A plain OS thread is used because the watch blocks in `inotify` reads and the reload path is
-/// fully synchronous/blocking.
-#[cfg(target_os = "linux")]
-fn spawn_cert_watcher(ctx: WatchContext) {
-    std::thread::Builder::new()
-        .name("tls-cert-watch".into())
-        .spawn(move || ctx.watch())
-        .ok();
-}
+fn spawn_cert_watcher(mut ctx: WatchContext) {
+    ctx.targets = cert_watcher::watch_targets(ctx.paths());
+    let targets = ctx.targets.clone();
 
-#[cfg(not(target_os = "linux"))]
-fn spawn_cert_watcher(_ctx: WatchContext) {
-    tracing::warn!(
-        "TLS certificate watch is only supported on Linux; automatic reload is disabled"
-    );
+    // Prime the last-modified guards with the material just loaded, so the initial catch-up
+    // reload performed when the watch is armed is a no-op.
+    let mut last_cert = modified(&ctx.cert_path).zip(modified(&ctx.key_path));
+    let mut last_ca = ctx.client_ca_path.as_deref().and_then(modified);
+
+    cert_watcher::spawn("tls-cert-watcher", targets, move || {
+        ctx.reload_all(&mut last_cert, &mut last_ca)
+    });
 }
 
 /// Last-modified time of a file, used to skip redundant reloads.
-#[cfg(target_os = "linux")]
 fn modified(path: &Path) -> Option<std::time::SystemTime> {
     std::fs::metadata(path).and_then(|m| m.modified()).ok()
 }
@@ -260,7 +257,6 @@ fn modified(path: &Path) -> Option<std::time::SystemTime> {
 /// since the last reload, and `Err` when the modification times cannot be read or the certificate
 /// material fails to load (a rotation can briefly leave the files inconsistent; the next event
 /// retries).
-#[cfg(target_os = "linux")]
 fn maybe_reload_cert(
     ctx: &WatchContext,
     last: &mut Option<(std::time::SystemTime, std::time::SystemTime)>,
@@ -284,7 +280,6 @@ fn maybe_reload_cert(
 /// Returns `Ok(true)` when the verifier was reloaded, `Ok(false)` when the file was unchanged (or
 /// client authentication is disabled), and `Err` when the modification time cannot be read or the
 /// CA bundle fails to load.
-#[cfg(target_os = "linux")]
 fn maybe_reload_verifier(
     ctx: &WatchContext,
     last: &mut Option<std::time::SystemTime>,
@@ -304,24 +299,11 @@ fn maybe_reload_verifier(
 }
 
 impl WatchContext {
-    /// Filesystem paths to watch for certificate changes.
-    ///
-    /// If all certs share a parent, watch that directory. This catches atomic
-    /// symlink-swap rotations where individual file symlinks may not emit events.
-    #[cfg(target_os = "linux")]
+    /// Certificate files that must be watched for automatic reload.
     fn paths(&self) -> Vec<PathBuf> {
         let mut paths = vec![self.cert_path.clone(), self.key_path.clone()];
         if let Some(ca_path) = &self.client_ca_path {
             paths.push(ca_path.clone());
-        }
-        if paths.is_empty() || std::env::var("KUBERNETES_SERVICE_HOST").is_err() {
-            return paths;
-        }
-        let mut parents = paths.iter().map(|path| path.parent().map(PathBuf::from));
-        if let Some(Some(first)) = parents.next() {
-            if parents.all(|parent| parent.as_ref() == Some(&first)) {
-                return vec![first];
-            }
         }
         paths
     }
@@ -351,89 +333,6 @@ impl WatchContext {
             Err(error) => {
                 tracing::warn!(?targets, %error, "Failed to reload TLS certificates");
             }
-        }
-    }
-
-    /// Watch the certificate files and reload after changes.
-    ///
-    /// The parent directories are watched (rather than the files) so atomic symlink-swap rotations,
-    /// as used by Kubernetes secret mounts, are observed even when the individual file symlinks do
-    /// not emit events. Fingerprint guards collapse the batch of events a single rotation produces
-    /// into one reload each. When inotify cannot be armed, this falls back to a polling reload on a
-    /// timer.
-    #[cfg(target_os = "linux")]
-    fn watch(mut self) {
-        use inotify::{Inotify, WatchMask};
-        use std::time::Duration;
-
-        /// The polling interval used whenever the inotify watch is unavailable.
-        const POLL_INTERVAL: Duration = Duration::from_secs(60);
-
-        self.targets = self.paths();
-
-        let mut last_cert = modified(&self.cert_path).zip(modified(&self.key_path));
-        let mut last_ca = self.client_ca_path.as_deref().and_then(modified);
-
-        let mut inotify = loop {
-            match Inotify::init() {
-                Ok(inotify) => break inotify,
-                Err(error) => {
-                    tracing::warn!(%error, "Failed to initialise inotify for TLS watch; polling for changes");
-                    std::thread::sleep(POLL_INTERVAL);
-                    if let Err(error) = self.reload_all_(&mut last_cert, &mut last_ca) {
-                        tracing::warn!(%error, "Failed to reload TLS certificates during polling fallback");
-                    }
-                }
-            }
-        };
-
-        let mask = WatchMask::MODIFY | WatchMask::MOVED_TO;
-        let mut buffer = [0u8; 4096];
-        'outer: loop {
-            for target in &self.targets {
-                if let Err(error) = inotify.watches().add(target, mask) {
-                    tracing::warn!(%error, path = %target.display(), "Failed to watch TLS path; will retry");
-                    std::thread::sleep(POLL_INTERVAL);
-                    if let Err(error) = self.reload_all_(&mut last_cert, &mut last_ca) {
-                        tracing::warn!(%error, "Failed to reload TLS certificates during polling fallback");
-                    }
-                    continue 'outer;
-                }
-            }
-
-            // Catch up on any change that happened before the watches were (re-)armed, since
-            // such changes emit no events; the fingerprint guards make this a no-op otherwise.
-            self.reload_all(&mut last_cert, &mut last_ca);
-
-            loop {
-                // Blocks until an event is available, then returns the whole batch of
-                // currently-queued events in one read.
-                let events = match inotify.read_events_blocking(&mut buffer) {
-                    Ok(events) => events,
-                    Err(error) => {
-                        tracing::warn!(%error, "TLS watch read error; re-arming");
-                        break;
-                    }
-                };
-
-                tracing::debug!(targets = ?self.targets, "TLS watch events received");
-
-                // The watch descriptor is only dropped when the watched inode itself is
-                // removed (delivered as `IGNORED`); in-directory rotations keep the inode
-                // and the watch keeps reporting `MOVED_TO`/`MODIFY`.
-                let ignored = events
-                    .into_iter()
-                    .any(|event| event.mask.contains(inotify::EventMask::IGNORED));
-
-                self.reload_all(&mut last_cert, &mut last_ca);
-
-                if ignored {
-                    break;
-                }
-            }
-
-            // Brief settle time before re-arming.
-            std::thread::sleep(Duration::from_millis(100));
         }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -238,6 +238,9 @@ pub struct NodeFeatures {
     /// Max version of the nexus label supported by the node.
     #[serde(default)]
     pub nexus_label_version: NexusVersion,
+    /// The io-engine gRPC server has TLS enabled and expects TLS connections.
+    #[serde(default)]
+    pub grpc_tls: Option<bool>,
 }
 
 /// Bug fixe in enum format

--- a/deployer/bin/src/deployer.rs
+++ b/deployer/bin/src/deployer.rs
@@ -53,6 +53,7 @@ impl Action {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    utils::init_rustls_crypto_provider();
     init_tracing();
 
     let mut cli_args = CliArgs::parse();

--- a/deployer/misc/rwx-vm/csi-node-2.nix
+++ b/deployer/misc/rwx-vm/csi-node-2.nix
@@ -45,7 +45,7 @@
           # ARGS=--nvme-nr-io-queues 1 --node-name app-node-2 --csi-socket /var/tmp/csi-app-node-2.sock --grpc-endpoint [::]:50055
           # EnvironmentFile = "/workspace/tmp/run/csi-node.env";
           # ExecStart = "/workspace/target/debug/csi-node $ARGS";
-          ExecStart = "/workspace/target/debug/csi-node --nvme-nr-io-queues 1 --node-name app-node-2 --csi-socket /var/tmp/csi-app-node-2.sock --grpc-endpoint [::]:50055";
+          ExecStart = "/workspace/target/debug/csi-node --nvme-nr-io-queues 1 --node-name app-node-2 --csi-socket /var/tmp/csi-app-node-2.sock --grpc-endpoint [::]:50055 --grpc-auto-tls";
         };
       };
       agent-ha-node = {
@@ -54,7 +54,7 @@
         after = [ "network-online.target" ];
         wants = [ "network-online.target" ];
         serviceConfig = {
-          ExecStart = "/workspace/target/debug/agent-ha-node -napp-node-2 -g[::]:50070 --csi-socket /var/tmp/csi-app-node-2.sock --cluster-agent https://10.1.0.1:11500 --fake-grpc-endpoint 10.1.0.1:50070";
+          ExecStart = "/workspace/target/debug/agent-ha-node -napp-node-2 -g[::]:50070 --grpc-auto-tls --csi-socket /var/tmp/csi-app-node-2.sock --cluster-agent https://10.1.0.1:11500 --fake-grpc-endpoint 10.1.0.1:50070";
         };
       };
       # this is required to convert TCP into unix-socket which is what the csi node plugin listen on

--- a/deployer/src/infra/agents/core.rs
+++ b/deployer/src/infra/agents/core.rs
@@ -80,6 +80,9 @@ impl ComponentAction for CoreAgent {
         if !options.no_deprecated_access_mode {
             binary = binary.with_arg("--deprecated-access-mode");
         }
+        if !options.no_grpc_tls {
+            binary = binary.with_arg("--grpc-auto-tls");
+        }
 
         Ok(cfg.add_container_spec(
             ContainerSpec::from_binary(name, binary).with_portmap("50051", "50051"),
@@ -95,11 +98,12 @@ impl ComponentAction for CoreAgent {
     }
     async fn wait_on(
         &self,
-        _options: &StartOptions,
+        options: &StartOptions,
         cfg: &crate::ComposeTestNt,
     ) -> Result<(), Error> {
         let ip = cfg.container_ip("core");
-        let uri = tonic::transport::Uri::from_str(&format!("https://{ip}:50051")).unwrap();
+        let scheme = if options.no_grpc_tls { "http" } else { "https" };
+        let uri = tonic::transport::Uri::from_str(&format!("{scheme}://{ip}:50051")).unwrap();
         let timeout = grpc::context::TimeoutOptions::new()
             .with_req_timeout(std::time::Duration::from_millis(100));
         let core =
@@ -115,9 +119,10 @@ impl ComponentAction for CoreAgent {
 
 impl CoreAgent {
     /// Wait for a node to become online.
-    pub(crate) async fn wait_node_online(cfg: &ComposeTest, node: &str) {
+    pub(crate) async fn wait_node_online(cfg: &ComposeTest, node: &str, no_grpc_tls: bool) {
         let ip = cfg.container_ip("core");
-        let uri = tonic::transport::Uri::from_str(&format!("https://{ip}:50051")).unwrap();
+        let scheme = if no_grpc_tls { "http" } else { "https" };
+        let uri = tonic::transport::Uri::from_str(&format!("{scheme}://{ip}:50051")).unwrap();
 
         let timeout = grpc::context::TimeoutOptions::new()
             .with_req_timeout(std::time::Duration::from_millis(100));

--- a/deployer/src/infra/agents/ha/cluster.rs
+++ b/deployer/src/infra/agents/ha/cluster.rs
@@ -8,11 +8,12 @@ use composer::{Binary, ContainerSpec};
 #[async_trait]
 impl ComponentAction for HaClusterAgent {
     fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
-        let mut spec = ContainerSpec::from_binary(
-            "agent-ha-cluster",
-            Binary::from_dbg("agent-ha-cluster").with_args(vec!["-g=[::]:11500"]),
-        )
-        .with_portmap("11500", "11500");
+        let mut binary = Binary::from_dbg("agent-ha-cluster").with_args(vec!["-g=[::]:11500"]);
+        if !options.no_grpc_tls {
+            binary = binary.with_arg("--grpc-auto-tls");
+        }
+        let mut spec =
+            ContainerSpec::from_binary("agent-ha-cluster", binary).with_portmap("11500", "11500");
 
         if let Some(env) = &options.agents_env {
             for kv in env {
@@ -50,21 +51,28 @@ impl ComponentAction for HaClusterAgent {
 
     async fn wait_on(
         &self,
-        _options: &StartOptions,
+        options: &StartOptions,
         cfg: &crate::ComposeTestNt,
     ) -> Result<(), Error> {
         // Wait till cluster-agent's gRPC server is ready to server the request
         loop {
-            match Endpoint::try_from(format!(
-                "https://{}:11500",
+            // The auto-tls connector performs the TLS handshake itself, so the endpoint always
+            // uses an http scheme to stop tonic from applying (and rejecting) its own TLS logic.
+            let endpoint = Endpoint::try_from(format!(
+                "http://{}:11500",
                 cfg.container_ip("agent-ha-cluster")
             ))?
-            .connect_timeout(Duration::from_millis(100))
-            .connect()
-            .await
-            {
+            .connect_timeout(Duration::from_millis(100));
+            let connect = match options.no_grpc_tls {
+                true => endpoint.connect().await,
+                false => grpc::tls::auto_tls_connect(&endpoint).await,
+            };
+            match connect {
                 Ok(_) => break,
-                Err(_) => sleep(Duration::from_millis(25)).await,
+                Err(error) => {
+                    tracing::error!(?error, "Failed to connect to cluster-agent gRPC server");
+                    sleep(Duration::from_millis(25)).await;
+                }
             }
         }
         Ok(())

--- a/deployer/src/infra/agents/ha/node.rs
+++ b/deployer/src/infra/agents/ha/node.rs
@@ -10,21 +10,22 @@ use tonic::transport::Endpoint;
 impl ComponentAction for HaNodeAgent {
     fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
         let socket = format!("-g{}:11600", cfg.next_ip_for_name("agent-ha-node")?);
-        let mut spec = ContainerSpec::from_binary(
-            "agent-ha-node",
-            Binary::from_dbg("agent-ha-node")
-                .with_arg(format!("-n{}", CsiNode::name(0)).as_str())
-                .with_arg(socket.as_str())
-                // Hardcoding the csi-socket file for now as we can launch only one instance
-                // of ha node agent. TODO: Map csi-node with ha-node.
-                .with_args(vec!["--csi-socket", "/var/tmp/csi-app-node-1.sock"]),
-        )
-        .with_bypass_default_mounts(true)
-        .with_bind("/var/tmp", "/var/tmp")
-        .with_bind("/run/udev", "/run/udev:ro")
-        .with_bind("/dev", "/dev:ro")
-        .with_privileged(Some(true))
-        .with_portmap("11600", "11600");
+        let mut binary = Binary::from_dbg("agent-ha-node")
+            .with_arg(format!("-n{}", CsiNode::name(0)).as_str())
+            .with_arg(socket.as_str())
+            // Hardcoding the csi-socket file for now as we can launch only one instance
+            // of ha node agent. TODO: Map csi-node with ha-node.
+            .with_args(vec!["--csi-socket", "/var/tmp/csi-app-node-1.sock"]);
+        if !options.no_grpc_tls {
+            binary = binary.with_arg("--grpc-auto-tls");
+        }
+        let mut spec = ContainerSpec::from_binary("agent-ha-node", binary)
+            .with_bypass_default_mounts(true)
+            .with_bind("/var/tmp", "/var/tmp")
+            .with_bind("/run/udev", "/run/udev:ro")
+            .with_bind("/dev", "/dev:ro")
+            .with_privileged(Some(true))
+            .with_portmap("11600", "11600");
 
         if let Some(env) = &options.agents_env {
             for kv in env {
@@ -54,30 +55,33 @@ impl ComponentAction for HaNodeAgent {
 
     async fn wait_on(
         &self,
-        _options: &StartOptions,
+        options: &StartOptions,
         cfg: &crate::ComposeTestNt,
     ) -> Result<(), Error> {
         // Wait till node-agent's gRPC server is ready to server the request
-        wait_on(&format!(
-            "https://{}:11600",
-            cfg.container_ip("agent-ha-node")
-        ))
+        wait_on(
+            &format!("http://{}:11600", cfg.container_ip("agent-ha-node")),
+            options.no_grpc_tls,
+        )
         .await?;
 
-        wait_on("https://10.1.0.1:11600").await?;
+        wait_on("http://10.1.0.1:11600", options.no_grpc_tls).await?;
 
         Ok(())
     }
 }
 
-async fn wait_on(uri: &str) -> Result<(), Error> {
+async fn wait_on(uri: &str, no_grpc_tls: bool) -> Result<(), Error> {
     // Wait till node-agent's gRPC server is ready to server the request
     loop {
-        match Endpoint::from_str(uri)?
-            .connect_timeout(Duration::from_millis(100))
-            .connect()
-            .await
-        {
+        // The auto-tls connector performs the TLS handshake itself, so the endpoint always
+        // uses an http scheme to stop tonic from applying (and rejecting) its own TLS logic.
+        let endpoint = Endpoint::from_str(uri)?.connect_timeout(Duration::from_millis(100));
+        let connect = match no_grpc_tls {
+            true => endpoint.connect().await,
+            false => grpc::tls::auto_tls_connect(&endpoint).await,
+        };
+        match connect {
             Ok(_) => break,
             Err(_) => sleep(Duration::from_millis(25)).await,
         }

--- a/deployer/src/infra/agents/jsongrpc.rs
+++ b/deployer/src/infra/agents/jsongrpc.rs
@@ -24,6 +24,10 @@ impl ComponentAction for JsonGrpcAgent {
             }
         }
 
+        if !options.no_grpc_tls {
+            binary = binary.with_arg("--grpc-auto-tls");
+        }
+
         if let Some(size) = &options.otel_max_batch_size {
             binary = binary.with_env("OTEL_BSP_MAX_EXPORT_BATCH_SIZE", size);
         }
@@ -39,11 +43,12 @@ impl ComponentAction for JsonGrpcAgent {
     }
     async fn wait_on(
         &self,
-        _options: &StartOptions,
+        options: &StartOptions,
         cfg: &crate::ComposeTestNt,
     ) -> Result<(), Error> {
         let ip = cfg.container_ip("jsongrpc");
-        let uri = tonic::transport::Uri::from_str(&format!("https://{ip}:50052")).unwrap();
+        let scheme = if options.no_grpc_tls { "http" } else { "https" };
+        let uri = tonic::transport::Uri::from_str(&format!("{scheme}://{ip}:50052")).unwrap();
         let timeout = grpc::context::TimeoutOptions::new()
             .with_req_timeout(std::time::Duration::from_millis(5));
         let json_grpc = JsonGrpcClient::new(uri, Some(timeout.with_max_retries(Some(10)))).await;

--- a/deployer/src/infra/csi-driver/controller.rs
+++ b/deployer/src/infra/csi-driver/controller.rs
@@ -32,6 +32,10 @@ impl ComponentAction for CsiController {
                 // Disable force unstage volume. TODO: remove the flag and fix test.
                 .with_args(vec!["--force-unstage-volume", "false"]);
 
+            if !options.no_grpc_tls {
+                binary = binary.with_arg("--grpc-auto-tls");
+            }
+
             if cfg.container_exists("jaeger") {
                 let jaeger_config = format!("jaeger.{}", cfg.get_name());
                 binary = binary.with_args(vec!["--jaeger", &jaeger_config])

--- a/deployer/src/infra/csi-driver/node.rs
+++ b/deployer/src/infra/csi-driver/node.rs
@@ -45,6 +45,7 @@ impl ComponentAction for CsiNode {
                     options.enable_app_node_registration,
                     options.csi_node_rest,
                     options.io_engine_cores,
+                    !options.no_grpc_tls,
                 )?;
             }
             cfg
@@ -126,6 +127,7 @@ impl CsiNode {
         enable_registration: bool,
         enable_rest: bool,
         io_queues: u32,
+        grpc_auto_tls: bool,
     ) -> Result<Builder, Error> {
         let container_name = Self::container_name(index);
         let node_name = Self::name(index);
@@ -139,6 +141,7 @@ impl CsiNode {
             enable_registration,
             enable_rest,
             io_queues,
+            grpc_auto_tls,
         )
     }
     fn with_local_node(index: u32, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
@@ -154,11 +157,13 @@ impl CsiNode {
             options.enable_app_node_registration,
             options.csi_node_rest,
             options.io_engine_cores,
+            !options.no_grpc_tls,
         )
     }
     fn vm_node(index: u32, option: &StartOptions) -> bool {
         index == 1 && option.rwx_vm
     }
+    #[allow(clippy::too_many_arguments)]
     fn with_node(
         container_name: &str,
         node_name: &str,
@@ -167,6 +172,7 @@ impl CsiNode {
         enable_registration: bool,
         enable_rest: bool,
         io_queues: u32,
+        grpc_auto_tls: bool,
     ) -> Result<Builder, Error> {
         let io_queues = io_queues.max(1);
         let mut binary = Binary::from_dbg(CSI_NODE)
@@ -175,6 +181,10 @@ impl CsiNode {
             // Make sure that CSI socket is always under shared directory
             // regardless of what its default value is.
             .with_args(vec!["--csi-socket", socket]);
+
+        if grpc_auto_tls {
+            binary = binary.with_arg("--grpc-auto-tls");
+        }
 
         if enable_registration || enable_rest {
             binary = binary.with_args(vec!["--rest-endpoint", "http://rest:8081"]);

--- a/deployer/src/infra/io_engine.rs
+++ b/deployer/src/infra/io_engine.rs
@@ -3,7 +3,7 @@ use composer::{Binary, ContainerSpec};
 use rpc::io_engine::{IoEngineApiVersion, RpcHandle};
 use std::net::{IpAddr, SocketAddr};
 use stor_port::types::v0::openapi::apis::Uuid;
-use utils::DEFAULT_GRPC_CLIENT_ADDR;
+use utils::DEFAULT_GRPC_REGISTRATION_CLIENT_ADDR;
 
 #[async_trait]
 impl ComponentAction for IoEngine {
@@ -38,7 +38,7 @@ impl ComponentAction for IoEngine {
             }
             .with_args(vec!["-N", &reg_name])
             .with_args(vec!["-g", &io_engine_socket])
-            .with_args(vec!["-R", DEFAULT_GRPC_CLIENT_ADDR])
+            .with_args(vec!["-R", DEFAULT_GRPC_REGISTRATION_CLIENT_ADDR])
             .with_args(vec![
                 "--api-versions".to_string(),
                 IoEngineApiVersion::vec_to_str(options.io_engine_api_versions.clone()),
@@ -148,7 +148,7 @@ impl ComponentAction for IoEngine {
                 cfg.exec(&name, vec![rm.as_str(), "-rf", Self::ptpl().1])
                     .await?;
             }
-            super::CoreAgent::wait_node_online(cfg, &name).await;
+            super::CoreAgent::wait_node_online(cfg, &name, options.no_grpc_tls).await;
         }
         Ok(())
     }

--- a/deployer/src/infra/mod.rs
+++ b/deployer/src/infra/mod.rs
@@ -239,6 +239,11 @@ impl Components {
     pub fn core_enabled(&self) -> bool {
         self.0.contains(&Component::CoreAgent(Default::default()))
     }
+
+    /// The deployment start options.
+    pub fn options(&self) -> &StartOptions {
+        &self.1
+    }
 }
 
 #[macro_export]

--- a/deployer/src/infra/rest.rs
+++ b/deployer/src/infra/rest.rs
@@ -1,7 +1,6 @@
 use crate::infra::{async_trait, Builder, ComponentAction, Components, Error, Rest, StartOptions};
 use composer::{Binary, ContainerSpec};
 use std::time::Duration;
-use utils::DEFAULT_JSON_GRPC_CLIENT_ADDR;
 
 #[async_trait]
 impl ComponentAction for Rest {
@@ -19,9 +18,12 @@ impl ComponentAction for Rest {
             } else {
                 "--http"
             };
+            let grpc_scheme = if options.no_grpc_tls { "http" } else { "https" };
+            let core_grpc = format!("{grpc_scheme}://core:50051/");
             let binary = Binary::from_dbg("rest")
                 .with_arg("--auto-tls")
                 .with_args(vec!["--https", "rest:8080"])
+                .with_args(vec!["--core-grpc", &core_grpc])
                 .with_args(vec![http, "rest:8081"])
                 .with_arg("--workers=1");
             let binary = if let Some(jwk) = &options.rest_jwk {
@@ -57,7 +59,8 @@ impl ComponentAction for Rest {
             };
 
             if cfg.container_exists("jsongrpc") {
-                binary = binary.with_args(vec!["--json-grpc", DEFAULT_JSON_GRPC_CLIENT_ADDR]);
+                let json_grpc = format!("{grpc_scheme}://jsongrpc:50052");
+                binary = binary.with_args(vec!["--json-grpc", &json_grpc]);
             }
 
             if let Some(size) = &options.otel_max_batch_size {

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -100,6 +100,10 @@ pub struct StartOptions {
     #[clap(long)]
     pub no_rest: bool,
 
+    /// Disable gRPC TLS.
+    #[clap(long)]
+    pub no_grpc_tls: bool,
+
     /// Enable the CSI Controller plugin.
     #[clap(long)]
     pub csi_controller: bool,
@@ -500,6 +504,11 @@ impl StartOptions {
     #[must_use]
     pub fn with_http_restrict(mut self, enabled: bool) -> Self {
         self.http_restrict = enabled;
+        self
+    }
+    #[must_use]
+    pub fn with_grpc_tls(mut self, enabled: bool) -> Self {
+        self.no_grpc_tls = !enabled;
         self
     }
     #[must_use]

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -43,6 +43,8 @@ http-body = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 pin-project = { workspace = true, optional = true }
 hyper-body = { workspace = true }
+# certificate file watching for TLS auto-reload (tower client); Linux/inotify only
+cert-watcher = { workspace = true }
 
 # SSL
 rustls = { workspace = true, default-features = false, optional = true }
@@ -56,7 +58,3 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry-http = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"], optional = true }
-
-# certificate file watching for TLS auto-reload (tower client); Linux/inotify only
-[target.'cfg(target_os = "linux")'.dependencies]
-inotify = { workspace = true }

--- a/openapi/templates/default/Cargo.mustache
+++ b/openapi/templates/default/Cargo.mustache
@@ -39,6 +39,8 @@ tokio = { version = "1.32.0", features = ["full"], optional = true }
 http-body = { version = "0.4.5", optional = true }
 futures = { version = "0.3.28", optional = true }
 pin-project = { version = "1.1.3", optional = true }
+# certificate file watching for TLS auto-reload (tower client); Linux/inotify only
+cert-watcher = { path = "../utils/cert-watcher" }
 
 # SSL
 rustls = { version = "0.21.12", optional = true, features = [ "dangerous_configuration" ] }

--- a/openapi/templates/default/tower-hyper/client/configuration.mustache
+++ b/openapi/templates/default/tower-hyper/client/configuration.mustache
@@ -113,24 +113,6 @@ pub enum TlsMode {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum TlsFingerprint {
-    None,
-    Auto,
-    ServerVerify {
-        ca_certificate: std::time::SystemTime,
-    },
-    ClientVerify {
-        client_certificate: std::time::SystemTime,
-        client_key: std::time::SystemTime,
-    },
-    Mtls {
-        ca_certificate: std::time::SystemTime,
-        client_certificate: std::time::SystemTime,
-        client_key: std::time::SystemTime,
-    },
-}
-
 impl TlsMode {
     /// Check if tls mode is auto.
     pub fn is_auto(&self) -> bool {
@@ -356,56 +338,15 @@ impl TlsMode {
     }
 
     /// Last-modified fingerprint used to skip duplicate reload events.
-    fn fingerprint(&self) -> Result<TlsFingerprint, std::io::Error> {
-        fn modified(path: &PathBuf) -> Result<std::time::SystemTime, std::io::Error> {
-            std::fs::metadata(path)?.modified()
-        }
-        Ok(match self {
-            Self::None => TlsFingerprint::None,
-            Self::Auto => TlsFingerprint::Auto,
-            Self::ServerVerify {
-                ca_certificate_path: Some(ca_certificate),
-                ..
-            } => TlsFingerprint::ServerVerify {
-                ca_certificate: modified(ca_certificate)?,
-            },
-            Self::ClientVerify {
-                client_certificate_path: Some(client_certificate),
-                client_key_path: Some(client_key),
-                ..
-            } => TlsFingerprint::ClientVerify {
-                client_certificate: modified(client_certificate)?,
-                client_key: modified(client_key)?,
-            },
-            Self::Mtls {
-                ca_certificate_path: Some(ca_certificate),
-                client_certificate_path: Some(client_certificate),
-                client_key_path: Some(client_key),
-                ..
-            } => TlsFingerprint::Mtls {
-                ca_certificate: modified(ca_certificate)?,
-                client_certificate: modified(client_certificate)?,
-                client_key: modified(client_key)?,
-            },
-            _ => TlsFingerprint::None,
-        })
+    fn fingerprint(&self) -> Result<Vec<std::time::SystemTime>, std::io::Error> {
+        cert_watcher::fingerprint(&self.paths())
     }
     /// Filesystem paths to watch for certificate changes.
     ///
     /// If all certs share a parent, watch that directory. This catches atomic
     /// symlink-swap rotations where individual file symlinks may not emit events.
     fn watch_targets(&self) -> Vec<PathBuf> {
-        let paths = self.paths();
-        if paths.is_empty() || std::env::var("KUBERNETES_SERVICE_HOST").is_err() {
-            return paths;
-        }
-        let mut parents = paths.iter().map(|path| path.parent().map(PathBuf::from));
-        if let Some(Some(first)) = parents.next() {
-            if parents.all(|parent| parent.as_ref() == Some(&first)) {
-                return vec![first];
-            }
-        }
-        paths
+        cert_watcher::watch_targets(self.paths())
     }
 }
 
@@ -422,7 +363,7 @@ struct TlsReloadService {
 struct TlsReloadState {
     url: url::Url,
     tls: TlsMode,
-    fingerprint: TlsFingerprint,
+    fingerprint: Vec<std::time::SystemTime>,
     client: HttpClientService,
 }
 
@@ -440,7 +381,10 @@ impl TlsReloadService {
             client,
         }));
 
-        Self::spawn_watcher(watch_paths, state.clone());
+        let reload_state = state.clone();
+        cert_watcher::spawn("tls-cert-watch", watch_paths.clone(), move || {
+            Self::reload(&reload_state, &watch_paths)
+        });
 
         Ok((Self { state }, url))
     }
@@ -471,11 +415,7 @@ impl TlsReloadService {
     }
     /// Re-read the certificate files and rebuild the TLS client, but only when the
     /// fingerprint changed, so duplicate or spurious watch events are no-ops.
-    ///
-    /// Returns `true` when the client was rebuilt.
     fn reload(state: &Arc<std::sync::Mutex<TlsReloadState>>, paths: &[PathBuf]) {
-        // Catch up on any change that happened before the watches were (re-)armed, since
-        // such changes emit no events; the fingerprint guard makes this a no-op otherwise.
         match Self::reload_(state) {
             Ok(true) => {
                 #[cfg(feature = "tower-trace")]
@@ -487,143 +427,8 @@ impl TlsReloadService {
                 tracing::warn!(?paths, error = %_error, "Failed to reload TLS certificates");
             }
         }
-    }
-
-    /// Spawn the certificate watch loop on a background OS thread.
-    ///
-    /// A plain OS thread is used rather than a Tokio task because the watch blocks in
-    /// `inotify` reads and the reload path is fully synchronous/blocking.
-    #[cfg(target_os = "linux")]
-    fn spawn_watcher(watch_paths: Vec<PathBuf>, state: Arc<std::sync::Mutex<TlsReloadState>>) {
-        if watch_paths.is_empty() {
-            return;
-        }
-        std::thread::Builder::new()
-            .name("tls-cert-watch".into())
-            .spawn(move || Self::watch(watch_paths, state))
-            .ok();
-    }
-
-    #[cfg(not(target_os = "linux"))]
-    fn spawn_watcher(watch_paths: Vec<PathBuf>, _state: Arc<std::sync::Mutex<TlsReloadState>>) {
-        #[cfg(feature = "tower-trace")]
-        tracing::warn!(
-            "TLS certificate watch is only supported on Linux; automatic reload is disabled"
-        );
-        let _ = watch_paths;
-    }
-
-    /// Watch certificate paths and reload after changes.
-    ///
-    /// Watch targets come from [`TlsMode::watch_targets`]: either the shared parent
-    /// directory of the certificate files, or the individual files as a fallback. A
-    /// single inotify instance reacts to `MODIFY` (in-place writes) and `MOVED_TO` (an
-    /// entry moved into the watched directory, i.e. an atomic-rename rotation).
-    ///
-    /// A renewal usually touches several files at once; each blocking read drains the
-    /// whole batch of queued events, which collapses into a single reload, and the
-    /// fingerprint guard in [`TlsReloadService::reload`] ensures the client is rebuilt
-    /// only once per actual change. Watches are re-armed only if the watched inode is
-    /// removed (`IGNORED`); the common Kubernetes symlink swap keeps the directory inode.
-    ///
-    /// inotify can fail at runtime: `init` when `fs.inotify.max_user_instances` is
-    /// exhausted, and `add` when a path is briefly missing mid-rotation or
-    /// `fs.inotify.max_user_watches` is exhausted. Whenever a watch cannot be (re)armed,
-    /// this falls back to a fingerprint-guarded reload on a timer until it recovers.
-    #[cfg(target_os = "linux")]
-    fn watch(watch_paths: Vec<PathBuf>, state: Arc<std::sync::Mutex<TlsReloadState>>) {
-        use inotify::{EventMask, Inotify, WatchMask};
-
-        /// The polling interval used whenever the inotify watch is unavailable.
-        const POLL_INTERVAL: Duration = Duration::from_secs(60);
-
-        /// A fingerprint-guarded reload, used when polling for changes.
-        fn poll_reload(state: &Arc<std::sync::Mutex<TlsReloadState>>) {
-            match TlsReloadService::reload_(state) {
-                Ok(true) => {
-                    #[cfg(feature = "tower-trace")]
-                    tracing::info!("Reloaded TLS certificates after change (polled)");
-                }
-                Ok(false) => {}
-                Err(_error) => {
-                    #[cfg(feature = "tower-trace")]
-                    tracing::warn!(error = %_error, "Failed to reload TLS certificates");
-                }
-            }
-        }
-
-        tracing::debug!(?watch_paths, "TLS watch requested");
-
-        // Keep one inotify instance for the watcher's lifetime: the kernel only drops the
-        // watch descriptors when their inodes are deleted, the instance stays usable.
-        let mut inotify = loop {
-            match Inotify::init() {
-                Ok(inotify) => break inotify,
-                Err(_error) => {
-                    #[cfg(feature = "tower-trace")]
-                    tracing::warn!(
-                        error = %_error,
-                        "Failed to initialise inotify for TLS watch; polling for changes"
-                    );
-                    std::thread::sleep(POLL_INTERVAL);
-                    poll_reload(&state);
-                }
-            }
-        };
-
-        let mask = WatchMask::MODIFY | WatchMask::MOVED_TO;
-        let mut buffer = [0u8; 4096];
-        'outer: loop {
-            for path in &watch_paths {
-                if let Err(_error) = inotify.watches().add(path, mask) {
-                    #[cfg(feature = "tower-trace")]
-                    tracing::warn!(
-                        error = %_error,
-                        path = %path.display(),
-                        "Failed to watch TLS path; will retry"
-                    );
-                    // Fall back to polling until the full set can be re-armed
-                    std::thread::sleep(POLL_INTERVAL);
-                    poll_reload(&state);
-                    continue 'outer;
-                }
-            }
-
-            // Catch up on any change that happened before the watches were (re-)armed, since
-            // such changes emit no events; the fingerprint guard makes this a no-op otherwise.
-            Self::reload(&state, &watch_paths);
-
-            loop {
-                // Blocks until an event is available, then returns the whole batch of
-                // currently-queued events in one read.
-                let events = match inotify.read_events_blocking(&mut buffer) {
-                    Ok(events) => events,
-                    Err(_error) => {
-                        #[cfg(feature = "tower-trace")]
-                        tracing::warn!(error = %_error, "TLS watch read error; re-arming");
-                        break;
-                    }
-                };
-
-                #[cfg(feature = "tower-trace")]
-                tracing::debug!(?watch_paths, "TLS watch events received");
-
-                // The watch descriptor is only dropped when the watched inode itself is
-                // removed (delivered as `IGNORED`); in-directory rotations keep the inode
-                // and the watch keeps reporting `MOVED_TO`/`MODIFY`.
-                let ignored = events
-                    .into_iter()
-                    .any(|event| event.mask.contains(EventMask::IGNORED));
-
-                Self::reload(&state, &watch_paths);
-
-                if ignored {
-                    break;
-                }
-            }
-            // Brief settle time before re-arming.
-            std::thread::sleep(Duration::from_millis(100));
-        }
+        #[cfg(not(feature = "tower-trace"))]
+        let _ = paths;
     }
 }
 

--- a/tests/bdd/common/cluster_agent.py
+++ b/tests/bdd/common/cluster_agent.py
@@ -1,10 +1,21 @@
+import ssl
+
 import grpc
 import v1.ha.cluster_agent_pb2_grpc as rpc
 
 
 class ClusterAgentHandle(object):
     def __init__(self, endpoint):
-        self.channel = grpc.insecure_channel(endpoint)
+        # The cluster-agent serves gRPC over TLS using an ephemeral, in-memory
+        # self-signed certificate (SAN "localhost"). Since the certificate is
+        # generated at start-up and not available on disk, fetch it from the
+        # running server and pin it as the trust root, overriding the target name
+        # so hostname verification passes regardless of the dialled address.
+        host, _, port = endpoint.rpartition(":")
+        server_cert = ssl.get_server_certificate((host, int(port))).encode()
+        credentials = grpc.ssl_channel_credentials(root_certificates=server_cert)
+        options = (("grpc.ssl_target_name_override", "localhost"),)
+        self.channel = grpc.secure_channel(endpoint, credentials, options)
         self.api = rpc.HaClusterRpcStub(self.channel)
 
     def __del__(self):

--- a/utils/cert-watcher/Cargo.toml
+++ b/utils/cert-watcher/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cert-watcher"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tracing = { workspace = true }
+
+# certificate file watching for TLS auto-reload; Linux/inotify only
+[target.'cfg(target_os = "linux")'.dependencies]
+inotify = { workspace = true }

--- a/utils/cert-watcher/src/lib.rs
+++ b/utils/cert-watcher/src/lib.rs
@@ -1,0 +1,169 @@
+//! Filesystem watching for file-backed TLS certificate reload.
+//!
+//! Consolidates the watch machinery shared by every TLS hot-reload site: watch-target
+//! selection, modification-time fingerprinting, and a background inotify loop with a
+//! polling fallback. Consumers provide a reload callback which owns the actual reload
+//! logic (fingerprint guard, rebuilding connectors/acceptors, logging).
+
+use std::{io, path::PathBuf, time::SystemTime};
+
+/// Filesystem paths to watch for certificate changes.
+///
+/// If all paths share a parent directory and the process runs inside Kubernetes, watch
+/// that directory instead. This catches atomic symlink-swap rotations (as used by
+/// Kubernetes secret mounts) where individual file symlinks may not emit events.
+pub fn watch_targets(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    if paths.is_empty() || std::env::var("KUBERNETES_SERVICE_HOST").is_err() {
+        return paths;
+    }
+    let mut parents = paths.iter().map(|path| path.parent().map(PathBuf::from));
+    if let Some(Some(first)) = parents.next() {
+        if parents.all(|parent| parent.as_ref() == Some(&first)) {
+            return vec![first];
+        }
+    }
+    paths
+}
+
+/// Last-modified fingerprint of the given files, used to skip redundant reloads.
+pub fn fingerprint(paths: &[PathBuf]) -> io::Result<Vec<SystemTime>> {
+    paths
+        .iter()
+        .map(|path| std::fs::metadata(path)?.modified())
+        .collect()
+}
+
+/// Spawn a background OS thread that watches `watch_paths` and invokes `reload` on changes.
+///
+/// The callback is invoked whenever the watched paths may have changed: right after the
+/// watches are (re-)armed (to catch up on changes that predate the watch), and after every
+/// batch of filesystem events. Spurious invocations are expected; callers are responsible
+/// for guarding actual reload work with a [`fingerprint`] comparison.
+///
+/// A plain OS thread is used rather than an async task because the watch blocks in
+/// `inotify` reads and the reload path is fully synchronous/blocking.
+///
+/// On non-Linux platforms this logs a warning and does nothing.
+#[cfg(target_os = "linux")]
+pub fn spawn(thread_name: &str, watch_paths: Vec<PathBuf>, reload: impl FnMut() + Send + 'static) {
+    if watch_paths.is_empty() {
+        return;
+    }
+    std::thread::Builder::new()
+        .name(thread_name.into())
+        .spawn(move || watch(watch_paths, reload))
+        .ok();
+}
+
+/// Spawn a background OS thread that watches `watch_paths` and invokes `reload` on changes.
+///
+/// On non-Linux platforms this logs a warning and does nothing.
+#[cfg(not(target_os = "linux"))]
+pub fn spawn(
+    _thread_name: &str,
+    watch_paths: Vec<PathBuf>,
+    _reload: impl FnMut() + Send + 'static,
+) {
+    if watch_paths.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        "TLS certificate watch is only supported on Linux; automatic reload is disabled"
+    );
+}
+
+/// Watch certificate paths and invoke the reload callback after changes.
+///
+/// Watch targets normally come from [`watch_targets`]: either the shared parent directory
+/// of the certificate files, or the individual files as a fallback. A single inotify
+/// instance reacts to `MODIFY` (in-place writes) and `MOVED_TO` (an entry moved into the
+/// watched directory, i.e. an atomic-rename rotation).
+///
+/// A renewal usually touches several files at once; each blocking read drains the whole
+/// batch of queued events, which collapses into a single reload, and the caller's
+/// fingerprint guard ensures reload work happens only once per actual change. Watches are
+/// re-armed only if the watched inode is removed (`IGNORED`); the common Kubernetes
+/// symlink swap keeps the directory inode.
+///
+/// inotify can fail at runtime: `init` when `fs.inotify.max_user_instances` is exhausted,
+/// and `add` when a path is briefly missing mid-rotation or `fs.inotify.max_user_watches`
+/// is exhausted. Whenever a watch cannot be (re)armed, this falls back to invoking the
+/// reload callback on a timer until it recovers.
+#[cfg(target_os = "linux")]
+fn watch(watch_paths: Vec<PathBuf>, mut reload: impl FnMut()) {
+    use inotify::{EventMask, Inotify, WatchMask};
+    use std::time::Duration;
+
+    /// The polling interval used whenever the inotify watch is unavailable.
+    const POLL_INTERVAL: Duration = Duration::from_secs(60);
+
+    tracing::debug!(?watch_paths, "TLS watch requested");
+
+    // Keep one inotify instance for the watcher's lifetime: the kernel only drops the
+    // watch descriptors when their inodes are deleted, the instance stays usable.
+    let mut inotify = loop {
+        match Inotify::init() {
+            Ok(inotify) => break inotify,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    "Failed to initialise inotify for TLS watch; polling for changes"
+                );
+                std::thread::sleep(POLL_INTERVAL);
+                reload();
+            }
+        }
+    };
+
+    let mask = WatchMask::MODIFY | WatchMask::MOVED_TO;
+    let mut buffer = [0u8; 4096];
+    'outer: loop {
+        for path in &watch_paths {
+            if let Err(error) = inotify.watches().add(path, mask) {
+                tracing::warn!(
+                    %error,
+                    path = %path.display(),
+                    "Failed to watch TLS path; will retry"
+                );
+                // Fall back to polling until the full set can be re-armed.
+                std::thread::sleep(POLL_INTERVAL);
+                reload();
+                continue 'outer;
+            }
+        }
+
+        // Catch up on any change that happened before the watches were (re-)armed, since
+        // such changes emit no events; the caller's fingerprint guard makes this a no-op
+        // otherwise.
+        reload();
+
+        loop {
+            // Blocks until an event is available, then returns the whole batch of
+            // currently-queued events in one read.
+            let events = match inotify.read_events_blocking(&mut buffer) {
+                Ok(events) => events,
+                Err(error) => {
+                    tracing::warn!(%error, "TLS watch read error; re-arming");
+                    break;
+                }
+            };
+
+            tracing::debug!(?watch_paths, "TLS watch events received");
+
+            // The watch descriptor is only dropped when the watched inode itself is
+            // removed (delivered as `IGNORED`); in-directory rotations keep the inode
+            // and the watch keeps reporting `MOVED_TO`/`MODIFY`.
+            let ignored = events
+                .into_iter()
+                .any(|event| event.mask.contains(EventMask::IGNORED));
+
+            reload();
+
+            if ignored {
+                break;
+            }
+        }
+        // Brief settle time before re-arming.
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}

--- a/utils/deployer-cluster/Cargo.toml
+++ b/utils/deployer-cluster/Cargo.toml
@@ -29,6 +29,6 @@ tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing-opentelemetry = { workspace = true }
 # Open Telemetry
 opentelemetry = { workspace = true }
-opentelemetry_sdk = { workspace = true, features = ["rt-tokio-current-thread"] }
+opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -8,7 +8,7 @@ use deployer_lib::{
     ComposeTestNt, StartOptions,
 };
 use opentelemetry::{global, KeyValue};
-use opentelemetry_sdk::{propagation::TraceContextPropagator, trace as sdktrace};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::SdkTracerProvider};
 
 use stor_port::{transport_api::TimeoutOptions, types::v0::transport};
 
@@ -1163,22 +1163,19 @@ impl ClusterBuilder {
                 ));
 
                 global::set_text_map_propagator(TraceContextPropagator::new());
-                let provider = opentelemetry_otlp::new_pipeline()
-                    .tracing()
-                    .with_exporter(
-                        opentelemetry_otlp::new_exporter()
-                            .tonic()
-                            .with_endpoint("http://127.0.0.1:4317"),
-                    )
-                    .with_trace_config(
-                        sdktrace::Config::default().with_resource(Resource::new(tracing_tags)),
-                    )
-                    // TODO: there's currently a few bugs on opentelemetry
-                    // 1. We can't use simple exporter on a tokio environment
-                    // 2. Even wit the tokio batch exporter, we can't shutdown properly,
-                    // meaning that we might not flush traces to jaeger :(
-                    .install_batch(opentelemetry_sdk::runtime::TokioCurrentThread)
+                let exporter = opentelemetry_otlp::SpanExporter::builder()
+                    .with_tonic()
+                    .with_endpoint("http://127.0.0.1:4317")
+                    .build()
                     .expect("Should be able to initialise the exporter");
+                let provider = SdkTracerProvider::builder()
+                    .with_batch_exporter(exporter)
+                    .with_resource(
+                        Resource::builder_empty()
+                            .with_attributes(tracing_tags)
+                            .build(),
+                    )
+                    .build();
                 global::set_tracer_provider(provider.clone());
                 let tracer = provider.tracer("tracing-otel-subscriber");
                 let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);

--- a/utils/deployer-cluster/src/lib.rs
+++ b/utils/deployer-cluster/src/lib.rs
@@ -111,7 +111,12 @@ impl Cluster {
 
     pub async fn new_grpc_client(&self, grpc_timeout: TimeoutOptions) -> CoreClient {
         let core_ip = self.composer.container_ip("core");
-        CoreClient::new(Uri::try_from(grpc_addr(core_ip)).unwrap(), grpc_timeout).await
+        let no_grpc_tls = self.builder.opts.no_grpc_tls;
+        CoreClient::new(
+            Uri::try_from(grpc_addr(core_ip, no_grpc_tls)).unwrap(),
+            grpc_timeout,
+        )
+        .await
     }
 
     /// volume service liveness checks whether the volume service responds to the
@@ -360,8 +365,9 @@ impl Cluster {
         let csi_endpoint = self
             .composer()
             .container_ip(&CsiNode::container_name(index));
-        let internal = csi_driver::node::internal::node_plugin_client::NodePluginClient::connect(
-            format!("http://{csi_endpoint}:50055"),
+        let internal = nodeplugin_client(
+            &format!("{csi_endpoint}:50055"),
+            self.builder.opts.no_grpc_tls,
         )
         .await?;
 
@@ -379,8 +385,9 @@ impl Cluster {
         let csi =
             rpc::csi::node_client::NodeClient::connect(format!("http://{csi_endpoint}:50059"))
                 .await?;
-        let internal = csi_driver::node::internal::node_plugin_client::NodePluginClient::connect(
-            format!("http://{csi_endpoint}:50056"),
+        let internal = nodeplugin_client(
+            &format!("{csi_endpoint}:50056"),
+            self.builder.opts.no_grpc_tls,
         )
         .await?;
 
@@ -598,7 +605,11 @@ impl Cluster {
         let grpc_client = if components.core_enabled() {
             Some(
                 CoreClient::new(
-                    Uri::try_from(grpc_addr(composer.container_ip("core"))).unwrap(),
+                    Uri::try_from(grpc_addr(
+                        composer.container_ip("core"),
+                        components.options().no_grpc_tls,
+                    ))
+                    .unwrap(),
                     grpc_timeout.clone(),
                 )
                 .await,
@@ -1022,6 +1033,12 @@ impl ClusterBuilder {
         self.grpc_timeout = timeout;
         self
     }
+    /// Specify whether gRPC TLS is enabled or not.
+    #[must_use]
+    pub fn with_grpc_tls(mut self, tls: bool) -> Self {
+        self.opts = self.opts.with_grpc_tls(tls);
+        self
+    }
     /// Specify whether rest is enabled or not.
     #[must_use]
     pub fn with_rest(mut self, enabled: bool) -> Self {
@@ -1296,8 +1313,32 @@ impl Pool {
     }
 }
 
-fn grpc_addr(ip: String) -> String {
-    format!("https://{ip}:50051")
+fn grpc_addr(ip: String, no_grpc_tls: bool) -> String {
+    let scheme = if no_grpc_tls { "http" } else { "https" };
+    format!("{scheme}://{ip}:50051")
+}
+
+/// Connect an internal node plugin client to `host:port`.
+///
+/// The nodeplugin server is TLS-only when gRPC TLS is enabled, so connect over auto-TLS in that
+/// case; otherwise a plaintext connection is used.
+async fn nodeplugin_client(
+    endpoint: &str,
+    no_grpc_tls: bool,
+) -> Result<
+    csi_driver::node::internal::node_plugin_client::NodePluginClient<tonic::transport::Channel>,
+    Error,
+> {
+    use csi_driver::node::internal::node_plugin_client::NodePluginClient;
+    if no_grpc_tls {
+        Ok(NodePluginClient::connect(format!("http://{endpoint}")).await?)
+    } else {
+        // The auto-tls connector performs the TLS handshake itself, so the endpoint uses an
+        // http scheme to stop tonic from applying (and rejecting) its own TLS logic.
+        let endpoint = tonic::transport::Endpoint::try_from(format!("http://{endpoint}"))?;
+        let channel = grpc::tls::auto_tls_connect(&endpoint).await?;
+        Ok(NodePluginClient::new(channel))
+    }
 }
 
 /// Bundles both the csi and the internal node service.

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -11,10 +11,11 @@ rls = ["event-publisher/rls-aws-lc-rs"]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 tracing-opentelemetry = { workspace = true }
 tracing = { workspace = true }
+rustls = { workspace = true }
 
 opentelemetry = { workspace = true }
 
-opentelemetry_sdk = { workspace = true, features = ["rt-tokio-current-thread"] }
+opentelemetry_sdk = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 

--- a/utils/utils-lib/src/constants.rs
+++ b/utils/utils-lib/src/constants.rs
@@ -90,10 +90,16 @@ pub const NATS_LABEL: &str = "app.kubernetes.io/name=nats";
 pub const NATS_PORT: &str = "client";
 
 /// The default value to be assigned as GRPC server addr if not overridden.
+/// A single port serves both TLS and plaintext connections, chosen per connection by sniffing the
+/// TLS handshake, so legacy plaintext io-engine registration and TLS clients share this port.
 pub const DEFAULT_GRPC_SERVER_ADDR: &str = "[::]:50051";
 
 /// The default value to be assigned as GRPC client addr if not overridden.
 pub const DEFAULT_GRPC_CLIENT_ADDR: &str = "https://core:50051";
+
+/// The default value for legacy io-engine registration clients.
+/// This targets the same port as the main gRPC server, using plaintext.
+pub const DEFAULT_GRPC_REGISTRATION_CLIENT_ADDR: &str = "http://core:50051";
 
 /// The default value to be assigned as JSON GRPC server addr if not overridden.
 pub const DEFAULT_JSON_GRPC_SERVER_ADDR: &str = "[::]:50052";

--- a/utils/utils-lib/src/lib.rs
+++ b/utils/utils-lib/src/lib.rs
@@ -11,6 +11,11 @@ pub mod version;
 pub use version::{long_raw_version_str, raw_version_str, raw_version_string};
 pub use version_info::{version_info as version_info_inner, VersionInfo};
 
+/// Select aws-lc-rs as Rustls's process-wide crypto provider when one has not been selected yet.
+pub fn init_rustls_crypto_provider() {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+}
+
 /// Byte conversion helpers.
 pub mod bytes;
 /// Dev path normalizer helpers.

--- a/utils/utils-lib/src/tracing_telemetry.rs
+++ b/utils/utils-lib/src/tracing_telemetry.rs
@@ -4,7 +4,7 @@ pub use opentelemetry::{global, trace};
 /// OpenTelemetry KeyVal for Processor Tags
 pub use opentelemetry::{Context, KeyValue};
 use opentelemetry_otlp::WithExportConfig;
-use opentelemetry_sdk::{propagation::TraceContextPropagator, trace as sdktrace, Resource};
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::SdkTracerProvider, Resource};
 use tracing::Level;
 use tracing_subscriber::{filter, layer::SubscriberExt, util::SubscriberInitExt, Layer, Registry};
 
@@ -165,18 +165,19 @@ impl TracingTelemetry {
 
             set_jaeger_env();
             global::set_text_map_propagator(TraceContextPropagator::new());
-            opentelemetry_otlp::new_pipeline()
-                .tracing()
-                .with_exporter(
-                    opentelemetry_otlp::new_exporter()
-                        .tonic()
-                        .with_endpoint(jaeger),
+            let exporter = opentelemetry_otlp::SpanExporter::builder()
+                .with_tonic()
+                .with_endpoint(jaeger)
+                .build()
+                .expect("Should be able to initialise the exporter");
+            SdkTracerProvider::builder()
+                .with_batch_exporter(exporter)
+                .with_resource(
+                    Resource::builder_empty()
+                        .with_attributes(tracing_tags)
+                        .build(),
                 )
-                .with_trace_config(
-                    sdktrace::Config::default().with_resource(Resource::new(tracing_tags)),
-                )
-                .install_batch(opentelemetry_sdk::runtime::TokioCurrentThread)
-                .expect("Should be able to initialise the exporter")
+                .build()
         });
         let tracer = tracer.map(|tracer_provider| {
             global::set_tracer_provider(tracer_provider.clone());
@@ -259,12 +260,10 @@ impl TracingTelemetry {
 
 /// We have to force flush the tracer provider as it lives in a global context.
 /// todo: return provider on [`TracingTelemetry::init`] and let the caller manage this.
-static TRACER_PROVIDER: std::sync::OnceLock<opentelemetry_sdk::trace::TracerProvider> =
-    std::sync::OnceLock::new();
+static TRACER_PROVIDER: std::sync::OnceLock<SdkTracerProvider> = std::sync::OnceLock::new();
 
 /// Flush the traces from the provider.
 pub fn flush_traces() {
-    global::shutdown_tracer_provider();
     if let Some(trace_provider) = TRACER_PROVIDER.get() {
         trace_provider.shutdown().ok();
     }


### PR DESCRIPTION
The agent gRPC servers and clients now support TLS end to end. Servers accept both TLS and plaintext on a single port via connection sniffing, clients can dial over TLS transparently, and core selects http/https per io-engine based on the capability advertised at registration.

This dual support is only meant for upgrades to ensure smooth transition. After all io-engines are upgraded, only TLS should be enabled.

Single-port TLS + plaintext
- Add `MaybeTlsConnection` and `sniff_and_accept()`: peek the first byte and route a TLS ClientHello (0x16) to the TLS acceptor, otherwise serve plaintext h2c; `incoming`/`incoming_with_server_config` now yield sniffed connections.
- Remove the obsolete `TlsConnection` type.
- Collapse the core listener to a single port (50051); drop the separate registration listener/port (50053) and `DEFAULT_GRPC_REGISTRATION_SERVER_ADDR`, and update deployer portmap/wait addresses accordingly.

Client transport
- `Client::new` now returns `anyhow::Result<Self>` and delegates to `new_with_tls`; auto-TLS is derived from an `https` scheme. The infallible call sites are preserved via `.expect`.
- Add an auto-TLS connector so clients can dial TLS endpoints transparently.

Per-node io-engine scheme selection
- Add `optional bool grpcTls` to `MayastorFeatures` and map it through registration into transport `NodeFeatures.grpc_tls`, persisted on the node spec/state.
- `NodeWrapper::node_grpc_tls()` reads the flag (false for sim nodes, defaults to plaintext when absent) and threads it into `GrpcContext`.
- `GrpcContext::connect_channel()` dials https when set, else http; v0/v1 io-engine clients use it. On core restart, carry the persisted features so the first liveness probe uses the correct scheme.