### PR TITLE
fix(labels): allow slashes in delete/cordon/drain routes

### DIFF
--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -278,6 +278,7 @@ paths:
           required: true
           schema:
             type: string
+          x-actix-tail-match: true
       responses:
         '200':
           description: OK
@@ -306,6 +307,7 @@ paths:
           required: true
           schema:
             type: string
+          x-actix-tail-match: true
       responses:
         '200':
           description: OK
@@ -335,6 +337,7 @@ paths:
           required: true
           schema:
             type: string
+          x-actix-tail-match: true
       responses:
         '200':
           description: OK

--- a/control-plane/rest/openapi-specs/v0_api_spec.yaml
+++ b/control-plane/rest/openapi-specs/v0_api_spec.yaml
@@ -416,6 +416,7 @@ paths:
           required: true
           schema:
             type: string
+          x-actix-tail-match: true
           description: |-
             The key of the label to be removed.
       responses:
@@ -1443,6 +1444,7 @@ paths:
           required: true
           schema:
             type: string
+          x-actix-tail-match: true
           description: |-
             The key of the label to be removed.
       responses:


### PR DESCRIPTION
GTM-5623

 PR #1001 added x-actix-tail-match to the PUT label routes' key/value params so labels with a slash-containing key/value (the normal Kubernetes <domain>/<name> format) can be added. The DELETE label routes, and node cordon/uncordon/drain, never got the same annotation:

- delete_node_label: /nodes/{id}/label/{key}
- del_pool_label: /pools/{id}/label/{key}
- put_node_cordon / delete_node_cordon: /nodes/{id}/cordon/{label}
- put_node_drain: /nodes/{id}/drain/{label}

Result: a label added with a key like openebs.io/engine can never be deleted, and a node can never be cordoned or drained with a slash-containing label, through the REST API. The router treats the "/" as an extra path segment instead of part of the value, and the request 404s even though the target genuinely exists.

Confirmed live against a real cluster: this works fine over a direct connection to the REST service (a well-behaved client percent-encodes the "/"), but breaks when the request goes through Kubernetes' own apiserver service-proxy subresource, which decodes %2F back to a literal "/" before forwarding - regardless of client-side encoding. This is why it affects browser-based clients (which always go through that proxy) even when a CLI hitting the service directly doesn't.

This adds the same x-actix-tail-match: true to all the affected routes' label/key param, matching the pattern already established for the PUT label routes. Pool cordon isn't affected; it takes its constraints via a JSON body, not a path segment.