### PR TITLE
ci: run on arm cncf runners

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -1,6 +1,15 @@
 name: BDD CI
 on:
   workflow_call:
+    inputs:
+      io-engine-img:
+        required: false
+        description: "The io-engine image to use for the tests. If not provided, the default image will be used."
+        type: string
+      fio-spdk-img:
+        required: false
+        description: "The fio_spdk image to use for the tests. If not provided, the default image will be used."
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,8 +23,7 @@ jobs:
       matrix:
         runner:
           - cncf-ubuntu-16-64-x86
-          # can't run until we build io-engine arm images
-          # - cncf-ubuntu-16-64-arm
+          - cncf-ubuntu-16-64-arm
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -28,6 +36,15 @@ jobs:
           submodules: 'recursive'
 
       - run: echo "CI_REPORT_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+
+      - name: Set container image overrides
+        run: |
+          if [ -n "${{ inputs.io-engine-img }}" ]; then
+            echo "IO_ENGINE_IMAGE=${{ inputs.io-engine-img }}" >> $GITHUB_ENV
+          fi
+          if [ -n "${{ inputs.fio-spdk-img }}" ]; then
+            echo "FIO_SPDK_IMAGE=${{ inputs.fio-spdk-img }}" >> $GITHUB_ENV
+          fi
 
       - name: Configure Docker logging driver
         run: |

--- a/.github/workflows/io-engine.yml
+++ b/.github/workflows/io-engine.yml
@@ -1,0 +1,37 @@
+name: Validate io-engine image
+on:
+  workflow_dispatch:
+    inputs:
+      io-engine-img:
+        required: true
+        description: "The io-engine image to use for the tests. If not provided, the default image will be used."
+        type: string
+      fio-spdk-img:
+        required: true
+        description: "The fio_spdk image to use for the tests. If not provided, the default image will be used."
+        type: string
+
+jobs:
+  int-ci:
+    uses: ./.github/workflows/unit-int.yml
+    with:
+      io-engine-img: ${{ inputs.io-engine-img }}
+      fio-spdk-img: ${{ inputs.fio-spdk-img }}
+  bdd-ci:
+    uses: ./.github/workflows/bdd.yml
+    with:
+      io-engine-img: ${{ inputs.io-engine-img }}
+      fio-spdk-img: ${{ inputs.fio-spdk-img }}
+  bors-ci:
+    if: ${{ !cancelled() }}
+    needs:
+      - int-ci
+      - bdd-ci
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI succeeded
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            exit 1
+          fi
+          exit 0

--- a/.github/workflows/unit-int.yml
+++ b/.github/workflows/unit-int.yml
@@ -1,6 +1,15 @@
 name: Integration CI
 on:
   workflow_call:
+    inputs:
+      io-engine-img:
+        required: false
+        description: "The io-engine image to use for the tests. If not provided, the default image will be used."
+        type: string
+      fio-spdk-img:
+        required: false
+        description: "The fio_spdk image to use for the tests. If not provided, the default image will be used."
+        type: string
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,8 +23,7 @@ jobs:
       matrix:
         runner:
           - cncf-ubuntu-16-64-x86
-          # can't run until we build io-engine arm images
-          # - cncf-ubuntu-16-64-arm
+          - cncf-ubuntu-16-64-arm
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -28,6 +36,15 @@ jobs:
           submodules: 'recursive'
 
       - run: echo "CI_REPORT_START_DATE=$(date +"%Y-%m-%d %H:%M:%S")" >> $GITHUB_ENV
+
+      - name: Set container image overrides
+        run: |
+          if [ -n "${{ inputs.io-engine-img }}" ]; then
+            echo "IO_ENGINE_IMAGE=${{ inputs.io-engine-img }}" >> $GITHUB_ENV
+          fi
+          if [ -n "${{ inputs.fio-spdk-img }}" ]; then
+            echo "FIO_SPDK_IMAGE=${{ inputs.fio-spdk-img }}" >> $GITHUB_ENV
+          fi
 
       - name: Configure Docker logging driver
         run: |
@@ -58,6 +75,9 @@ jobs:
           sudo modprobe nvme_tcp
           # Check if nvme config is valid, otherwise apply it
           sudo ./utils/dependencies/scripts/nvme-conf.sh --check --apply --overwrite
+          # On the arm runners we have:
+          # -A INPUT -j REJECT --reject-with icmp-host-prohibited
+          sudo iptables -I INPUT 1 -p tcp -s 10.1.0.0/16 -d 10.1.0.1 --dport 8082 -m conntrack --ctstate NEW -j ACCEPT
 
       - name: Run Tests
         run: |

--- a/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
+++ b/control-plane/agents/src/bin/core/tests/volume/snapshot.rs
@@ -1,3 +1,4 @@
+#[cfg(target_arch = "x86_64")]
 use super::RECONCILE_TIMEOUT_SECS;
 use crate::volume::helpers::wait_node_online;
 use deployer_cluster::{Cluster, ClusterBuilder, FindVolumeRequest};
@@ -636,6 +637,7 @@ async fn unknown_snapshot_garbage_collector() {
 }
 
 #[tokio::test]
+#[cfg(target_arch = "x86_64")]
 async fn snapshot_upgrade() {
     let mb = 1024 * 1024;
     let gc_period = Duration::from_millis(200);

--- a/deployer/src/infra/fio_spdk.rs
+++ b/deployer/src/infra/fio_spdk.rs
@@ -6,7 +6,7 @@ impl ComponentAction for FioSpdk {
     fn configure(&self, options: &StartOptions, cfg: Builder) -> Result<Builder, Error> {
         Ok(if options.fio_spdk {
             cfg.add_container_spec(
-                ContainerSpec::from_image("fio-spdk", &utils::fio_spdk_image())
+                ContainerSpec::from_image("fio-spdk", &options.fio_spdk_image)
                     .with_entrypoint("tini")
                     .with_bind("/var/run/dpdk", "/var/run/dpdk")
                     .with_bind("/dev/vfio/vfio", "/dev/vfio/vfio")

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -161,6 +161,10 @@ pub struct StartOptions {
     #[clap(long, env = "IO_ENGINE_IMAGE", default_value = utils::io_engine_image())]
     pub io_engine_image: String,
 
+    /// Use the following docker image for the fio_spdk instances.
+    #[clap(long, env = "FIO_SPDK_IMAGE", default_value = utils::fio_spdk_image())]
+    pub fio_spdk_image: String,
+
     /// Use the following docker image for the io_engine instances.
     /// This is used for upgrade tests, where this is the older version.
     #[clap(long, env = "PREV_IO_ENGINE_IMAGE")]

--- a/tests/bdd/features/rebuild/test_log_based_rebuild.py
+++ b/tests/bdd/features/rebuild/test_log_based_rebuild.py
@@ -36,11 +36,11 @@ POOL_1_UUID = "4cc6ee64-7232-497d-a26f-38284a444980"
 POOL_2_UUID = "91a60318-bcfe-4e36-92cb-ddc7abf212ea"
 POOL_3_UUID = "4d471e62-ca17-44d1-a6d3-8820f6156c1a"
 POOL_4_UUID = "d5c5e3de-d77b-11ed-afa1-0242ac120002"
-VOLUME_SIZE = 494 * 1024 * 1024
-POOL_SIZE = 800 * 1024 * 1024
+VOLUME_SIZE = 200 * 1024 * 1024
+POOL_SIZE = 500 * 1024 * 1024
 NUM_VOLUME_REPLICAS = 3
 FAULTED_CHILD_WAIT_SECS = 2
-FIO_RUN = 7
+FIO_RUN = 5
 SLEEP_BEFORE_START = 1
 
 
@@ -184,6 +184,7 @@ def wait_child_faulted():
     for child in childlist:
         if child.state == ChildState("Faulted"):
             pytest.faulted_child_uri = child.uri
+            print(f"Faulted child found: {pytest.faulted_child_uri}")
     assert pytest.faulted_child_uri is not None, "Failed to find Faulted child!"
 
 

--- a/tests/bdd/features/snapshot/garbage-collection/test_garbage-collection.py
+++ b/tests/bdd/features/snapshot/garbage-collection/test_garbage-collection.py
@@ -1,5 +1,7 @@
 """Volume Snapshot garbage collection feature tests."""
 
+import os
+
 import pytest
 from common.apiclient import ApiClient
 from common.deployer import Deployer
@@ -46,11 +48,17 @@ def create_pool_disk_images():
 
 @pytest.fixture(scope="module")
 def setup(create_pool_disk_images):
+    tmo = 300
+    is_arm = os.uname().machine in ("arm64", "aarch64")
+    if is_arm:
+        # At least on the CI runners, the ARM64 machines are slower and the default timeout of 300ms
+        #  is not enough for the gRPC calls to complete.
+        tmo *= 2
     Deployer.start(
         io_engines=1,
         cache_period="50ms",
         reconcile_period="50ms",
-        request_timeout="300ms",
+        request_timeout=f"{tmo}ms",
         no_min_timeouts=True,
         io_engine_env="MAYASTOR_HB_INTERVAL_SEC=1",
     )


### PR DESCRIPTION
We have to disable the snapshot upgrade test, because the arm image was not available in the previous release.
On the ARM runner there's a rule preventing the containers from reaching the host; one of the tests (watcher) needs it, so we bypass it for port 8082. 
Also adds a new workflow (io-engine.yml) which makes testing the control-plane against specific image of the data-plane very easy.