### PR TITLE
build: use static CDN for naersk crates

### DIFF
--- a/nix/lib/rust.nix
+++ b/nix/lib/rust.nix
@@ -1,10 +1,25 @@
 { pkgs }:
 let
+  sources = import ../sources.nix;
   makeRustTarget = platform: platform.rust.rustcTargetSpec;
   static_target = makeRustTarget pkgs.pkgsStatic.stdenv.hostPlatform;
 in
 rec {
   inherit makeRustTarget;
+  naersk_package = channel: pkgs.callPackage sources.naersk {
+    rustc = channel.stable;
+    cargo = channel.stable;
+    # Rewrite crates.io API URLs to static CDN to avoid intermittent 403s
+    fetchurl = attrs@{ url, ... }:
+      let
+        m = builtins.match "https://crates\\.io/api/v1/crates/([^/]+)/([^/]+)/download" url;
+        resolvedUrl =
+          if m != null then
+            "https://static.crates.io/crates/${builtins.elemAt m 0}/${builtins.elemAt m 0}-${builtins.elemAt m 1}.crate"
+          else url;
+      in
+      pkgs.fetchurl (attrs // { url = resolvedUrl; });
+  };
   rust_default = { override ? { } }: rec {
     nightly_pkg = pkgs.rust-bin.nightly."2026-07-16";
     stable_pkg = pkgs.rust-bin.stable."1.97.1";

--- a/nix/pkgs/control-plane/cargo-project.nix
+++ b/nix/pkgs/control-plane/cargo-project.nix
@@ -37,10 +37,7 @@ let
     rustc = stable_channel.rustc;
     cargo = stable_channel.cargo;
   };
-  naersk = pkgs.callPackage sources.naersk {
-    rustc = stable_channel.rustc;
-    cargo = stable_channel.cargo;
-  };
+  naersk = channel.naersk_package channel.default;
   LIBCLANG_PATH = "${llvmPackages.libclang.lib}/lib";
   PROTOC = "${protobuf}/bin/protoc";
   PROTOC_INCLUDE = "${protobuf}/include";


### PR DESCRIPTION
Use static.crates.io for naersk crate downloads.