### PR TITLE
feat(docker/image): build and push multi-arch container images

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -4,6 +4,24 @@ on:
     branches:
       - develop
       - 'release/**'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to be released (e.g. v2.10.0)'
+        required: false
+        type: string
+      registry:
+        description: 'Registry host (no slash), example: ghcr.io'
+        required: false
+        type: string
+      owner:
+        description: 'Repository owner (defaults to github.repository_owner if empty)'
+        required: false
+        type: string
+      namespace:
+        description: 'Namespace, example: mayastor/dev'
+        required: false
+        type: string
   workflow_call:
     inputs:
       tag:
@@ -11,8 +29,12 @@ on:
         required: true
         type: string
       registry:
-        description: 'Registry, example: ghcr.io'
+        description: 'Registry host (no slash), example: ghcr.io'
         required: true
+        type: string
+      owner:
+        description: 'Repository owner (defaults to github.repository_owner if empty)'
+        required: false
         type: string
       namespace:
         description: 'Namespace, example: mayastor/dev'
@@ -26,45 +48,55 @@ env:
   TAG: ${{ inputs.tag }}
 
 jobs:
-  image-build-push:
+  vars:
+    runs-on: ubuntu-latest
+    outputs:
+      registry: ${{ steps.registry.outputs.registry }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: 'recursive'
+      - name: Compose the registry
+        id: registry
+        uses: ./utils/dependencies/.github/actions/registry-compose
+        with:
+          registry: ${{ inputs.registry }}
+          owner: ${{ inputs.owner || github.repository_owner }}
+          namespace: ${{ inputs.namespace }}
+
+  image-build:
+    needs: vars
     strategy:
       fail-fast: false
       matrix:
         runner:
           - ubuntu-latest
-          # todo: once we support multi-arch builds
-          #- ubuntu-24.04-arm
+          - ubuntu-24.04-arm
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0
-      - run: |
-          # BUG: HEAD tag is fetched as lightweight instead of annotated
-          # https://github.com/actions/checkout/issues/290
-          if [ "${{ github.ref_type }}" == "tag" ]; then
-            git fetch -f origin ${{ github.ref }}:${{ github.ref }}
-          fi
-      - name: Setup Nix Environment
-        uses: ./.github/actions/setup-nix
+      - name: Build the release images
+        uses: ./utils/dependencies/.github/actions/image-build
         with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
+          tag: ${{ env.TAG }}
+          registry: ${{ needs.vars.outputs.registry }}
+
+  manifest-push:
+    needs: [vars, image-build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GHCR
-        uses: docker/login-action@v4
+          submodules: 'recursive'
+          fetch-depth: 0
+      - name: Assemble and push the multi-arch images
+        uses: ./utils/dependencies/.github/actions/image-manifest-push
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push the release images
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            ./scripts/release.sh --tag ${{ inputs.tag }} --registry ${{ inputs.registry }}/${{ github.repository_owner }}/${{ inputs.namespace }}
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            ./scripts/release.sh
-          fi
+          tag: ${{ env.TAG }}
+          registry: ${{ needs.vars.outputs.registry }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKERHUB_TOKEN }}
+          ghcr-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Builds the container images natively for amd64 and arm64 on separate runners and pushes them as multi-arch manifest lists, with no per-arch tags left in the registry.

The image push workflow is now split into two phases, delegating to the composite actions from the dependencies submodule:

- image-build: matrix over ubuntu-latest and ubuntu-24.04-arm, building the images natively per arch and uploading the archives as short-lived workflow artifacts (no registry access).

- manifest-push: downloads the per-arch archives and assembles/pushes the multi-arch manifest lists, with the member images uploaded untagged (addressed only by digest).

The plain image tags (hash/develop/release) only appear once both arch builds have succeeded; a failed run leaves the previous manifests untouched.