### PR TITLE
feat(pool): add GetPoolHealth gRPC for disk SMART data

### DIFF
--- a/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/mod.rs
@@ -9,8 +9,8 @@ pub(crate) use client::*;
 
 use crate::controller::io_engine::types::{
     CreateNexusSnapshot, CreateNexusSnapshotResp, CreateSnapRebuild, DestroySnapRebuild,
-    ListSnapRebuild, ListSnapRebuildRsp, ProbePoolRequest, ProbePoolResponse, RebuildHistoryResp,
-    SnapshotRebuild,
+    GetPoolHealthRequest, GetPoolHealthResponse, ListSnapRebuild, ListSnapRebuildRsp,
+    ProbePoolRequest, ProbePoolResponse, RebuildHistoryResp, SnapshotRebuild,
 };
 use agents::errors::SvcError;
 use stor_port::{
@@ -74,6 +74,11 @@ pub(crate) trait PoolApi {
     async fn clear_errors(&self, request: &ClearErrorsRequest) -> Result<PoolState, SvcError>;
     /// Probe pool's disks for errors.
     async fn probe_pool(&self, request: &ProbePoolRequest) -> Result<ProbePoolResponse, SvcError>;
+    /// Get pool health (SMART) information.
+    async fn get_pool_health(
+        &self,
+        request: &GetPoolHealthRequest,
+    ) -> Result<GetPoolHealthResponse, SvcError>;
 }
 
 #[async_trait]

--- a/control-plane/agents/src/bin/core/controller/io_engine/types.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/types.rs
@@ -143,3 +143,15 @@ pub(crate) struct ProbeDiskInfo {
     #[allow(unused)]
     pub(crate) error: Vec<PoolDiskError>,
 }
+
+/// Get pool health request (forwarded to io-engine).
+#[derive(Debug, Clone)]
+pub(crate) struct GetPoolHealthRequest {
+    /// Name of the pool.
+    pub(crate) pool_name: String,
+    /// Optional UUID of the pool.
+    pub(crate) pool_uuid: Option<String>,
+}
+
+/// Pool health response from io-engine.
+pub(crate) type GetPoolHealthResponse = transport::GetPoolHealthResponse;

--- a/control-plane/agents/src/bin/core/controller/io_engine/v0/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v0/pool.rs
@@ -1,5 +1,7 @@
 use super::translation::{rpc_pool_to_agent, AgentToIoEngine};
-use crate::controller::io_engine::types::{ProbePoolRequest, ProbePoolResponse};
+use crate::controller::io_engine::types::{
+    GetPoolHealthRequest, GetPoolHealthResponse, ProbePoolRequest, ProbePoolResponse,
+};
 use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::io_engine::Null;
 use stor_port::{
@@ -102,6 +104,17 @@ impl crate::controller::io_engine::PoolApi for super::RpcClient {
         Err(SvcError::GrpcRequestError {
             resource: ResourceKind::Pool,
             request: "probe_pool".to_string(),
+            source: tonic::Status::unimplemented("not supported on v0"),
+        })
+    }
+
+    async fn get_pool_health(
+        &self,
+        _request: &GetPoolHealthRequest,
+    ) -> Result<GetPoolHealthResponse, SvcError> {
+        Err(SvcError::GrpcRequestError {
+            resource: ResourceKind::Pool,
+            request: "get_pool_health".to_string(),
             source: tonic::Status::unimplemented("not supported on v0"),
         })
     }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/pool.rs
@@ -1,5 +1,8 @@
 use super::translation::{rpc_pool_to_agent, AgentToIoEngine};
-use crate::controller::io_engine::types::{ProbePoolRequest, ProbePoolResponse};
+use crate::controller::io_engine::{
+    translation::IoEngineToAgent,
+    types::{GetPoolHealthRequest, GetPoolHealthResponse, ProbePoolRequest, ProbePoolResponse},
+};
 use agents::errors::{GrpcRequest as GrpcRequestError, SvcError};
 use rpc::v1::pool::ListPoolOptions;
 use stor_port::{
@@ -145,5 +148,20 @@ impl crate::controller::io_engine::PoolApi for super::RpcClient {
                 request: "probe_pool",
             })?;
         Ok(probed.into_inner().into())
+    }
+
+    async fn get_pool_health(
+        &self,
+        request: &GetPoolHealthRequest,
+    ) -> Result<GetPoolHealthResponse, SvcError> {
+        let response = self
+            .pool()
+            .get_pool_health(request.to_rpc())
+            .await
+            .context(GrpcRequestError {
+                resource: ResourceKind::Pool,
+                request: "get_pool_health",
+            })?;
+        Ok(response.into_inner().to_agent())
     }
 }

--- a/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
+++ b/control-plane/agents/src/bin/core/controller/io_engine/v1/translation.rs
@@ -2,7 +2,8 @@ use crate::controller::io_engine::{
     translation::{IoEngineToAgent, TryIoEngineToAgent},
     types::{
         CreateNexusSnapReplDescr, CreateNexusSnapshot, CreateNexusSnapshotReplicaStatus,
-        CreateNexusSnapshotResp, ProbeDiskInfo, ProbePoolRequest, ProbePoolResponse,
+        CreateNexusSnapshotResp, GetPoolHealthRequest, GetPoolHealthResponse, ProbeDiskInfo,
+        ProbePoolRequest, ProbePoolResponse,
     },
 };
 use agents::errors::SvcError;
@@ -1098,6 +1099,116 @@ impl From<rpc::v1::pool::ProbeDiskInfo> for ProbeDiskInfo {
         });
         Self {
             error: errors.collect(),
+        }
+    }
+}
+
+impl AgentToIoEngine for GetPoolHealthRequest {
+    type IoEngineMessage = v1::pool::GetPoolHealthRequest;
+    fn to_rpc(&self) -> Self::IoEngineMessage {
+        v1::pool::GetPoolHealthRequest {
+            name: self.pool_name.clone(),
+            uuid: self.pool_uuid.clone(),
+        }
+    }
+}
+
+impl IoEngineToAgent for v1::pool::GetPoolHealthResponse {
+    type AgentMessage = GetPoolHealthResponse;
+    fn to_agent(&self) -> Self::AgentMessage {
+        GetPoolHealthResponse {
+            disks: self.disks.iter().map(|d| d.to_agent()).collect(),
+        }
+    }
+}
+
+impl IoEngineToAgent for v1::pool::DiskHealth {
+    type AgentMessage = transport::DiskHealth;
+    fn to_agent(&self) -> Self::AgentMessage {
+        transport::DiskHealth {
+            disk_uri: self.disk_uri.clone(),
+            supported: self.supported,
+            health: self.health.as_ref().map(|h| h.to_agent()),
+            error: self.error.clone(),
+        }
+    }
+}
+
+impl IoEngineToAgent for v1::pool::DeviceHealth {
+    type AgentMessage = transport::DeviceHealth;
+    fn to_agent(&self) -> Self::AgentMessage {
+        transport::DeviceHealth {
+            critical_warning: self.critical_warning,
+            healthy: self.healthy,
+            temperature_celsius: self.temperature_celsius,
+            available_spare_percent: self.available_spare_percent,
+            available_spare_threshold_percent: self.available_spare_threshold_percent,
+            percentage_used: self.percentage_used,
+            data_units_read: self.data_units_read,
+            data_units_written: self.data_units_written,
+            host_reads: self.host_reads,
+            host_writes: self.host_writes,
+            controller_busy_minutes: self.controller_busy_minutes,
+            power_cycles: self.power_cycles,
+            power_on_hours: self.power_on_hours,
+            unsafe_shutdowns: self.unsafe_shutdowns,
+            media_errors: self.media_errors,
+            num_error_log_entries: self.num_error_log_entries,
+            identity: self.identity.as_ref().map(|i| i.to_agent()),
+            smart_attributes: self.smart_attributes.iter().map(|a| a.to_agent()).collect(),
+            error_log_entries: self
+                .error_log_entries
+                .iter()
+                .map(|e| e.to_agent())
+                .collect(),
+        }
+    }
+}
+
+impl IoEngineToAgent for v1::pool::DeviceIdentity {
+    type AgentMessage = transport::DeviceIdentity;
+    fn to_agent(&self) -> Self::AgentMessage {
+        transport::DeviceIdentity {
+            model: self.model.clone(),
+            model_family: self.model_family.clone(),
+            serial_number: self.serial_number.clone(),
+            firmware_revision: self.firmware_revision.clone(),
+            wwn: self.wwn.clone(),
+            capacity_bytes: self.capacity_bytes,
+            logical_sector_size: self.logical_sector_size,
+            physical_sector_size: self.physical_sector_size,
+            rotation_rate: self.rotation_rate,
+            form_factor: self.form_factor.clone(),
+            transport: self.transport.clone(),
+            link_speed: self.link_speed.clone(),
+        }
+    }
+}
+
+impl IoEngineToAgent for v1::pool::SmartAttribute {
+    type AgentMessage = transport::SmartAttribute;
+    fn to_agent(&self) -> Self::AgentMessage {
+        transport::SmartAttribute {
+            id: self.id,
+            name: self.name.clone(),
+            value: self.value,
+            worst: self.worst,
+            threshold: self.threshold,
+            raw_value: self.raw_value,
+        }
+    }
+}
+
+impl IoEngineToAgent for v1::pool::NvmeErrorLogEntry {
+    type AgentMessage = transport::NvmeErrorLogEntry;
+    fn to_agent(&self) -> Self::AgentMessage {
+        transport::NvmeErrorLogEntry {
+            error_count: self.error_count,
+            submission_queue_id: self.submission_queue_id,
+            command_id: self.command_id,
+            status_field: self.status_field,
+            lba: self.lba,
+            namespace_id: self.namespace_id,
         }
     }
 }

--- a/control-plane/agents/src/bin/core/node/wrapper.rs
+++ b/control-plane/agents/src/bin/core/node/wrapper.rs
@@ -2,7 +2,8 @@ use crate::{
     controller::{
         io_engine::{
             types::{
-                CreateNexusSnapshot, CreateNexusSnapshotResp, ProbePoolRequest, ProbePoolResponse,
+                CreateNexusSnapshot, CreateNexusSnapshotResp, GetPoolHealthRequest,
+                GetPoolHealthResponse, ProbePoolRequest, ProbePoolResponse,
             },
             GrpcClient, GrpcClientLocked, GrpcContext, HostApi, NexusApi, NexusChildActionApi,
             NexusChildApi, NexusShareApi, NexusSnapshotApi, PoolApi, ReplicaApi,
@@ -1366,6 +1367,25 @@ impl PoolApi for Arc<tokio::sync::RwLock<NodeWrapper>> {
             {
                 tracing::warn!(node=%request.import.node, pool=%request.import.id, "Node does not implement probing...");
                 Ok(ProbePoolResponse::new_unimpl())
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    async fn get_pool_health(
+        &self,
+        request: &GetPoolHealthRequest,
+    ) -> Result<GetPoolHealthResponse, SvcError> {
+        let dataplane = self
+            .grpc_client_locked(MessageIdVs::GetPoolHealth.into())
+            .await?;
+        match dataplane.get_pool_health(request).await {
+            Ok(resp) => Ok(resp),
+            Err(SvcError::GrpcRequestError { source, .. })
+                if source.code() == tonic::Code::Unimplemented =>
+            {
+                tracing::warn!(pool=%request.pool_name, "Node does not implement pool health...");
+                Ok(GetPoolHealthResponse::default())
             }
             Err(error) => Err(error),
         }

--- a/control-plane/agents/src/bin/core/pool/service.rs
+++ b/control-plane/agents/src/bin/core/pool/service.rs
@@ -29,14 +29,18 @@ use stor_port::{
     types::v0::{
         store::{pool::PoolSpec, replica::ReplicaSpec},
         transport::{
-            CreatePool, CreateReplica, DestroyPool, DestroyReplica, ExpandPool, Filter, GetPools,
-            GetReplicas, LabelPool, NodeId, Pool, PoolDeleteResult, PoolId, Replica, ResizeReplica,
-            ShareReplica, UnlabelPool, UnshareReplica, VolumeId,
+            CreatePool, CreateReplica, DestroyPool, DestroyReplica, ExpandPool, Filter,
+            GetPoolHealthResponse, GetPools, GetReplicas, LabelPool, NodeId, Pool,
+            PoolDeleteResult, PoolId, Replica, ResizeReplica, ShareReplica, UnlabelPool,
+            UnshareReplica, VolumeId,
         },
     },
 };
 
-use crate::controller::resources::{operations::ResourceCordon, ResourceUid};
+use crate::controller::{
+    io_engine::{types::GetPoolHealthRequest, PoolApi},
+    resources::{operations::ResourceCordon, ResourceUid},
+};
 use grpc::operations::pool::traits::{ClearErrorsRequest, PoolCordonRequest, PoolCreateError};
 use snafu::OptionExt;
 
@@ -133,6 +137,13 @@ impl PoolOperations for Service {
         let service = self.clone();
         let pool = Context::spawn(async move { service.clear_errors(request).await }).await??;
         Ok(pool)
+    }
+
+    async fn get_pool_health(&self, pool_id: &PoolId) -> Result<GetPoolHealthResponse, ReplyError> {
+        let pool_id = pool_id.clone();
+        let service = self.clone();
+        let health = Context::spawn(async move { service.pool_health(&pool_id).await }).await??;
+        Ok(health)
     }
 }
 
@@ -458,5 +469,25 @@ impl Service {
         let mut guarded_pool = self.specs().guarded_pool(&request.pool_id).await?;
         let pool = guarded_pool.clear_errors(&self.registry, &request).await?;
         Ok(pool)
+    }
+
+    /// Get health information for the disks backing the specified pool.
+    #[tracing::instrument(level = "info", skip(self), err, fields(pool.id = %pool_id))]
+    async fn pool_health(&self, pool_id: &PoolId) -> Result<GetPoolHealthResponse, SvcError> {
+        let pool = self.registry.ctrl_pool(pool_id).await?;
+        let node_id = pool.node();
+        let node = self.registry.node_wrapper(&node_id).await?;
+
+        let pool_uuid = pool
+            .state()
+            .and_then(|s| s.uuid.as_ref())
+            .map(|u| u.to_string());
+
+        let request = GetPoolHealthRequest {
+            pool_name: pool_id.to_string(),
+            pool_uuid,
+        };
+
+        node.get_pool_health(&request).await
     }
 }

--- a/control-plane/grpc/proto/v1/pool/pool.proto
+++ b/control-plane/grpc/proto/v1/pool/pool.proto
@@ -628,4 +628,84 @@ service PoolGrpc {
 
   // Clear error counters and alerts
   rpc ClearErrors (ClearErrorsRequest) returns (ClearErrorsReply) {}
+
+  // Get SMART / health information for the disk(s) backing a pool
+  rpc GetPoolHealth (GetPoolHealthRequest) returns (GetPoolHealthReply) {}
+}
+
+message GetPoolHealthRequest {
+  string pool_id = 1;
+}
+
+message GetPoolHealthReply {
+  oneof reply {
+    PoolHealthResponse health = 1;
+    common.ReplyError error = 2;
+  }
+}
+
+message PoolHealthResponse {
+  repeated DiskHealthInfo disks = 1;
+}
+
+message DiskHealthInfo {
+  string disk_uri = 1;
+  bool supported = 2;
+  optional DeviceHealthInfo health = 3;
+  optional string error = 4;
+}
+
+message DeviceHealthInfo {
+  uint32 critical_warning = 1;
+  bool healthy = 2;
+  optional sint32 temperature_celsius = 3;
+  optional uint32 available_spare_percent = 4;
+  optional uint32 available_spare_threshold_percent = 5;
+  optional uint32 percentage_used = 6;
+  optional uint64 data_units_read = 7;
+  optional uint64 data_units_written = 8;
+  optional uint64 host_reads = 9;
+  optional uint64 host_writes = 10;
+  optional uint64 controller_busy_minutes = 11;
+  optional uint64 power_cycles = 12;
+  optional uint64 power_on_hours = 13;
+  optional uint64 unsafe_shutdowns = 14;
+  optional uint64 media_errors = 15;
+  optional uint64 num_error_log_entries = 16;
+  optional DeviceIdentityInfo identity = 17;
+  repeated SmartAttributeInfo smart_attributes = 18;
+  repeated NvmeErrorLogEntryInfo error_log_entries = 19;
+}
+
+message DeviceIdentityInfo {
+  optional string model = 1;
+  optional string model_family = 2;
+  optional string serial_number = 3;
+  optional string firmware_revision = 4;
+  optional string wwn = 5;
+  optional uint64 capacity_bytes = 6;
+  optional uint32 logical_sector_size = 7;
+  optional uint32 physical_sector_size = 8;
+  optional uint32 rotation_rate = 9;
+  optional string form_factor = 10;
+  optional string transport = 11;
+  optional string link_speed = 12;
+}
+
+message SmartAttributeInfo {
+  uint32 id = 1;
+  string name = 2;
+  uint32 value = 3;
+  uint32 worst = 4;
+  uint32 threshold = 5;
+  uint64 raw_value = 6;
+}
+
+message NvmeErrorLogEntryInfo {
+  uint64 error_count = 1;
+  uint32 submission_queue_id = 2;
+  optional uint32 command_id = 3;
+  uint32 status_field = 4;
+  optional uint64 lba = 5;
+  optional uint32 namespace_id = 6;
 }

--- a/control-plane/grpc/src/operations/pool/client.rs
+++ b/control-plane/grpc/src/operations/pool/client.rs
@@ -8,15 +8,17 @@ use crate::{
     },
     pool::{
         self, clear_errors_reply, cordon_pool_reply, create_pool_reply, destroy_pool_reply,
-        expand_pool_reply, get_pools_reply, get_pools_request, label_pool_reply,
-        pool_grpc_client::PoolGrpcClient, unlabel_pool_reply, CordonPoolRequest, ExpandPoolRequest,
-        GetPoolsRequest,
+        expand_pool_reply, get_pool_health_reply, get_pools_reply, get_pools_request,
+        label_pool_reply, pool_grpc_client::PoolGrpcClient, unlabel_pool_reply, CordonPoolRequest,
+        ExpandPoolRequest, GetPoolsRequest,
     },
 };
 use std::{convert::TryFrom, ops::Deref};
 use stor_port::{
     transport_api::{v0::Pools, ReplyError, ResourceKind, TimeoutOptions},
-    types::v0::transport::{Filter, MessageIdVs, Pool, PoolDeleteResult},
+    types::v0::transport::{
+        Filter, GetPoolHealthResponse, MessageIdVs, Pool, PoolDeleteResult, PoolId,
+    },
 };
 use tonic::transport::Uri;
 
@@ -205,6 +207,21 @@ impl PoolOperations for PoolClient {
             Some(reply) => match reply {
                 clear_errors_reply::Reply::Pool(pool) => Ok(Pool::try_from(pool)?),
                 clear_errors_reply::Reply::Error(err) => Err(err.into()),
+            },
+            None => Err(ReplyError::invalid_response(ResourceKind::Pool)),
+        }
+    }
+
+    #[tracing::instrument(name = "PoolClient::get_pool_health", level = "info", skip(self), err)]
+    async fn get_pool_health(&self, pool_id: &PoolId) -> Result<GetPoolHealthResponse, ReplyError> {
+        let request = pool::GetPoolHealthRequest {
+            pool_id: pool_id.to_string(),
+        };
+        let response = self.client().get_pool_health(request).await?.into_inner();
+        match response.reply {
+            Some(reply) => match reply {
+                get_pool_health_reply::Reply::Health(health) => Ok(health.into()),
+                get_pool_health_reply::Reply::Error(err) => Err(err.into()),
             },
             None => Err(ReplyError::invalid_response(ResourceKind::Pool)),
         }

--- a/control-plane/grpc/src/operations/pool/mod.rs
+++ b/control-plane/grpc/src/operations/pool/mod.rs
@@ -173,6 +173,14 @@ mod test {
             ) -> Result<Pool, ReplyError> {
                 todo!()
             }
+
+            async fn get_pool_health(
+                &self,
+                _pool_id: &stor_port::types::v0::transport::PoolId,
+            ) -> Result<stor_port::types::v0::transport::GetPoolHealthResponse, ReplyError>
+            {
+                todo!()
+            }
         }
     }
 }

--- a/control-plane/grpc/src/operations/pool/server.rs
+++ b/control-plane/grpc/src/operations/pool/server.rs
@@ -3,12 +3,13 @@ use crate::{
     operations::pool::traits::PoolOperations,
     pool::{
         self, clear_errors_reply, cordon_pool_reply, create_pool_reply, expand_pool_reply,
-        get_pools_reply, label_pool_reply,
+        get_pool_health_reply, get_pools_reply, label_pool_reply,
         pool_grpc_server::{PoolGrpc, PoolGrpcServer},
         unlabel_pool_reply, ClearErrorsReply, ClearErrorsRequest, CordonPoolReply,
         CordonPoolRequest, CreatePoolReply, CreatePoolRequest, DestroyPoolReply,
-        DestroyPoolRequest, ExpandPoolReply, ExpandPoolRequest, GetPoolsReply, GetPoolsRequest,
-        LabelPoolReply, LabelPoolRequest, UnlabelPoolReply, UnlabelPoolRequest,
+        DestroyPoolRequest, ExpandPoolReply, ExpandPoolRequest, GetPoolHealthReply,
+        GetPoolHealthRequest, GetPoolsReply, GetPoolsRequest, LabelPoolReply, LabelPoolRequest,
+        UnlabelPoolReply, UnlabelPoolRequest,
     },
 };
 use std::sync::Arc;
@@ -180,6 +181,21 @@ impl PoolGrpc for PoolServer {
             })),
             Err(err) => Ok(Response::new(ClearErrorsReply {
                 reply: Some(clear_errors_reply::Reply::Error(err.into())),
+            })),
+        }
+    }
+
+    async fn get_pool_health(
+        &self,
+        request: Request<GetPoolHealthRequest>,
+    ) -> Result<tonic::Response<GetPoolHealthReply>, tonic::Status> {
+        let request = request.into_inner();
+        match self.service.get_pool_health(&request.pool_id.into()).await {
+            Ok(health) => Ok(Response::new(GetPoolHealthReply {
+                reply: Some(get_pool_health_reply::Reply::Health(health.into())),
+            })),
+            Err(err) => Ok(Response::new(GetPoolHealthReply {
+                reply: Some(get_pool_health_reply::Reply::Error(err.into())),
             })),
         }
     }

--- a/control-plane/grpc/src/operations/pool/traits.rs
+++ b/control-plane/grpc/src/operations/pool/traits.rs
@@ -19,11 +19,13 @@ use stor_port::{
             PoolUsage, SnapshotPolicy, SpareReplica, UnwindSpare, POOL_BS_CLUSTER_SIZE_DEFAULT,
         },
         transport::{
-            CreatePool, CtrlPoolState, DestroyPool, DiskInfo, ExpandPool, Filter, LabelPool,
-            NodeId, Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolDef, PoolDeleteResult,
-            PoolDeviceUri, PoolDiag, PoolDiskError, PoolError, PoolErrorCode, PoolErrorInfo,
-            PoolId, PoolState, PoolStatus, ReplicaId, SnapshotLossDetail, SnapshotLossInfo,
-            UnlabelPool, VolumeId, VolumeLossDetail, VolumeLossInfo,
+            CreatePool, CtrlPoolState, DestroyPool, DeviceHealth, DeviceIdentity, DiskHealth,
+            DiskInfo, ExpandPool, Filter, GetPoolHealthResponse, LabelPool, NodeId,
+            NvmeErrorLogEntry, Pool, PoolAlert, PoolAlertStatus, PoolAlerts, PoolDef,
+            PoolDeleteResult, PoolDeviceUri, PoolDiag, PoolDiskError, PoolError, PoolErrorCode,
+            PoolErrorInfo, PoolId, PoolState, PoolStatus, ReplicaId, SmartAttribute,
+            SnapshotLossDetail, SnapshotLossInfo, UnlabelPool, VolumeId, VolumeLossDetail,
+            VolumeLossInfo,
         },
     },
     IntoOption, IntoVec, TryIntoOption, TryIntoVec,
@@ -144,6 +146,8 @@ pub trait PoolOperations: Send + Sync {
     async fn expand(&self, info: &dyn ExpandPoolInfo) -> Result<Pool, ReplyError>;
     /// Clears runtime errors from the specified pool.
     async fn clear_errors(&self, request: &ClearErrorsRequest) -> Result<Pool, ReplyError>;
+    /// Get pool health (SMART) information.
+    async fn get_pool_health(&self, pool_id: &PoolId) -> Result<GetPoolHealthResponse, ReplyError>;
 }
 
 impl TryFrom<pool::PoolDefinition> for PoolSpec {
@@ -1674,5 +1678,187 @@ impl TryFrom<pool::PoolDeleteResult> for PoolDeleteResult {
             volume_loss,
             snapshot_loss,
         })
+    }
+}
+
+// ── GetPoolHealth conversions (control-plane proto <-> transport) ──
+
+impl From<GetPoolHealthResponse> for pool::PoolHealthResponse {
+    fn from(value: GetPoolHealthResponse) -> Self {
+        Self {
+            disks: value.disks.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<pool::PoolHealthResponse> for GetPoolHealthResponse {
+    fn from(value: pool::PoolHealthResponse) -> Self {
+        Self {
+            disks: value.disks.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<DiskHealth> for pool::DiskHealthInfo {
+    fn from(d: DiskHealth) -> Self {
+        Self {
+            disk_uri: d.disk_uri,
+            supported: d.supported,
+            health: d.health.map(Into::into),
+            error: d.error,
+        }
+    }
+}
+
+impl From<pool::DiskHealthInfo> for DiskHealth {
+    fn from(d: pool::DiskHealthInfo) -> Self {
+        Self {
+            disk_uri: d.disk_uri,
+            supported: d.supported,
+            health: d.health.map(Into::into),
+            error: d.error,
+        }
+    }
+}
+
+impl From<DeviceHealth> for pool::DeviceHealthInfo {
+    fn from(h: DeviceHealth) -> Self {
+        Self {
+            critical_warning: h.critical_warning,
+            healthy: h.healthy,
+            temperature_celsius: h.temperature_celsius,
+            available_spare_percent: h.available_spare_percent,
+            available_spare_threshold_percent: h.available_spare_threshold_percent,
+            percentage_used: h.percentage_used,
+            data_units_read: h.data_units_read,
+            data_units_written: h.data_units_written,
+            host_reads: h.host_reads,
+            host_writes: h.host_writes,
+            controller_busy_minutes: h.controller_busy_minutes,
+            power_cycles: h.power_cycles,
+            power_on_hours: h.power_on_hours,
+            unsafe_shutdowns: h.unsafe_shutdowns,
+            media_errors: h.media_errors,
+            num_error_log_entries: h.num_error_log_entries,
+            identity: h.identity.map(Into::into),
+            smart_attributes: h.smart_attributes.into_iter().map(Into::into).collect(),
+            error_log_entries: h.error_log_entries.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<pool::DeviceHealthInfo> for DeviceHealth {
+    fn from(h: pool::DeviceHealthInfo) -> Self {
+        Self {
+            critical_warning: h.critical_warning,
+            healthy: h.healthy,
+            temperature_celsius: h.temperature_celsius,
+            available_spare_percent: h.available_spare_percent,
+            available_spare_threshold_percent: h.available_spare_threshold_percent,
+            percentage_used: h.percentage_used,
+            data_units_read: h.data_units_read,
+            data_units_written: h.data_units_written,
+            host_reads: h.host_reads,
+            host_writes: h.host_writes,
+            controller_busy_minutes: h.controller_busy_minutes,
+            power_cycles: h.power_cycles,
+            power_on_hours: h.power_on_hours,
+            unsafe_shutdowns: h.unsafe_shutdowns,
+            media_errors: h.media_errors,
+            num_error_log_entries: h.num_error_log_entries,
+            identity: h.identity.map(Into::into),
+            smart_attributes: h.smart_attributes.into_iter().map(Into::into).collect(),
+            error_log_entries: h.error_log_entries.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<DeviceIdentity> for pool::DeviceIdentityInfo {
+    fn from(i: DeviceIdentity) -> Self {
+        Self {
+            model: i.model,
+            model_family: i.model_family,
+            serial_number: i.serial_number,
+            firmware_revision: i.firmware_revision,
+            wwn: i.wwn,
+            capacity_bytes: i.capacity_bytes,
+            logical_sector_size: i.logical_sector_size,
+            physical_sector_size: i.physical_sector_size,
+            rotation_rate: i.rotation_rate,
+            form_factor: i.form_factor,
+            transport: i.transport,
+            link_speed: i.link_speed,
+        }
+    }
+}
+
+impl From<pool::DeviceIdentityInfo> for DeviceIdentity {
+    fn from(i: pool::DeviceIdentityInfo) -> Self {
+        Self {
+            model: i.model,
+            model_family: i.model_family,
+            serial_number: i.serial_number,
+            firmware_revision: i.firmware_revision,
+            wwn: i.wwn,
+            capacity_bytes: i.capacity_bytes,
+            logical_sector_size: i.logical_sector_size,
+            physical_sector_size: i.physical_sector_size,
+            rotation_rate: i.rotation_rate,
+            form_factor: i.form_factor,
+            transport: i.transport,
+            link_speed: i.link_speed,
+        }
+    }
+}
+
+impl From<SmartAttribute> for pool::SmartAttributeInfo {
+    fn from(a: SmartAttribute) -> Self {
+        Self {
+            id: a.id,
+            name: a.name,
+            value: a.value,
+            worst: a.worst,
+            threshold: a.threshold,
+            raw_value: a.raw_value,
+        }
+    }
+}
+
+impl From<pool::SmartAttributeInfo> for SmartAttribute {
+    fn from(a: pool::SmartAttributeInfo) -> Self {
+        Self {
+            id: a.id,
+            name: a.name,
+            value: a.value,
+            worst: a.worst,
+            threshold: a.threshold,
+            raw_value: a.raw_value,
+        }
+    }
+}
+
+impl From<NvmeErrorLogEntry> for pool::NvmeErrorLogEntryInfo {
+    fn from(e: NvmeErrorLogEntry) -> Self {
+        Self {
+            error_count: e.error_count,
+            submission_queue_id: e.submission_queue_id,
+            command_id: e.command_id,
+            status_field: e.status_field,
+            lba: e.lba,
+            namespace_id: e.namespace_id,
+        }
+    }
+}
+
+impl From<pool::NvmeErrorLogEntryInfo> for NvmeErrorLogEntry {
+    fn from(e: pool::NvmeErrorLogEntryInfo) -> Self {
+        Self {
+            error_count: e.error_count,
+            submission_queue_id: e.submission_queue_id,
+            command_id: e.command_id,
+            status_field: e.status_field,
+            lba: e.lba,
+            namespace_id: e.namespace_id,
+        }
     }
 }

--- a/control-plane/stor-port/src/types/v0/transport/mod.rs
+++ b/control-plane/stor-port/src/types/v0/transport/mod.rs
@@ -200,6 +200,7 @@ pub enum MessageIdVs {
     ListAppNodes,
     ClearPoolErrors,
     ProbePool,
+    GetPoolHealth,
 }
 
 impl From<MessageIdVs> for MessageId {

--- a/control-plane/stor-port/src/types/v0/transport/pool.rs
+++ b/control-plane/stor-port/src/types/v0/transport/pool.rs
@@ -1087,3 +1087,81 @@ impl From<models::EncryptionSecret> for EncryptionSecret {
         Self { name: value.name }
     }
 }
+
+/// Response from a GetPoolHealth query.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct GetPoolHealthResponse {
+    pub disks: Vec<DiskHealth>,
+}
+
+/// Health for a single disk backing the pool.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct DiskHealth {
+    pub disk_uri: String,
+    pub supported: bool,
+    pub health: Option<DeviceHealth>,
+    pub error: Option<String>,
+}
+
+/// SMART / health information for a backing device.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct DeviceHealth {
+    pub critical_warning: u32,
+    pub healthy: bool,
+    pub temperature_celsius: Option<i32>,
+    pub available_spare_percent: Option<u32>,
+    pub available_spare_threshold_percent: Option<u32>,
+    pub percentage_used: Option<u32>,
+    pub data_units_read: Option<u64>,
+    pub data_units_written: Option<u64>,
+    pub host_reads: Option<u64>,
+    pub host_writes: Option<u64>,
+    pub controller_busy_minutes: Option<u64>,
+    pub power_cycles: Option<u64>,
+    pub power_on_hours: Option<u64>,
+    pub unsafe_shutdowns: Option<u64>,
+    pub media_errors: Option<u64>,
+    pub num_error_log_entries: Option<u64>,
+    pub identity: Option<DeviceIdentity>,
+    pub smart_attributes: Vec<SmartAttribute>,
+    pub error_log_entries: Vec<NvmeErrorLogEntry>,
+}
+
+/// Device identity/inventory data.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct DeviceIdentity {
+    pub model: Option<String>,
+    pub model_family: Option<String>,
+    pub serial_number: Option<String>,
+    pub firmware_revision: Option<String>,
+    pub wwn: Option<String>,
+    pub capacity_bytes: Option<u64>,
+    pub logical_sector_size: Option<u32>,
+    pub physical_sector_size: Option<u32>,
+    pub rotation_rate: Option<u32>,
+    pub form_factor: Option<String>,
+    pub transport: Option<String>,
+    pub link_speed: Option<String>,
+}
+
+/// A single SMART attribute table entry (ATA devices only).
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct SmartAttribute {
+    pub id: u32,
+    pub name: String,
+    pub value: u32,
+    pub worst: u32,
+    pub threshold: u32,
+    pub raw_value: u64,
+}
+
+/// A single NVMe Error Information Log entry.
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
+pub struct NvmeErrorLogEntry {
+    pub error_count: u64,
+    pub submission_queue_id: u32,
+    pub command_id: Option<u32>,
+    pub status_field: u32,
+    pub lba: Option<u64>,
+    pub namespace_id: Option<u32>,
+}

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -678,10 +678,11 @@ pub mod v1 {
     pub mod pool {
         pub use super::pb::{
             pool_rpc_client, ClearErrorRequest, ClearErrors, CreatePoolRequest, DestroyPoolRequest,
-            DiskInfo, GrowPoolRequest, ImportPoolRequest, ListPoolOptions, ListPoolsResponse, Pool,
-            PoolAlert, PoolAlertStatus, PoolAlerts, PoolErrors, PoolMetadataArgs, PoolProbeMeta,
-            PoolProbes, PoolType, ProbeDiskInfo, ProbeError, ProbeErrorCode, ProbePoolRequest,
-            ProbePoolResponse,
+            DeviceHealth, DeviceIdentity, DiskHealth, DiskInfo, GetPoolHealthRequest,
+            GetPoolHealthResponse, GrowPoolRequest, ImportPoolRequest, ListPoolOptions,
+            ListPoolsResponse, NvmeErrorLogEntry, Pool, PoolAlert, PoolAlertStatus, PoolAlerts,
+            PoolErrors, PoolMetadataArgs, PoolProbeMeta, PoolProbes, PoolType, ProbeDiskInfo,
+            ProbeError, ProbeErrorCode, ProbePoolRequest, ProbePoolResponse, SmartAttribute,
         };
     }
 

--- a/utils/bundle-sim/src/bin/io-engine.rs
+++ b/utils/bundle-sim/src/bin/io-engine.rs
@@ -389,6 +389,13 @@ impl rpc::v1::pb::pool_rpc_server::PoolRpc for IoEngine {
     ) -> Result<tonic::Response<ProbePoolResponse>, tonic::Status> {
         Err(tonic::Status::unimplemented(""))
     }
+
+    async fn get_pool_health(
+        &self,
+        _request: tonic::Request<rpc::v1::pool::GetPoolHealthRequest>,
+    ) -> Result<tonic::Response<rpc::v1::pool::GetPoolHealthResponse>, tonic::Status> {
+        Err(tonic::Status::unimplemented(""))
+    }
 }
 
 #[tonic::async_trait]


### PR DESCRIPTION
- transport types: GetPoolHealthResponse, DiskHealth, DeviceHealth, DeviceIdentity, SmartAttribute, NvmeErrorLogEntry
- io-engine client: PoolApi trait, v1 RpcClient, v0 stub, IoEngineToAgent/AgentToIoEngine translations
- NodeWrapper: forwarding with graceful Unimplemented fallback
- control-plane gRPC: proto messages, PoolOperations trait, PoolServer handler, PoolClient handler, bidirectional From impls
- core agent Service: pool lookup + forward to node