### PR TITLE
build: switch to rustls for coming fips feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,7 +50,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -131,8 +131,6 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "futures-core",
- "http 0.2.12",
- "http 1.1.0",
  "impl-more",
  "pin-project-lite",
  "rustls-pki-types",
@@ -276,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -308,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -384,9 +382,9 @@ checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
 
 [[package]]
 name = "async-broadcast"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cd0e2e25ea8e5f7e9df04578dc6cf5c83577fd09b1a46aaf5c85e1c33f2a7e"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -396,34 +394,33 @@ dependencies = [
 
 [[package]]
 name = "async-nats"
-version = "0.37.0"
+version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3bdd6ea595b2ea504500a3566071beb81125fc15d40a6f6bffa43575f64152"
+checksum = "07d6f157065c3461096d51aacde0c326fa49f3f6e0199e204c566842cdaa5299"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
- "futures",
+ "futures-util",
  "memchr",
- "nkeys",
- "nuid",
- "once_cell",
+ "pin-project",
  "portable-atomic",
- "rand",
+ "rand 0.8.5",
  "regex",
- "ring",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "rustls-webpki",
  "serde",
  "serde_json",
  "serde_nanos",
  "serde_repr",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
  "tokio",
  "tokio-rustls",
+ "tokio-stream",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "tryhard",
  "url",
@@ -475,64 +472,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
-name = "awc"
-version = "3.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79049b2461279b886e46f1107efc347ebecc7b88d74d023dda010551a124967b"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-rt",
- "actix-service",
- "actix-tls",
- "actix-utils",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "cookie",
- "derive_more",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "itoa",
- "log",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
-]
-
-[[package]]
 name = "aws-lc-rs"
-version = "1.10.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
- "mirai-annotations",
- "paste",
  "untrusted 0.7.1",
  "zeroize",
 ]
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.22.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
- "bindgen",
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
- "libc",
- "paste",
+ "pkg-config",
 ]
 
 [[package]]
@@ -583,14 +543,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
 dependencies = [
- "getrandom",
- "instant",
- "rand",
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -619,12 +579,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bindgen"
@@ -695,7 +649,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -770,9 +724,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -788,10 +742,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
+ "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
@@ -886,9 +841,9 @@ checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "cmake"
-version = "0.1.51"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -921,12 +876,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -1096,32 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,17 +1143,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,17 +1150,6 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
-]
-
-[[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1384,25 +1285,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
-name = "ed25519"
-version = "2.2.3"
+name = "educe"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
 dependencies = [
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "sha2",
- "signature",
- "subtle",
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1424,6 +1315,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1483,7 +1394,7 @@ dependencies = [
  "async-nats",
  "events-api",
  "futures",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
  "url",
@@ -1491,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1502,9 +1413,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -1553,19 +1464,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "filedescriptor"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.68",
  "winapi",
 ]
 
@@ -1580,6 +1485,12 @@ dependencies = [
  "libredox",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1598,34 +1509,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "fluent-uri"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c704e9dbe1ddd863da1e6ff3567795087b1eb201ce80d8fa81162e1516500d"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -1650,7 +1543,6 @@ checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1780,10 +1672,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -1806,6 +1708,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "grpc"
@@ -1875,27 +1789,22 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "headers"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http 1.1.0",
@@ -1944,6 +1853,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2041,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-http-proxy"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d06dbdfbacf34d996c6fb540a71a684a7aae9056c71951163af8a8a4c07b9a4"
+checksum = "bd1d471ea2f65ba45eddb1d6ab7d58ac2671d2d4ac14da5c6516ae1d97e1327a"
 dependencies = [
  "bytes",
  "futures-util",
@@ -2053,7 +1973,6 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls-native-certs 0.7.3",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2086,7 +2005,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -2103,22 +2022,6 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -2389,15 +2292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-engine-tests"
 version = "1.0.0"
 dependencies = [
@@ -2506,62 +2400,61 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "2.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
+checksum = "7421438de105a0827e44fadd05377727847d717c80ce29a229f85fd04c427b72"
 dependencies = [
  "jsonptr",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "jsonpath-rust"
-version = "0.5.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
 dependencies = [
- "lazy_static",
- "once_cell",
  "pest",
  "pest_derive",
  "regex",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "jsonptr"
-version = "0.4.7"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6e529149475ca0b2820835d3dce8fcc41c6b943ca608d32f35b449255e4627"
+checksum = "a5a3cc660ba5d72bce0b3bb295bf20847ccbb40fd423f3f05b61273672e561fe"
 dependencies = [
- "fluent-uri",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.0"
+version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
+checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
- "base64 0.21.7",
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "getrandom 0.2.15",
  "js-sys",
  "pem",
- "ring",
  "serde",
  "serde_json",
+ "signature",
  "simple_asn1",
 ]
 
 [[package]]
 name = "k8s-openapi"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
+checksum = "2c75b990324f09bef15e791606b7b7a296d02fc88a344f6eba9390970a870ad5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2597,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ace78a62b361077505f2950bd48aa3e46596fb15350c9c993de15ddfa3cac5"
+checksum = "9a4eb20010536b48abe97fec37d23d43069bcbe9686adcf9932202327bc5ca6e"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2610,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18ec0fcafd3add30b413b096a61d69b0a37f94d3f95b6f505a57ea3d27cec2a7"
+checksum = "7fc2ed952042df20d15ac2fe9614d0ec14b6118eab89633985d4b36e688dccf1"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2632,27 +2525,25 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "pem",
- "rand",
  "rustls",
- "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",
  "serde_yaml",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite",
  "tokio-util",
- "tower 0.4.13",
+ "tower 0.5.1",
  "tower-http",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50c095f051dada37740d883b6d47ad0430e95082140718073b773c8a70f231c"
+checksum = "ff0d0793db58e70ca6d689489183816cb3aa481673e7433dc618cf7e8007c675"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2663,18 +2554,19 @@ dependencies = [
  "serde",
  "serde-value",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "kube-derive"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7871f02c3c848b63fee3d2f2645bb4a3c0b68ee147badcddf1b0cf8fb5db87ad"
+checksum = "c562f58dc9f7ca5feac8a6ee5850ca221edd6f04ce0dd2ee873202a88cd494c9"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
+ "serde",
  "serde_json",
  "syn 2.0.98",
 ]
@@ -2691,7 +2583,7 @@ dependencies = [
  "kube",
  "openapi",
  "shutdown",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
  "tower 0.5.1",
@@ -2710,7 +2602,7 @@ dependencies = [
  "kube",
  "kube-forward",
  "openapi",
- "thiserror",
+ "thiserror 1.0.68",
  "tower 0.5.1",
  "url",
  "utils",
@@ -2718,27 +2610,27 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.94.2"
+version = "0.99.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d844a274127dfe8fad766db5bc53aa783fb3f9dd48b20f955ec65d454ec9b1"
+checksum = "88f34cfab9b4bd8633062e0e85edb81df23cb09f159f2e31c60b069ae826ffdc"
 dependencies = [
  "ahash",
  "async-broadcast",
  "async-stream",
  "async-trait",
- "backoff",
- "derivative",
+ "backon",
+ "educe",
  "futures",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
+ "hostname",
  "json-patch",
- "jsonptr",
  "k8s-openapi",
  "kube-client",
  "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2937,12 +2829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2953,23 +2839,6 @@ name = "mutually_exclusive_features"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e94e1e6445d314f972ff7395df2de295fe51b71821694f0b0e1e79c4f12c8577"
-
-[[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
 
 [[package]]
 name = "newline-converter"
@@ -2993,21 +2862,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nkeys"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f49e787f4c61cbd0f9320b31cc26e58719f6aa5068e34697dd3aea361412fe3"
-dependencies = [
- "data-encoding",
- "ed25519",
- "ed25519-dalek",
- "getrandom",
- "log",
- "rand",
- "signatory",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,15 +2879,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "nuid"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc895af95856f929163a0aa20c26a78d26bfdc839f51b9d5aa7a5b79e52b7e83"
-dependencies = [
- "rand",
 ]
 
 [[package]]
@@ -3118,7 +2963,6 @@ version = "1.0.0"
 dependencies = [
  "actix-web",
  "async-trait",
- "awc",
  "dyn-clonable",
  "futures",
  "http-body",
@@ -3126,7 +2970,6 @@ dependencies = [
  "hyper",
  "hyper-body",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "inotify",
  "opentelemetry",
@@ -3141,7 +2984,6 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
- "tokio-native-tls",
  "tower 0.5.1",
  "tower-http",
  "tracing",
@@ -3149,33 +2991,6 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "webpki",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
 ]
 
 [[package]]
@@ -3183,18 +2998,6 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -3207,7 +3010,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -3235,7 +3038,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tonic",
 ]
@@ -3272,9 +3075,9 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
 ]
@@ -3368,15 +3171,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,20 +3178,19 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
 dependencies = [
  "memchr",
- "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.14"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3405,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.14"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
 dependencies = [
  "pest",
  "pest_meta",
@@ -3418,11 +3211,10 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.14"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -3468,16 +3260,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -3660,14 +3442,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3677,7 +3475,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3686,7 +3494,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3695,8 +3512,8 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
+ "aws-lc-rs",
  "pem",
- "ring",
  "rustls-pki-types",
  "time",
  "yasna",
@@ -3717,9 +3534,9 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -3880,7 +3697,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -3939,31 +3756,17 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.19"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934b404430bb06b3fae2cba809eb45a1ab1aecd64491213d7c3301b88393f8d1"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
- "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -3990,15 +3793,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4029,9 +3835,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -4041,9 +3847,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4065,11 +3871,10 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secrecy"
-version = "0.8.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
 dependencies = [
- "serde",
  "zeroize",
 ]
 
@@ -4104,10 +3909,11 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
+ "serde_core",
  "serde_derive",
 ]
 
@@ -4122,10 +3928,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive"
-version = "1.0.217"
+name = "serde_core"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4323,25 +4138,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "signatory"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e303f8205714074f6068773f0e29527e0453937fe837c9717d066635b65f31"
-dependencies = [
- "pkcs8",
- "rand_core",
- "signature",
- "zeroize",
-]
-
-[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4352,7 +4154,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.68",
  "time",
 ]
 
@@ -4414,16 +4216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4450,7 +4242,7 @@ dependencies = [
  "platform",
  "prost-types",
  "pstor",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "serde_tuple",
@@ -4518,6 +4310,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4552,7 +4355,7 @@ dependencies = [
  "bitflags 2.6.0",
  "libc",
  "smart-default",
- "thiserror",
+ "thiserror 1.0.68",
  "tracing",
 ]
 
@@ -4601,7 +4404,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
+dependencies = [
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4613,6 +4425,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4706,16 +4529,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4728,9 +4541,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -4739,9 +4552,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.23.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6989540ced10490aaf14e6bad2e3d33728a2813310a0c71d1574304c49631cd"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
@@ -4772,6 +4585,27 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f591660438b3038dd04d16c938271c79e7e06260ad2ea2885a4861bfb238605d"
+dependencies = [
+ "aws-lc-rs",
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "httparse",
+ "rand 0.8.5",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -4829,7 +4663,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -4857,16 +4691,15 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.5.2"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bitflags 2.6.0",
  "bytes",
  "http 1.1.0",
  "http-body",
- "http-body-util",
  "mime",
  "pin-project-lite",
  "tower-layer",
@@ -5009,30 +4842,28 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tryhard"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9f0a709784e86923586cff0d872dba54cd2d2e116b3bc57587d15737cfce9d"
+checksum = "9fe58ebd5edd976e0fe0f8a14d2a04b7c81ef153ea9a54eebc42e67c2c23b4e5"
 dependencies = [
- "futures",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "tungstenite"
-version = "0.23.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e2ce1e47ed2994fd43b04c8f618008d4cabdd5ee34027cf14f9d918edd9c8"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http 1.1.0",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.5",
  "sha1",
- "thiserror",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
@@ -5166,7 +4997,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -5175,12 +5006,6 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-info"
@@ -5210,6 +5035,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -5299,13 +5133,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.4"
+name = "webpki-roots"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "ring",
- "untrusted 0.9.0",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5381,6 +5223,12 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-registry"
@@ -5485,7 +5333,7 @@ version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -5639,6 +5487,12 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "write16"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,17 +59,16 @@ nvmeadm = { path = "./utils/dependencies/nvmeadm" }
 sysfs = { path = "./utils/dependencies/sysfs" }
 composer = { path = "./utils/dependencies/composer", default-features = false }
 
-rustls = { version = "0.23.19", default-features = false }
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 rustls-pemfile = "2.2.0"
 webpki = "0.22.4"
 tokio-native-tls = "0.3.1"
-rcgen = "0.13"
+rcgen = { version = "0.13", default-features = false, features = ["crypto", "pem", "aws_lc_rs"] }
 
 actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
 actix-service = "2.0.3"
-awc = { version = "3.5.1" }
 tinytemplate = "1.2.1"
-jsonwebtoken = "9.3.0"
+jsonwebtoken = { version = "10.3.0", features = ["aws_lc_rs"] }
 
 tokio = { version = "1.45.1", features = ["sync"] }
 tokio-stream = { version = "0.1", features = ["net"] }
@@ -144,13 +143,12 @@ pbjson = "0.7.0"
 pbjson-build = "0.7.0"
 bytes = "1.8.0"
 tower = { version = "=0.5.1", default-features = false, features = ["timeout", "util"] }
-tower-http = { version = "0.5.2", features = ["trace", "map-response-body", "auth"] }
+tower-http = { version = "0.6", features = ["trace", "map-response-body", "auth"] }
 hyper-util = "0.1.10"
 hyper = { version = "1.5.0", default-features = false, features = ["client", "http1", "http2"] }
 hyper-body = { path = "./utils/hyper-body" }
 http-body-util = { version = "0.1.3", default-features = false }
 hyper-rustls = { version = "0.27.3", default-features = false }
-hyper-tls = { version = "0.6.0" }
 
 udev = "0.9.1"
 sys-mount = { version = "3.0.1", default-features = false }
@@ -162,8 +160,8 @@ bindgen = "0.69.5"
 flate2 = "1.0"
 tar = "0.4"
 
-k8s-openapi = { version = "0.22.0", default-features = false, features = ["v1_24", "schemars"] }
-kube = { version = "0.94.2", features = ["runtime", "derive"] }
+k8s-openapi = { version = "0.24.0", default-features = false, features = ["v1_28", "schemars"] }
+kube = { version = "0.99.0", default-features = false, features = ["runtime", "derive", "client", "rustls-tls", "aws-lc-rs"] }
 schemars = { version = "0.8.21" }
-async-nats = { version = "0.37.0", default-features = false }
+async-nats = { version = "0.47.0", default-features = false, features = ["aws-lc-rs", "jetstream"] }
 etcd-client = "0.14.0"

--- a/control-plane/agents/src/bin/core/controller/registry.rs
+++ b/control-plane/agents/src/bin/core/controller/registry.rs
@@ -743,7 +743,7 @@ impl Registry {
         match self.max_rebuilds {
             Some(max_rebuilds) => {
                 let mut num_rebuilds = 0;
-                for (_id, node_wrapper) in self.nodes.read().await.iter() {
+                for node_wrapper in self.nodes.read().await.values() {
                     num_rebuilds += node_wrapper.read().await.num_rebuilds();
                 }
 

--- a/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/mod.rs
@@ -86,7 +86,7 @@ pub(crate) enum ResourceExcReason {
 }
 impl PartialOrd for ResourceExcReason {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.order_weight().cmp(&other.order_weight()))
+        Some(self.cmp(other))
     }
 }
 impl Ord for ResourceExcReason {

--- a/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
+++ b/control-plane/agents/src/bin/core/controller/scheduling/volume_policy/simple.rs
@@ -340,7 +340,7 @@ mod tests {
             .with_criteria(SimplePolicy::free_space)
             .with_criteria(SimplePolicy::over_commitment);
 
-        let mut pools = vec![
+        let mut pools = [
             make_pool("1", "1", gig, 0, None),
             make_pool("1", "2", gig * 2, 0, None),
             make_pool("2", "3", gig, 1, None),
@@ -350,7 +350,7 @@ mod tests {
         let pool_names = pools.iter().map(|p| p.pool.id.as_str()).collect::<Vec<_>>();
         assert_eq!(pool_names, vec!["2", "1", "3"]);
 
-        let mut pools = vec![
+        let mut pools = [
             make_pool("1", "1", gig * 3, 0, None),
             make_pool("1", "2", gig * 2, 0, None),
             make_pool("2", "3", gig, 1, None),
@@ -360,7 +360,7 @@ mod tests {
         let pool_names = pools.iter().map(|p| p.pool.id.as_str()).collect::<Vec<_>>();
         assert_eq!(pool_names, vec!["1", "2", "3"]);
 
-        let mut pools = vec![
+        let mut pools = [
             make_pool("1", "1", gig * 3, 400, None),
             make_pool("1", "2", gig * 2, 0, None),
             make_pool("2", "3", gig, 1, None),
@@ -370,7 +370,7 @@ mod tests {
         let pool_names = pools.iter().map(|p| p.pool.id.as_str()).collect::<Vec<_>>();
         assert_eq!(pool_names, vec!["2", "3", "1"]);
 
-        let mut pools = vec![
+        let mut pools = [
             make_pool("1", "1", gig * 50, 100, None),
             make_pool("1", "2", gig * 2, 0, None),
             make_pool("2", "3", gig, 1, None),
@@ -380,7 +380,7 @@ mod tests {
         let pool_names = pools.iter().map(|p| p.pool.id.as_str()).collect::<Vec<_>>();
         assert_eq!(pool_names, vec!["1", "2", "3"]);
 
-        let mut pools = vec![
+        let mut pools = [
             make_pool("1", "pool-1", gig, 500, None),
             make_pool("2", "pool-2", gig, 20, None),
             make_pool("3", "pool-3", gig, 500, Some(2)),
@@ -396,7 +396,7 @@ mod tests {
             vec!["pool-2", "pool-1", "pool-3", "pool-6", "pool-5", "pool-4"]
         );
 
-        let mut pools = vec![
+        let mut pools = [
             make_pool("1", "pool-1", gig, 500, None),
             make_pool("2", "pool-2", gig * 2, 20, None),
             make_pool("3", "pool-3", gig, 500, Some(2)),

--- a/control-plane/agents/src/bin/core/node/specs.rs
+++ b/control-plane/agents/src/bin/core/node/specs.rs
@@ -322,15 +322,16 @@ impl SpecOperationsHelper for NodeSpec {
             }
             NodeOperation::Unlabel(NodeUnLabelOp { label_key }) => {
                 // Check that the label is present.
-                if !self.has_labels_key(label_key) {
-                    Err(SvcError::LabelNotFound {
+                match self.has_labels_key(label_key) {
+                    false => Err(SvcError::LabelNotFound {
                         resource: ResourceKind::Node,
                         id: self.id().to_string(),
                         label_key: label_key.to_string(),
-                    })
-                } else {
-                    self.start_op(op);
-                    Ok(())
+                    }),
+                    true => {
+                        self.start_op(op);
+                        Ok(())
+                    }
                 }
             }
             _ => {

--- a/control-plane/agents/src/bin/core/pool/specs.rs
+++ b/control-plane/agents/src/bin/core/pool/specs.rs
@@ -103,30 +103,28 @@ impl SpecOperationsHelper for PoolSpec {
                     Ok(())
                 }
             }
-            PoolOperation::Cordon(cordon) => {
-                if !self.cordon_would_modify(cordon) {
-                    Err(SvcError::CordonResources {
-                        kind: ResourceKind::Pool,
-                        id: self.id().to_string(),
-                        resources: cordon.resources(),
-                    })
-                } else {
+            PoolOperation::Cordon(cordon) => match self.cordon_would_modify(cordon) {
+                false => Err(SvcError::CordonResources {
+                    kind: ResourceKind::Pool,
+                    id: self.id().to_string(),
+                    resources: cordon.resources(),
+                }),
+                true => {
                     self.start_op(op);
                     Ok(())
                 }
-            }
-            PoolOperation::Uncordon(uncordon) => {
-                if !self.uncordon_would_modify(uncordon) {
-                    Err(SvcError::UncordonResources {
-                        kind: ResourceKind::Pool,
-                        id: self.id().to_string(),
-                        resources: uncordon.resources(),
-                    })
-                } else {
+            },
+            PoolOperation::Uncordon(uncordon) => match self.uncordon_would_modify(uncordon) {
+                false => Err(SvcError::UncordonResources {
+                    kind: ResourceKind::Pool,
+                    id: self.id().to_string(),
+                    resources: uncordon.resources(),
+                }),
+                true => {
                     self.start_op(op);
                     Ok(())
                 }
-            }
+            },
             _ => {
                 self.start_op(op);
                 Ok(())

--- a/control-plane/agents/src/bin/core/pool/wrapper.rs
+++ b/control-plane/agents/src/bin/core/pool/wrapper.rs
@@ -186,9 +186,9 @@ impl From<&PoolWrapper> for Vec<Replica> {
 // (here we should have pool IO stats over time so we can pick less active
 // pools rather than the number of replicas which is useless if the volumes
 // are not active)
+#[allow(clippy::non_canonical_partial_ord_impl)]
 impl PartialOrd for PoolWrapper {
     // todo: change code to support using cmp
-    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match self.state.status.partial_cmp(&other.state.status) {
             Some(Ordering::Greater) => Some(Ordering::Greater),
@@ -204,6 +204,7 @@ impl PartialOrd for PoolWrapper {
 }
 
 impl Ord for PoolWrapper {
+    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other).unwrap_or(Ordering::Equal)
     }

--- a/control-plane/agents/src/bin/core/registry/service.rs
+++ b/control-plane/agents/src/bin/core/registry/service.rs
@@ -68,7 +68,7 @@ impl Service {
 
         // Aggregate the state information from each node.
         let nodes = self.registry.nodes().read().await;
-        for (_node_id, locked_node_wrapper) in nodes.iter() {
+        for locked_node_wrapper in nodes.values() {
             let node_wrapper = locked_node_wrapper.read().await;
             nexuses.extend(node_wrapper.nexus_states_cloned());
             pools.extend(node_wrapper.pool_states_cloned());

--- a/control-plane/agents/src/bin/core/volume/service.rs
+++ b/control-plane/agents/src/bin/core/volume/service.rs
@@ -614,10 +614,7 @@ impl Service {
 
         // If requested size is less than volume's current size(attempt to shrink volume),
         // then required becomes zero because we won't need to borrow anything from capacity_limit.
-        let required = request
-            .requested_size
-            .checked_sub(volume.as_ref().size)
-            .unwrap_or_default();
+        let required = request.requested_size.saturating_sub(volume.as_ref().size);
         let capacity_limit = self.capacity_limit_borrow.lock();
         // If there is a defined system wide capacity limit, ensure we don't breach that.
         self.specs()

--- a/control-plane/csi-driver/src/bin/controller/controller.rs
+++ b/control-plane/csi-driver/src/bin/controller/controller.rs
@@ -749,7 +749,7 @@ impl rpc::csi::controller_server::Controller for CsiControllerSvc {
             if !matches!(error, ApiClientError::NotAcceptable(_)) {
                 return Err(Status::not_found(format!(
                     "Failed to unpublish volume {}, error = {error:?}",
-                    &args.volume_id
+                    args.volume_id
                 )));
             }
         }

--- a/control-plane/csi-driver/src/bin/node/filesystem_vol.rs
+++ b/control-plane/csi-driver/src/bin/node/filesystem_vol.rs
@@ -52,8 +52,8 @@ pub(crate) async fn stage_fs_volume(
             return Err(Status::new(
                 Code::Internal,
                 format!(
-                    "Failed to create mountpoint {} for volume {}: {}",
-                    &fs_staging_path, volume_uuid, err
+                    "Failed to create mountpoint {} for volume {volume_uuid}: {err}",
+                    fs_staging_path,
                 ),
             ));
         }

--- a/control-plane/csi-driver/src/bin/node/node.rs
+++ b/control-plane/csi-driver/src/bin/node/node.rs
@@ -329,7 +329,7 @@ impl node_server::Node for Node {
                 Code::Internal,
                 format!(
                     "Failed to find parent dir for mountpoint {}, volume {}",
-                    &msg.target_path, &msg.volume_id
+                    msg.target_path, msg.volume_id
                 ),
             ));
         }
@@ -821,10 +821,7 @@ impl node_server::Node for Node {
                     if mounts.is_empty() {
                         detach(
                             &uuid,
-                            format!(
-                                "Failed to stage volume {}: {};",
-                                &msg.volume_id, fsmount_error
-                            ),
+                            format!("Failed to stage volume {}: {fsmount_error};", msg.volume_id),
                         )
                         .await?;
                     }
@@ -894,7 +891,7 @@ impl node_server::Node for Node {
         // this is correct, as the attach for nbd is a no-op.
         detach(
             &uuid,
-            format!("Failed to unstage volume {}:", &msg.volume_id),
+            format!("Failed to unstage volume {}:", msg.volume_id),
         )
         .await?;
 

--- a/control-plane/plugin/Cargo.toml
+++ b/control-plane/plugin/Cargo.toml
@@ -16,7 +16,6 @@ path = "./src/lib.rs"
 [features]
 default = ["rls"]
 rls = ["openapi/tower-client-rls"]
-tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 tracing = { workspace = true }

--- a/control-plane/rest/Cargo.toml
+++ b/control-plane/rest/Cargo.toml
@@ -35,7 +35,7 @@ snafu = { workspace = true }
 url = { workspace = true }
 http = { workspace = true }
 tinytemplate = { workspace = true }
-jsonwebtoken = { workspace = true }
+jsonwebtoken = { workspace = true, features = ["aws_lc_rs"] }
 stor-port = { path = "../stor-port" }
 utils = { path = "../../utils/utils-lib" }
 humantime = { workspace = true }

--- a/control-plane/rest/service/src/main.rs
+++ b/control-plane/rest/service/src/main.rs
@@ -332,7 +332,7 @@ async fn probes_only_on_insecure(
 async fn main() -> anyhow::Result<()> {
     utils::print_package_info!();
     let cli_args = CliArgs::args();
-    println!("Using options: {:?}", &cli_args);
+    println!("Using options: {cli_args:?}");
 
     utils::tracing_telemetry::TracingTelemetry::builder()
         .with_writer(FmtLayer::Stdout)

--- a/control-plane/stor-port/src/types/v0/store/mod.rs
+++ b/control-plane/stor-port/src/types/v0/store/mod.rs
@@ -141,9 +141,10 @@ impl Default for OperationSequence {
 }
 
 /// Sequence operations
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub enum OperationSequenceState {
     /// None in progress
+    #[default]
     Idle,
     /// An single exclusive operation (openapi driven)
     Exclusive,
@@ -151,11 +152,6 @@ pub enum OperationSequenceState {
     /// todo: If we have multiple concurrent reconcile loops, then we'll need an ID to
     /// distinguish between them and avoid concurrent updates
     Reconcile { active: bool },
-}
-impl Default for OperationSequenceState {
-    fn default() -> Self {
-        Self::Idle
-    }
 }
 
 /// Operations are locked

--- a/control-plane/stor-port/src/types/v0/store/registry.rs
+++ b/control-plane/stor-port/src/types/v0/store/registry.rs
@@ -92,23 +92,19 @@ impl CoreRegistryConfig {
 }
 
 /// How the Node Registration is handled
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Clone)]
 pub enum NodeRegistration {
     /// Nodes have to be registered via the RestApi before they can be used.
     Manual,
     /// Nodes are automatically registered when a Register message is received from an
     /// io-engine instance.
     /// They can be explicitly removed via the RestApi.
+    #[default]
     Automatic,
 }
 impl NodeRegistration {
     pub fn automatic(&self) -> bool {
         self == &Self::Automatic
-    }
-}
-impl Default for NodeRegistration {
-    fn default() -> Self {
-        Self::Automatic
     }
 }
 

--- a/control-plane/stor-port/src/types/v0/transport/child.rs
+++ b/control-plane/stor-port/src/types/v0/transport/child.rs
@@ -77,9 +77,10 @@ impl PartialEq<String> for ChildUri {
 }
 
 /// Child State information
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq, Display)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq, Display)]
 pub enum ChildState {
     /// Default Unknown state
+    #[default]
     Unknown,
     /// healthy and contains the latest bits
     Online,
@@ -181,11 +182,6 @@ impl From<&ChildStateReason> for Option<models::ChildStateReason> {
     }
 }
 
-impl Default for ChildState {
-    fn default() -> Self {
-        Self::Unknown
-    }
-}
 impl From<ChildState> for models::ChildState {
     fn from(src: ChildState) -> Self {
         match src {

--- a/control-plane/stor-port/src/types/v0/transport/misc.rs
+++ b/control-plane/stor-port/src/types/v0/transport/misc.rs
@@ -14,9 +14,10 @@ use strum_macros::Display;
 /// // Get all nexuses from the node `node_id`
 /// let nexuses =
 ///     client.get_nexuses(Filter::Node(node_id)).await.unwrap();
-#[derive(Serialize, Deserialize, Debug, Clone, strum_macros::Display)] // likely this ToString does not do the right thing...
+#[derive(Serialize, Deserialize, Debug, Default, Clone, strum_macros::Display)] // likely this ToString does not do the right thing...
 pub enum Filter {
     /// All objects.
+    #[default]
     None,
     /// Filter by Node id.
     Node(NodeId),
@@ -48,11 +49,6 @@ pub enum Filter {
     Snapshot(SnapshotId),
     /// Filter by Volume and Snapshot.
     VolumeSnapshot(VolumeId, SnapshotId),
-}
-impl Default for Filter {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 #[macro_export]
@@ -299,11 +295,12 @@ macro_rules! rpc_impl_string_id_percent_decoding {
 }
 
 /// Indicates what protocol the bdev is shared as.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, Display, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, Display, Eq, PartialEq)]
 #[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 pub enum Protocol {
     /// Not shared by any of the variants.
+    #[default]
     None = 0,
     /// Shared as NVMe-oF TCP.
     Nvmf = 1,
@@ -317,11 +314,6 @@ impl Protocol {
     /// Is the protocol set to be shared.
     pub fn shared(&self) -> bool {
         self != &Self::None
-    }
-}
-impl Default for Protocol {
-    fn default() -> Self {
-        Self::None
     }
 }
 impl From<i32> for Protocol {

--- a/control-plane/stor-port/src/types/v0/transport/nexus.rs
+++ b/control-plane/stor-port/src/types/v0/transport/nexus.rs
@@ -158,9 +158,10 @@ impl CreateNexusSnapReplDescr {
 }
 
 /// Nexus State information
-#[derive(Serialize, Deserialize, Debug, Clone, EnumString, Display, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, EnumString, Display, Eq, PartialEq)]
 pub enum NexusStatus {
     /// Default Unknown state.
+    #[default]
     Unknown,
     /// Healthy and working.
     Online,
@@ -172,11 +173,6 @@ pub enum NexusStatus {
     Shutdown,
     /// Shutdown in progress: not able to serve I/O.
     ShuttingDown,
-}
-impl Default for NexusStatus {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 impl From<NexusStatus> for models::NexusState {
     fn from(src: NexusStatus) -> Self {
@@ -192,11 +188,14 @@ impl From<NexusStatus> for models::NexusState {
 }
 
 /// The protocol used to share the nexus.
-#[derive(Serialize, Deserialize, Debug, Copy, Clone, EnumString, Display, Eq, PartialEq)]
+#[derive(
+    Serialize, Deserialize, Debug, Default, Copy, Clone, EnumString, Display, Eq, PartialEq,
+)]
 #[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 pub enum NexusShareProtocol {
     /// shared as NVMe-oF TCP
+    #[default]
     Nvmf = 1,
     /// shared as iSCSI
     Iscsi = 2,
@@ -205,11 +204,6 @@ pub enum NexusShareProtocol {
 impl std::cmp::PartialEq<Protocol> for NexusShareProtocol {
     fn eq(&self, other: &Protocol) -> bool {
         &Protocol::from(*self) == other
-    }
-}
-impl Default for NexusShareProtocol {
-    fn default() -> Self {
-        Self::Nvmf
     }
 }
 impl From<NexusShareProtocol> for Protocol {

--- a/control-plane/stor-port/src/types/v0/transport/node.rs
+++ b/control-plane/stor-port/src/types/v0/transport/node.rs
@@ -206,9 +206,12 @@ impl From<NodeRscCounts> for models::NodeMeta {
 }
 
 /// Status of the Node
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, EnumString, Display, Eq, PartialEq)]
+#[derive(
+    Serialize, Deserialize, Debug, Default, Clone, Copy, EnumString, Display, Eq, PartialEq,
+)]
 pub enum NodeStatus {
     /// Node has unexpectedly disappeared
+    #[default]
     Unknown,
     /// Node is deemed online if it has not missed the
     /// registration keep alive deadline
@@ -216,12 +219,6 @@ pub enum NodeStatus {
     /// Node is deemed offline if has missed the
     /// registration keep alive deadline
     Offline,
-}
-
-impl Default for NodeStatus {
-    fn default() -> Self {
-        Self::Unknown
-    }
 }
 
 /// Node features as exposed by the node io-engine.
@@ -530,8 +527,9 @@ impl From<NodeStatus> for models::NodeStatus {
 }
 
 /// api versions known by control plane
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq, Ord, PartialOrd)]
 pub enum ApiVersion {
+    #[default]
     V0,
     V1,
 }
@@ -545,11 +543,5 @@ impl FromStr for ApiVersion {
             "v1" => Ok(Self::V1),
             _ => Err(format!("The api version: {s} is not supported")),
         }
-    }
-}
-
-impl Default for ApiVersion {
-    fn default() -> Self {
-        Self::V0
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -20,9 +20,10 @@ pub struct GetPools {
 }
 
 /// Status of the Pool.
-#[derive(Serialize, Deserialize, Debug, Clone, EnumString, Display, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, EnumString, Display, Eq, PartialEq)]
 pub enum PoolStatus {
     /// Unknown state.
+    #[default]
     Unknown,
     /// The pool is in normal working order.
     Online,
@@ -36,11 +37,6 @@ pub enum PoolStatus {
     Offline,
 }
 
-impl Default for PoolStatus {
-    fn default() -> Self {
-        Self::Unknown
-    }
-}
 // todo: this conversion is bypassing the io-engine proto-api translation.
 //  this may cause issues if the numbers here get desynced with the io-engine api.
 impl From<i32> for PoolStatus {

--- a/control-plane/stor-port/src/types/v0/transport/replica.rs
+++ b/control-plane/stor-port/src/types/v0/transport/replica.rs
@@ -768,22 +768,20 @@ pub struct UnshareReplica {
 }
 
 /// The protocol used to share the replica.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, EnumString, Display, Eq, PartialEq)]
+#[derive(
+    Serialize, Deserialize, Debug, Default, Clone, Copy, EnumString, Display, Eq, PartialEq,
+)]
 #[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 pub enum ReplicaShareProtocol {
     /// Shared as NVMe-oF TCP.
+    #[default]
     Nvmf = 1,
 }
 
 impl std::cmp::PartialEq<Protocol> for ReplicaShareProtocol {
     fn eq(&self, other: &Protocol) -> bool {
         &Protocol::from(*self) == other
-    }
-}
-impl Default for ReplicaShareProtocol {
-    fn default() -> Self {
-        Self::Nvmf
     }
 }
 impl From<i32> for ReplicaShareProtocol {
@@ -803,11 +801,12 @@ impl From<ReplicaShareProtocol> for Protocol {
 }
 
 /// State of the Replica.
-#[derive(Serialize, Deserialize, Debug, Clone, EnumString, Display, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, EnumString, Display, Eq, PartialEq)]
 #[strum(serialize_all = "camelCase")]
 #[serde(rename_all = "camelCase")]
 pub enum ReplicaStatus {
     /// Unknown state.
+    #[default]
     Unknown = 0,
     /// The replica is in normal working order.
     Online = 1,
@@ -823,11 +822,6 @@ impl ReplicaStatus {
     }
 }
 
-impl Default for ReplicaStatus {
-    fn default() -> Self {
-        Self::Unknown
-    }
-}
 impl From<i32> for ReplicaStatus {
     fn from(src: i32) -> Self {
         match src {

--- a/control-plane/stor-port/src/types/v0/transport/volume.rs
+++ b/control-plane/stor-port/src/types/v0/transport/volume.rs
@@ -493,22 +493,17 @@ impl GetVolumes {
 
 /// Policy for restoring a volume from a snapshot when one or more snapshot
 /// replica pools cannot accept a new clone (for example, the source pool is full).
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum SnapshotRestorePolicy {
     /// Require every requested replica to be cloned from the source snapshot.
     /// The restore fails if any clone cannot be created. This is the default.
+    #[default]
     Strict,
     /// Allow the restore to proceed with fewer clones than the requested replica
     /// count, as long as at least one clone can be created. The volume is created
     /// in a degraded state and the missing replicas are filled in by the regular
     /// replica reconciler via a full rebuild.
     BestEffort,
-}
-
-impl Default for SnapshotRestorePolicy {
-    fn default() -> Self {
-        Self::Strict
-    }
 }
 
 impl From<models::SnapshotRestorePolicy> for SnapshotRestorePolicy {
@@ -715,10 +710,11 @@ impl PublishVolume {
 /// Persisted on the volume metadata so internal callers (reconcilers, future
 /// maintenance flows) can identify a target they themselves established
 /// without leaking that distinction through the public publish API.
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum VolumeTargetMode {
     /// The target is serving a front-end application publish (the default
     /// path: CSI publish or REST publish that fronts a user workload).
+    #[default]
     ServeFrontendApp,
     /// The target was set up by the offline-rebuild reconciler to drive a
     /// rebuild on an unpublished volume. The reconciler owns its lifecycle.
@@ -727,12 +723,6 @@ pub enum VolumeTargetMode {
     /// (fsck, grow, migrate) and must not be promoted to serve app traffic
     /// until the maintenance flow releases it. Reserved for future use.
     MaintenanceMode,
-}
-
-impl Default for VolumeTargetMode {
-    fn default() -> Self {
-        Self::ServeFrontendApp
-    }
 }
 
 impl VolumeTargetMode {

--- a/control-plane/stor-port/src/types/v0/transport/watch.rs
+++ b/control-plane/stor-port/src/types/v0/transport/watch.rs
@@ -92,7 +92,7 @@ impl std::fmt::Display for WatchResourceId {
 }
 
 /// The difference types of watches
-#[derive(Serialize, Deserialize, Debug, Clone, Eq, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum WatchType {
     /// watch for changes on the desired state
@@ -100,12 +100,8 @@ pub enum WatchType {
     /// watch for changes on the actual state
     Actual,
     /// watch for both `Desired` and `Actual` changes
+    #[default]
     All,
-}
-impl Default for WatchType {
-    fn default() -> Self {
-        Self::All
-    }
 }
 
 /// Delete watch which was previously created by CreateWatch

--- a/k8s/operators/Cargo.toml
+++ b/k8s/operators/Cargo.toml
@@ -17,7 +17,6 @@ path = "src/lib.rs"
 default = ["rls", "bin"]
 bin = ["openapi", "utils", "anyhow", "chrono", "clap", "futures", "snafu", "tokio", "humantime", "tracing", "strum_macros", "strum"]
 rls = ["openapi/tower-client-rls"]
-tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 # CRD

--- a/k8s/operators/src/pool/context.rs
+++ b/k8s/operators/src/pool/context.rs
@@ -961,7 +961,7 @@ impl ResourceContext {
                 "DiskNotFound",
                 &format!(
                     "The block device(s): {} can not be found",
-                    &self.spec.disks()[0]
+                    self.spec.disks()[0]
                 ),
                 "Warning",
             )

--- a/k8s/proxy/Cargo.toml
+++ b/k8s/proxy/Cargo.toml
@@ -9,7 +9,6 @@ description = "Kubernetes OpenApi Client via k8s-proxy"
 [features]
 default = ["rls"]
 rls = ["openapi/tower-client-rls"]
-tls = ["openapi/tower-client-tls"]
 
 [dependencies]
 kube-forward = { path = "../forward" }

--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -6,8 +6,8 @@ in
 rec {
   inherit makeRustTarget;
   rust_default = { override ? { } }: rec {
-    nightly_pkg = pkgs.rust-bin.nightly."2025-06-26";
-    stable_pkg = pkgs.rust-bin.stable."1.88.0";
+    nightly_pkg = pkgs.rust-bin.nightly."2026-07-16";
+    stable_pkg = pkgs.rust-bin.stable."1.97.1";
 
     nightly = nightly_pkg.default.override (override);
     stable = stable_pkg.default.override (override);

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -4,7 +4,6 @@
 , lib
 , llvmPackages
 , makeRustPlatform
-, openssl
 , pkg-config
 , protobuf
 , sources
@@ -74,7 +73,7 @@ let
 
     inherit LIBCLANG_PATH PROTOC PROTOC_INCLUDE;
     nativeBuildInputs = [ clang pkg-config paperclip which git llvmPackages.bintools ];
-    buildInputs = [ llvmPackages.libclang protobuf openssl.dev systemdMinimal.dev utillinux.dev rdma-core ];
+    buildInputs = [ llvmPackages.libclang protobuf systemdMinimal.dev utillinux.dev rdma-core ];
     doCheck = false;
   };
   release_build = { "release" = true; "debug" = false; };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,62 +1,62 @@
 {
-  "naersk": {
-    "branch": "master",
-    "description": "Build rust crates in Nix. No configuration, no code generation, no IFD. Sandbox friendly. [maintainer: @nmattia]",
-    "homepage": "",
-    "owner": "nix-community",
-    "repo": "naersk",
-    "rev": "0e72363d0938b0208d6c646d10649164c43f4d64",
-    "sha256": "1isav7yifl520ifhvswkkicnp2ylhxwnpwdvm4xz2yqrb4258mxs",
-    "type": "tarball",
-    "url": "https://github.com/nix-community/naersk/archive/0e72363d0938b0208d6c646d10649164c43f4d64.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  },
-  "niv": {
-    "branch": "master",
-    "description": "Easy dependency management for Nix projects",
-    "homepage": "https://github.com/nmattia/niv",
-    "owner": "nmattia",
-    "repo": "niv",
-    "rev": "dd678782cae74508d6b4824580d2b0935308011e",
-    "sha256": "0dk8dhh9vla2s409anmrfkva6h3r32xmz3cm8ha09wyk8iyf1f87",
-    "type": "tarball",
-    "url": "https://github.com/nmattia/niv/archive/dd678782cae74508d6b4824580d2b0935308011e.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  },
-  "nixpkgs": {
-    "branch": "nixos-25.05",
-    "description": "Nix Packages collection",
-    "homepage": "",
-    "owner": "NixOS",
-    "repo": "nixpkgs",
-    "rev": "1f08a4df998e21f4e8be8fb6fbf61d11a1a5076a",
-    "sha256": "0ghn99k0nsbs8a83mhz5ylibvlps19yy690jgj5g6v9v3dkh8fgs",
-    "type": "tarball",
-    "url": "https://github.com/NixOS/nixpkgs/archive/1f08a4df998e21f4e8be8fb6fbf61d11a1a5076a.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  },
-  "nixpkgs-22_05": {
-    "branch": "release-22.05",
-    "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
-    "homepage": "https://github.com/NixOS/nixpkgs",
-    "owner": "NixOS",
-    "repo": "nixpkgs",
-    "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-    "sha256": "154x9swf494mqwi4z8nbq2f0sp8pwp4fvx51lqzindjfbb9yxxv5",
-    "type": "tarball",
-    "url": "https://github.com/NixOS/nixpkgs/archive/380be19fbd2d9079f677978361792cb25e8a3635.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  },
-  "rust-overlay": {
-    "branch": "master",
-    "description": "Pure and reproducible nix overlay for binary distributed rust toolchains",
-    "homepage": "",
-    "owner": "oxalica",
-    "repo": "rust-overlay",
-    "rev": "01ac47d86311fb030023f1dfc5f6bc368b9c6cee",
-    "sha256": "0cqy0yfmji6b73p7l6mh0vrfj2cg8hgk4h7km83azdvcnrpilh3b",
-    "type": "tarball",
-    "url": "https://github.com/oxalica/rust-overlay/archive/01ac47d86311fb030023f1dfc5f6bc368b9c6cee.tar.gz",
-    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-  }
+    "naersk": {
+        "branch": "master",
+        "description": "Build rust crates in Nix. No configuration, no code generation, no IFD. Sandbox friendly. [maintainer: @nmattia]",
+        "homepage": "",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "0e72363d0938b0208d6c646d10649164c43f4d64",
+        "sha256": "1isav7yifl520ifhvswkkicnp2ylhxwnpwdvm4xz2yqrb4258mxs",
+        "type": "tarball",
+        "url": "https://github.com/nix-community/naersk/archive/0e72363d0938b0208d6c646d10649164c43f4d64.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "niv": {
+        "branch": "master",
+        "description": "Easy dependency management for Nix projects",
+        "homepage": "https://github.com/nmattia/niv",
+        "owner": "nmattia",
+        "repo": "niv",
+        "rev": "dd678782cae74508d6b4824580d2b0935308011e",
+        "sha256": "0dk8dhh9vla2s409anmrfkva6h3r32xmz3cm8ha09wyk8iyf1f87",
+        "type": "tarball",
+        "url": "https://github.com/nmattia/niv/archive/dd678782cae74508d6b4824580d2b0935308011e.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs": {
+        "branch": "nixos-25.05",
+        "description": "Nix Packages collection",
+        "homepage": "",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1f08a4df998e21f4e8be8fb6fbf61d11a1a5076a",
+        "sha256": "0ghn99k0nsbs8a83mhz5ylibvlps19yy690jgj5g6v9v3dkh8fgs",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/1f08a4df998e21f4e8be8fb6fbf61d11a1a5076a.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "nixpkgs-22_05": {
+        "branch": "release-22.05",
+        "description": "A read-only mirror of NixOS/nixpkgs tracking the released channels. Send issues and PRs to",
+        "homepage": "https://github.com/NixOS/nixpkgs",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "sha256": "154x9swf494mqwi4z8nbq2f0sp8pwp4fvx51lqzindjfbb9yxxv5",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/380be19fbd2d9079f677978361792cb25e8a3635.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "rust-overlay": {
+        "branch": "master",
+        "description": "Pure and reproducible nix overlay for binary distributed rust toolchains",
+        "homepage": "",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "dc2fd1acc537f3583744e1373597a5731ff7a6e3",
+        "sha256": "1afpvg7m4jm7nf5algsd6mnfqww37rgvxlib4jfff81qgnmayx4d",
+        "type": "tarball",
+        "url": "https://github.com/oxalica/rust-overlay/archive/dc2fd1acc537f3583744e1373597a5731ff7a6e3.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    }
 }

--- a/openapi/Cargo.toml
+++ b/openapi/Cargo.toml
@@ -11,16 +11,12 @@ path = "src/lib.rs"
 [features]
 default = ["tower-client-rls", "tower-trace"]
 actix-server = ["actix"]
-actix-client = ["actix", "awc"]
 actix = ["actix-web", "rustls"]
-tower-client-rls = ["tower-client", "rustls_ring"]
-tower-client-tls = ["tower-client", "hyper_tls_feat"]
+tower-client-rls = ["tower-client", "rustls_aws_lc_rs"]
 tower-client = ["tower-hyper"]
 tower-hyper = ["hyper", "tower", "tower-http", "http-body", "futures", "pin-project", "tokio"]
-hyper_tls_feat = ["hyper-tls", "tokio-native-tls"]
-rustls_feat = ["rustls", "webpki", "hyper-rustls"]
+rustls_feat = ["rustls", "hyper-rustls"]
 rustls_aws_lc_rs = ["rustls_feat", "rustls/aws-lc-rs", "hyper-rustls/aws-lc-rs"]
-rustls_ring = ["rustls_feat", "rustls/ring", "hyper-rustls/ring"]
 tower-trace = ["opentelemetry-otlp", "opentelemetry_sdk", "tracing-opentelemetry", "opentelemetry", "opentelemetry-http", "tracing", "tracing-subscriber"]
 
 [dependencies]
@@ -36,7 +32,6 @@ serde_urlencoded = { workspace = true }
 # actix dependencies
 actix-web = { workspace = true, optional = true }
 
-awc = { workspace = true, optional = true }
 # tower and hyper dependencies
 hyper = { workspace = true, features = ["http1", "http2", "client"], optional = true }
 hyper-util = { workspace = true, features = ["client", "client-legacy", "http1", "http2", "tokio", "service"] }
@@ -52,10 +47,7 @@ hyper-body = { workspace = true }
 # SSL
 rustls = { workspace = true, default-features = false, optional = true }
 rustls-pemfile = { workspace = true }
-webpki = { workspace = true, optional = true }
 hyper-rustls = { workspace = true, default-features = false, features = ["rustls-native-certs"], optional = true }
-hyper-tls = { workspace = true, optional = true }
-tokio-native-tls = { workspace = true, optional = true }
 # tracing and telemetry
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }

--- a/openapi/templates/default/Cargo.mustache
+++ b/openapi/templates/default/Cargo.mustache
@@ -10,14 +10,12 @@ path = "src/lib.rs"
 [features]
 default = [ "tower-client-rls", "tower-trace" ]
 actix-server = [ "actix" ]
-actix-client = [ "actix", "actix-web-opentelemetry", "awc" ]
 actix = [ "actix-web", "rustls" ]
-tower-client-rls = [ "tower-client", "rustls_feat" ]
-tower-client-tls = [ "tower-client", "hyper_tls_feat" ]
+tower-client-rls = [ "tower-client", "rustls_aws_lc_rs" ]
 tower-client = [ "tower-hyper" ]
 tower-hyper = [ "hyper", "tower", "tower-http", "http-body", "futures", "pin-project", "tokio" ]
-hyper_tls_feat = [ "hyper-tls", "tokio-native-tls" ]
-rustls_feat = [ "rustls", "webpki", "hyper-rustls" ]
+rustls_feat = [ "rustls", "hyper-rustls" ]
+rustls_aws_lc_rs = ["rustls_feat", "rustls/aws-lc-rs", "hyper-rustls/aws-lc-rs"]
 tower-trace = [ "opentelemetry-jaeger", "tracing-opentelemetry", "opentelemetry", "opentelemetry-http", "tracing", "tracing-subscriber" ]
 
 [dependencies]
@@ -32,8 +30,6 @@ serde_urlencoded = "0.7"
 
 # actix dependencies
 actix-web = { version = "4.4.0", features = ["rustls-0_21"], optional = true }
-actix-web-opentelemetry = { version = "0.17.0", optional = true }
-awc = { version = "3.2.0", optional = true }
 
 # tower and hyper dependencies
 hyper = { version = "0.14.27", features = [ "client", "http1", "http2", "tcp", "stream" ], optional = true }
@@ -47,10 +43,7 @@ pin-project = { version = "1.1.3", optional = true }
 # SSL
 rustls = { version = "0.21.12", optional = true, features = [ "dangerous_configuration" ] }
 rustls-pemfile = "1.0.3"
-webpki = { version = "0.22.2", optional = true }
 hyper-rustls = { version = "0.24.1", optional = true }
-hyper-tls = { version = "0.5.0", optional = true }
-tokio-native-tls = { version = "0.3.1", optional = true }
 
 # tracing and telemetry
 opentelemetry-jaeger = { version = "0.21.0", features = ["rt-tokio-current-thread"], optional = true  }

--- a/openapi/templates/default/actix/mod.mustache
+++ b/openapi/templates/default/actix/mod.mustache
@@ -1,4 +1,2 @@
-#[cfg(feature = "actix-client")]
-pub mod client;
 #[cfg(feature = "actix-server")]
 pub mod server;

--- a/openapi/templates/default/lib.mustache
+++ b/openapi/templates/default/lib.mustache
@@ -16,9 +16,6 @@ pub mod tower {
 
 #[cfg(feature = "actix")]
 pub mod actix {
-    #[cfg(feature = "actix-client")]
-    pub use crate::clients::actix as client;
-
     #[cfg(feature = "actix-server")]
     pub use crate::apis::actix_server as server;
 }

--- a/openapi/templates/default/mod_clients.mustache
+++ b/openapi/templates/default/mod_clients.mustache
@@ -1,9 +1,2 @@
-#[cfg(feature = "actix-client")]
-pub mod actix;
 #[cfg(feature = "tower-client")]
 pub mod tower;
-
-// Enable once we move to rust-2021
-// #[cfg(all(feature = "tower-client-rls", feature = "tower-client-tls"))]
-// compile_error!("feature \"tower-client-rls\" and feature \"tower-client-tls\" cannot be enabled
-// at the same time");

--- a/openapi/templates/default/model.mustache
+++ b/openapi/templates/default/model.mustache
@@ -9,11 +9,12 @@ use crate::apis::{IntoOptVec, IntoVec};
 {{!-- for enum schemas --}}
 {{#isEnum}}
 /// {{{description}}}
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum {{{classname}}} {
 {{#allowableValues}}
 {{#enumVars}}
     #[serde(rename = "{{{value}}}")]
+    {{#-first}}#[default]{{/-first}}
     {{{name}}},
 {{/enumVars}}{{/allowableValues}}
 }
@@ -28,12 +29,6 @@ impl std::fmt::Display for {{{classname}}} {
             {{/allowableValues}}
         };
         write!(f, "{str_value}")
-    }
-}
-
-impl Default for {{{classname}}} {
-    fn default() -> Self {
-        Self::{{#allowableValues}}{{#enumVars}}{{#-first}}{{{name}}}{{/-first}}{{/enumVars}}{{/allowableValues}}
     }
 }
 
@@ -109,11 +104,12 @@ pub enum {{{classname}}} {
 {{#vars}}
 {{#isEnum}}
 {{#description}}/// {{{description}}}{{/description}}
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum {{{enumName}}} {
 {{#allowableValues}}
 {{#enumVars}}
     #[serde(rename = "{{{value}}}")]
+    {{#-first}}#[default]{{/-first}}
     {{{name}}},
 {{/enumVars}}
 {{/allowableValues}}
@@ -129,12 +125,6 @@ impl std::fmt::Display for {{{enumName}}} {
             {{/allowableValues}}
         };
         write!(f, "{str_value}")
-    }
-}
-
-impl Default for {{{enumName}}} {
-    fn default() -> Self {
-        Self::{{#allowableValues}}{{#enumVars}}{{#-first}}{{{name}}}{{/-first}}{{/enumVars}}{{/allowableValues}}
     }
 }
 

--- a/openapi/templates/default/tower-hyper/client/configuration.mustache
+++ b/openapi/templates/default/tower-hyper/client/configuration.mustache
@@ -4,7 +4,6 @@ pub type ReqBody = hyper_body::Body;
 
 pub use hyper::{body, Request, Response, Uri};
 
-#[cfg(all(not(feature = "tower-client-tls"), feature = "tower-client-rls"))]
 use hyper_rustls::ConfigBuilderExt;
 use std::{
     future::Future,
@@ -651,7 +650,7 @@ impl Service<Request<ReqBody>> for TlsReloadService {
 
 fn build_http_client(url: &mut url::Url, tls: &TlsMode) -> Result<HttpClientService, Error> {
     let insecure_skip_verify = url.scheme() == "https" && tls.certificate().is_none();
-    #[cfg(all(not(feature = "tower-client-tls"), feature = "tower-client-rls"))]
+
     let client = {
         match tls.certificate() {
             None => {
@@ -725,67 +724,6 @@ fn build_http_client(url: &mut url::Url, tls: &TlsMode) -> Result<HttpClientServ
                 http.enforce_http(false);
                 let connector =
                     hyper_rustls::HttpsConnector::from((http, std::sync::Arc::new(config)));
-                url.set_scheme("https").ok();
-                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                    .build(connector)
-            }
-        }
-    };
-    #[cfg(feature = "tower-client-tls")]
-    let client = {
-        match tls.certificate() {
-            None => {
-                let mut http = hyper_tls::HttpsConnector::new();
-                if url.scheme() == "https" {
-                    http.https_only(true);
-                }
-
-                let mut tls_builder = hyper_tls::native_tls::TlsConnector::builder();
-                tls_builder
-                    .danger_accept_invalid_certs(insecure_skip_verify)
-                    .danger_accept_invalid_hostnames(insecure_skip_verify);
-                match (tls.client_cert(), tls.client_key()) {
-                    (Some(cert_bytes), Some(key_bytes)) => {
-                        let identity =
-                            hyper_tls::native_tls::Identity::from_pkcs8(cert_bytes, key_bytes)
-                                .map_err(|_| Error::ClientIdentity)?;
-                        tls_builder.identity(identity);
-                    }
-                    (None, None) => {}
-                    _ => return Err(Error::ClientIdentity),
-                }
-                let tls = tls_builder.build().map_err(|_| Error::TlsConnector)?;
-                let tls = tokio_native_tls::TlsConnector::from(tls);
-
-                let connector = hyper_tls::HttpsConnector::from((http, tls));
-                hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
-                    .build(connector)
-            }
-            Some(bytes) => {
-                let certificate = hyper_tls::native_tls::Certificate::from_pem(bytes)
-                    .map_err(|_| Error::Certificate)?;
-
-                let mut tls_builder = hyper_tls::native_tls::TlsConnector::builder();
-                tls_builder
-                    .add_root_certificate(certificate)
-                    .danger_accept_invalid_hostnames(insecure_skip_verify)
-                    .disable_built_in_roots(true);
-                match (tls.client_cert(), tls.client_key()) {
-                    (Some(cert_bytes), Some(key_bytes)) => {
-                        let identity =
-                            hyper_tls::native_tls::Identity::from_pkcs8(cert_bytes, key_bytes)
-                                .map_err(|_| Error::ClientIdentity)?;
-                        tls_builder.identity(identity);
-                    }
-                    (None, None) => {}
-                    _ => return Err(Error::ClientIdentity),
-                }
-                let tls = tls_builder.build().map_err(|_| Error::TlsConnector)?;
-                let tls = tokio_native_tls::TlsConnector::from(tls);
-
-                let mut http = hyper_tls::HttpsConnector::new();
-                http.https_only(true);
-                let connector = hyper_tls::HttpsConnector::from((http, tls));
                 url.set_scheme("https").ok();
                 hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new())
                     .build(connector)
@@ -1155,10 +1093,9 @@ where
     }
 }
 
-#[cfg(all(feature = "tower-client-rls", not(feature = "tower-client-tls")))]
 #[derive(Debug)]
 struct NoCertificateVerification {}
-#[cfg(all(feature = "tower-client-rls", not(feature = "tower-client-tls")))]
+
 impl rustls::client::danger::ServerCertVerifier for NoCertificateVerification {
     fn verify_server_cert(
         &self,

--- a/shell.nix
+++ b/shell.nix
@@ -45,7 +45,6 @@ mkShellNoCC {
     nixpkgs-fmt
     nix
     openapi-generator-cli
-    openssl
     pkg-config
     utillinux
     which

--- a/utils/event-consumer/Cargo.toml
+++ b/utils/event-consumer/Cargo.toml
@@ -5,9 +5,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["rls-ring"]
+default = ["rls-aws-lc-rs"]
 rls-aws-lc-rs = ["async-nats/aws-lc-rs"]
-rls-ring = ["async-nats/ring"]
 
 [dependencies]
 async-nats = { workspace = true, default-features = false }

--- a/utils/event-consumer/src/consumer.rs
+++ b/utils/event-consumer/src/consumer.rs
@@ -27,6 +27,7 @@ pub enum ConsumerError {
 }
 
 /// A message received from NATS, abstracting over JetStream and Core NATS delivery.
+#[allow(clippy::large_enum_variant)]
 pub enum UnifiedMessage {
     /// A JetStream message that must be ACKed or NAKed by the caller.
     JetStream(async_nats::jetstream::Message),

--- a/utils/pstor-usage/src/simulation.rs
+++ b/utils/pstor-usage/src/simulation.rs
@@ -170,7 +170,7 @@ impl Simulation {
         // create some pools as backing for the volumes
         let four_mb = 4096 * 1024;
         let mut volume_size = args.volume_size;
-        if (volume_size % four_mb) != 0 {
+        if !volume_size.is_multiple_of(four_mb) {
             volume_size += four_mb - (volume_size % four_mb);
         }
         let pools = if args.volumes > 0 && args.volume_samples > 0 {

--- a/utils/pstor/src/etcd_keep_alive.rs
+++ b/utils/pstor/src/etcd_keep_alive.rs
@@ -493,6 +493,7 @@ impl LeaseLockKeeperClocking<Locking> for EtcdSingletonLock {
 #[async_trait::async_trait]
 impl LeaseLockKeeperClocking<Locked> for EtcdSingletonLock {
     #[tracing::instrument(skip(self, state), err)]
+    #[allow(clippy::result_large_err)]
     async fn clock(&mut self, state: Locked) -> LockStatesResult {
         tracing::info!(
             lock.name = %self.service_name,

--- a/utils/pstor/src/etcd_watcher.rs
+++ b/utils/pstor/src/etcd_watcher.rs
@@ -348,7 +348,7 @@ impl<Ctx: Send + Sync + 'static> EtcdWatchRunner<Ctx> {
         mut attempts: u32,
         request: &mut tokio::sync::mpsc::UnboundedReceiver<WatchRequest<Ctx>>,
     ) -> WatchState {
-        if attempts % 10 == 0 {
+        if attempts.is_multiple_of(10) {
             tracing::warn!("Starting etcd watch stream reconnection loop, attempt: {attempts}");
         }
 

--- a/utils/utils-lib/Cargo.toml
+++ b/utils/utils-lib/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-default = ["rls-ring"]
+default = ["rls"]
 rls = ["event-publisher/rls-aws-lc-rs"]
-rls-ring = ["event-publisher/rls-ring"]
 
 [dependencies]
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }


### PR DESCRIPTION
    build: switch to rustls for coming fips feature
    
    Drops hyper-client-tls feature and all related tls feats.
    This was used to build the windows kubectl-client but the rls build
    now works fine for windows targets, so let's drop it to avoid depending
    on the openssl, and it's also good to keep things consistent across targets.
    
    Also drops ring and favours aws-lc-rs. This will eventually make it easier
    to use fips algorithms.
    Also removes openssl dependency for windows plugins.
    
---

    build: upgrade to rust 1.97.1
    
    This will be required to update kube to 0.99.0
